### PR TITLE
Add tests for internal/controller

### DIFF
--- a/internal/controller/errors_test.go
+++ b/internal/controller/errors_test.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2019 GramLabs, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+	"testing"
+
+	redskyapi "github.com/redskyops/redskyops-controller/redskyapi/experiments/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestIgnoreNotFound(t *testing.T) {
+	cases := []struct {
+		desc        string
+		in          error
+		expectedErr error
+	}{
+		{
+			desc:        "nil",
+			in:          nil,
+			expectedErr: nil,
+		},
+		{
+			desc: "not found error",
+			in: &errors.StatusError{
+				ErrStatus: metav1.Status{
+					Reason: metav1.StatusReasonNotFound,
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			desc: "redskyapi error experiment not found",
+			in: &redskyapi.Error{
+				Type: redskyapi.ErrExperimentNotFound,
+			},
+			expectedErr: nil,
+		},
+		{
+			desc: "redskyapi error trial not found",
+			in: &redskyapi.Error{
+				Type: redskyapi.ErrTrialNotFound,
+			},
+			expectedErr: nil,
+		},
+		{
+			desc:        "other error",
+			in:          fmt.Errorf("111"),
+			expectedErr: fmt.Errorf("111"),
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			err := IgnoreNotFound(c.in)
+			assert.Equal(t, c.expectedErr, err)
+		})
+	}
+}
+
+func TestIgnoreAlreadyExists(t *testing.T) {
+	cases := []struct {
+		desc        string
+		in          error
+		expectedErr error
+	}{
+		{
+			desc:        "nil",
+			in:          nil,
+			expectedErr: nil,
+		},
+		{
+			desc: "already exists",
+			in: &errors.StatusError{
+				ErrStatus: metav1.Status{
+					Reason: metav1.StatusReasonAlreadyExists,
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			desc:        "other error",
+			in:          fmt.Errorf("111"),
+			expectedErr: fmt.Errorf("111"),
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			err := IgnoreAlreadyExists(c.in)
+			assert.Equal(t, c.expectedErr, err)
+		})
+	}
+}
+
+func TestIgnoreReportError(t *testing.T) {
+	cases := []struct {
+		desc        string
+		in          error
+		expectedErr error
+	}{
+		{
+			desc:        "nil",
+			in:          nil,
+			expectedErr: nil,
+		},
+		{
+			desc: "is not found error",
+			in: &errors.StatusError{
+				ErrStatus: metav1.Status{
+					Reason: metav1.StatusReasonNotFound,
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			desc: "redskyapi error trial already reported",
+			in: &redskyapi.Error{
+				Type: redskyapi.ErrTrialAlreadyReported,
+			},
+			expectedErr: nil,
+		},
+		{
+			desc:        "other error",
+			in:          fmt.Errorf("111"),
+			expectedErr: fmt.Errorf("111"),
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			err := IgnoreReportError(c.in)
+			assert.Equal(t, c.expectedErr, err)
+		})
+	}
+}

--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -17,10 +17,6 @@ limitations under the License.
 package controller
 
 import (
-	"path"
-	"runtime"
-	"strings"
-
 	"github.com/prometheus/client_golang/prometheus"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
@@ -56,25 +52,4 @@ func init() {
 		ExperimentTrials,
 		ExperimentActiveTrials,
 	)
-}
-
-// guessController dumps stack to try and guess what the controller name should be
-func guessController() string {
-	pc := make([]uintptr, 3)
-	n := runtime.Callers(3, pc)
-	if n > 0 {
-		frames := runtime.CallersFrames(pc[:n])
-		for {
-			frame, more := frames.Next()
-			if path.Base(path.Dir(frame.File)) == "controllers" {
-				p := strings.SplitN(path.Base(frame.File), "_", 2)
-				return p[0]
-			}
-
-			if !more {
-				break
-			}
-		}
-	}
-	return "controller"
 }

--- a/internal/controller/result_test.go
+++ b/internal/controller/result_test.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2019 GramLabs, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+	"runtime"
+	"testing"
+
+	redskyapi "github.com/redskyops/redskyops-controller/redskyapi/experiments/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+type testFrameStack struct {
+	files []string
+	idx   int
+}
+
+func (tfs *testFrameStack) Next() (runtime.Frame, bool) {
+	defer func() {
+		tfs.idx++
+	}()
+
+	more := len(tfs.files) > (tfs.idx + 1)
+
+	return runtime.Frame{
+		File: tfs.files[tfs.idx],
+	}, more
+}
+
+func TestGuessController(t *testing.T) {
+	cases := []struct {
+		desc string
+		name string
+		fs   frameStack
+	}{
+		{
+			desc: "no controllers",
+			name: "controller",
+			fs: &testFrameStack{
+				files: []string{
+					"/a/b/c.go",
+					"/e/f/g.go",
+					"/h/i/j.go",
+				},
+			},
+		},
+		{
+			desc: "controllers",
+			name: "111",
+			fs: &testFrameStack{
+				files: []string{
+					"/a/b/c.go",
+					"/e/f/g.go",
+					"/h/controllers/111_controller.go",
+				},
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			name := guessController(c.fs)
+			assert.Equal(t, c.name, name)
+		})
+	}
+}
+
+func TestGetFrames(t *testing.T) {
+	f, more := getFrames().Next()
+	assert.True(t, more)
+	assert.Equal(t, "testing.tRunner", f.Function)
+}
+
+func TestRequeueConflictForFrameStack(t *testing.T) {
+	cases := []struct {
+		desc        string
+		err         error
+		fs          frameStack
+		result      *ctrl.Result
+		expectedErr error
+	}{
+		{
+			desc:        "not conflict",
+			err:         fmt.Errorf("111"),
+			result:      &ctrl.Result{},
+			expectedErr: fmt.Errorf("111"),
+		},
+		{
+			desc: "conflict",
+			err: &errors.StatusError{
+				ErrStatus: metav1.Status{
+					Reason: metav1.StatusReasonConflict,
+				},
+			},
+			fs: &testFrameStack{
+				files: []string{
+					"/a/b/c.go",
+				},
+			},
+			result: &ctrl.Result{
+				Requeue: true,
+			},
+			expectedErr: nil,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			result, err := requeueConflictForFrameStack(c.err, c.fs)
+			assert.Equal(t, c.result, result)
+			assert.Equal(t, c.expectedErr, err)
+		})
+	}
+}
+
+func TestRequeueIfUnavailable(t *testing.T) {
+	cases := []struct {
+		desc        string
+		err         error
+		fs          frameStack
+		result      *ctrl.Result
+		expectedErr error
+	}{
+		{
+			desc:        "not correct error type",
+			err:         fmt.Errorf("111"),
+			result:      &ctrl.Result{},
+			expectedErr: fmt.Errorf("111"),
+		},
+		{
+			desc: "trial unavailable",
+			err: &redskyapi.Error{
+				Type:       redskyapi.ErrTrialUnavailable,
+				RetryAfter: 111,
+			},
+			result: &ctrl.Result{
+				RequeueAfter: 111,
+			},
+			expectedErr: nil,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			result, err := RequeueIfUnavailable(c.err)
+			assert.Equal(t, c.result, result)
+			assert.Equal(t, c.expectedErr, err)
+		})
+	}
+}


### PR DESCRIPTION
This adds tests for `internal/controller`.

```
✝ go test -cover -race ./internal/controller
ok      github.com/redskyops/redskyops-controller/internal/controller   0.724s  coverage: 95.1% of statements
```

@jgustie This required a little bit of refactoring to get test coverage over 90%