### PR TITLE
Add test coverage for internal/meta

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/prometheus/common v0.4.1
 	github.com/redskyops/redskyops-ui/v2 v2.0.2
 	github.com/spf13/cobra v0.0.5
+	github.com/stretchr/testify v1.4.0
 	github.com/zorkian/go-datadog-api v2.24.0+incompatible
 	golang.org/x/net v0.0.0-20191004110552-13f9640d40b9
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45

--- a/internal/meta/metadata_test.go
+++ b/internal/meta/metadata_test.go
@@ -1,0 +1,178 @@
+package meta
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type testObj struct {
+	metav1.ObjectMeta
+}
+
+func TestAddFinalizer(t *testing.T) {
+	cases := []struct {
+		desc           string
+		obj            metav1.Object
+		finalizer      string
+		finalizerAdded bool
+	}{
+		{
+			desc: "zero deletion timestamp",
+			obj: &testObj{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: &metav1.Time{
+						Time: time.Now(),
+					},
+				},
+			},
+			finalizerAdded: false,
+		},
+		{
+			desc: "finalizer already added",
+			obj: &testObj{
+				ObjectMeta: metav1.ObjectMeta{
+					Finalizers: []string{"111"},
+				},
+			},
+			finalizer:      "111",
+			finalizerAdded: false,
+		},
+		{
+			desc: "set finalizer",
+			obj: &testObj{
+				ObjectMeta: metav1.ObjectMeta{
+					Finalizers: []string{},
+				},
+			},
+			finalizer:      "111",
+			finalizerAdded: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			finalizerAdded := AddFinalizer(c.obj, c.finalizer)
+			assert.Equal(t, c.finalizerAdded, finalizerAdded)
+			if finalizerAdded {
+				assert.Contains(t, c.obj.GetFinalizers(), c.finalizer)
+			}
+		})
+	}
+}
+
+func TestRemoveFinalizer(t *testing.T) {
+	cases := []struct {
+		desc             string
+		obj              metav1.Object
+		finalizer        string
+		finalizerRemoved bool
+	}{
+		{
+			desc:             "no finalizers",
+			obj:              &testObj{},
+			finalizerRemoved: false,
+		},
+		{
+			desc: "finalizer not found",
+			obj: &testObj{
+				ObjectMeta: metav1.ObjectMeta{
+					Finalizers: []string{"111"},
+				},
+			},
+			finalizer:        "222",
+			finalizerRemoved: false,
+		},
+		{
+			desc: "remove finalizer",
+			obj: &testObj{
+				ObjectMeta: metav1.ObjectMeta{
+					Finalizers: []string{"111", "222", "333"},
+				},
+			},
+			finalizer:        "111",
+			finalizerRemoved: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			finalizerRemoved := RemoveFinalizer(c.obj, c.finalizer)
+			assert.Equal(t, c.finalizerRemoved, finalizerRemoved)
+			if finalizerRemoved {
+				assert.NotContains(t, c.obj.GetFinalizers(), c.finalizer)
+			}
+		})
+	}
+}
+
+func TestHasFinalizer(t *testing.T) {
+	cases := []struct {
+		desc         string
+		obj          metav1.Object
+		finalizer    string
+		hasFinalizer bool
+	}{
+		{
+			desc: "does not have finalizer",
+			obj: &testObj{
+				ObjectMeta: metav1.ObjectMeta{
+					Finalizers: []string{"111"},
+				},
+			},
+			finalizer:    "222",
+			hasFinalizer: false,
+		},
+		{
+			desc: "has finalizer",
+			obj: &testObj{
+				ObjectMeta: metav1.ObjectMeta{
+					Finalizers: []string{"111", "222", "333"},
+				},
+			},
+			finalizer:    "111",
+			hasFinalizer: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			hasFinalizer := HasFinalizer(c.obj, c.finalizer)
+			assert.Equal(t, c.hasFinalizer, hasFinalizer)
+		})
+	}
+}
+
+func TestAddLabel(t *testing.T) {
+	cases := []struct {
+		desc           string
+		obj            metav1.Object
+		label          string
+		value          string
+		expectedLables map[string]string
+	}{
+		{
+			desc:           "nil lables",
+			obj:            &testObj{},
+			label:          "111",
+			value:          "222",
+			expectedLables: map[string]string{"111": "222"},
+		},
+		{
+			desc: "existing lables",
+			obj: &testObj{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"_": "__"},
+				},
+			},
+			label:          "111",
+			value:          "222",
+			expectedLables: map[string]string{"_": "__", "111": "222"},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			AddLabel(c.obj, c.label, c.value)
+			assert.EqualValues(t, c.obj.GetLabels(), c.expectedLables)
+		})
+	}
+}

--- a/internal/meta/metadata_test.go
+++ b/internal/meta/metadata_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 GramLabs, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package meta
 
 import (

--- a/internal/meta/selector_test.go
+++ b/internal/meta/selector_test.go
@@ -1,0 +1,104 @@
+package meta
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestSelectorApplyToList(t *testing.T) {
+	cases := []struct {
+		desc              string
+		clientListOptions *client.ListOptions
+		selector          *Selector
+	}{
+		{
+			desc:              "nil",
+			clientListOptions: &client.ListOptions{},
+		},
+		{
+			desc:              "not nil",
+			clientListOptions: &client.ListOptions{},
+			selector: &Selector{
+				Selector: labels.Everything(),
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			c.selector.ApplyToList(c.clientListOptions)
+			assert.Equal(t, c.selector, c.clientListOptions.LabelSelector)
+		})
+	}
+}
+
+func TestSelectorApplyToListOptions(t *testing.T) {
+	cases := []struct {
+		desc            string
+		metaListOptions *metav1.ListOptions
+		selector        *Selector
+	}{
+		{
+			desc:            "not nil",
+			metaListOptions: &metav1.ListOptions{},
+			selector: &Selector{
+				Selector: labels.Everything(),
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			c.selector.ApplyToListOptions(c.metaListOptions)
+			assert.Equal(t, c.selector.String(), c.metaListOptions.LabelSelector)
+		})
+	}
+}
+
+func TestMatchingSelector(t *testing.T) {
+	cases := []struct {
+		desc              string
+		metaLabelSelector *metav1.LabelSelector
+		selectorResult    *Selector
+		errContains       string
+	}{
+		{
+			desc: "nil label selector",
+			selectorResult: &Selector{
+				Selector: labels.Nothing(),
+			},
+		},
+		{
+			desc:              "everything label selector",
+			metaLabelSelector: &metav1.LabelSelector{},
+			selectorResult: &Selector{
+				Selector: labels.Everything(),
+			},
+		},
+		{
+			desc: "invalid label selector",
+			metaLabelSelector: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{Operator: "111"},
+				},
+			},
+			errContains: "is not a valid pod selector operator",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			selector, err := MatchingSelector(c.metaLabelSelector)
+			if c.errContains != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), c.errContains)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, c.selectorResult, selector)
+		})
+	}
+}

--- a/internal/meta/selector_test.go
+++ b/internal/meta/selector_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 GramLabs, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package meta
 
 import (


### PR DESCRIPTION
This adds test coverage for the `internal/meta` package.

```
❯ go test -cover -race ./internal/meta
ok      github.com/redskyops/redskyops-controller/internal/meta 1.795s  coverage: 100.0% of statements

```