### PR TITLE
stopped setting parallelism equal to replicas by default

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -42,8 +42,6 @@ func FromCluster(in *redskyv1alpha1.Experiment) (redskyapi.ExperimentName, *reds
 	out.Optimization = redskyapi.Optimization{}
 	if in.Spec.Parallelism != nil {
 		out.Optimization.ParallelTrials = *in.Spec.Parallelism
-	} else {
-		out.Optimization.ParallelTrials = in.Replicas()
 	}
 	if in.Spec.BurnIn != nil {
 		out.Optimization.BurnIn = *in.Spec.BurnIn


### PR DESCRIPTION
Stopped setting parallelism equal to replicas by default. Now if it is not set the API can choose an appropriate default value