### PR TITLE
Add `redskyctl label`

### DIFF
--- a/docs/redskyctl/redskyctl.md
+++ b/docs/redskyctl/redskyctl.md
@@ -31,6 +31,7 @@ redskyctl [flags]
 * [redskyctl grant-permissions](redskyctl_grant-permissions.md)	 - Grant permissions
 * [redskyctl init](redskyctl_init.md)	 - Install to a cluster
 * [redskyctl kustomize](redskyctl_kustomize.md)	 - Kustomize integrations
+* [redskyctl label](redskyctl_label.md)	 - Label a Red Sky resource
 * [redskyctl login](redskyctl_login.md)	 - Authenticate
 * [redskyctl reset](redskyctl_reset.md)	 - Uninstall from a cluster
 * [redskyctl results](redskyctl_results.md)	 - Serve a visualization of the results

--- a/docs/redskyctl/redskyctl_get.md
+++ b/docs/redskyctl/redskyctl_get.md
@@ -7,12 +7,13 @@ Display a Red Sky resource
 Get Red Sky resources from the remote server
 
 ```
-redskyctl get TYPE NAME... [flags]
+redskyctl get (TYPE NAME | TYPE/NAME ...) [flags]
 ```
 
 ### Options
 
 ```
+  -A, --all                  Include all resources.
       --chunk-size int       Fetch large lists in chunks rather then all at once. (default 500)
   -h, --help                 help for get
       --no-headers           Don't print headers.

--- a/docs/redskyctl/redskyctl_label.md
+++ b/docs/redskyctl/redskyctl_label.md
@@ -1,19 +1,19 @@
-## redskyctl delete
+## redskyctl label
 
-Delete a Red Sky resource
+Label a Red Sky resource
 
 ### Synopsis
 
-Delete Red Sky resources from the remote server
+Label Red Sky resources on the remote server
 
 ```
-redskyctl delete (TYPE NAME | TYPE/NAME ...) [flags]
+redskyctl label (TYPE NAME | TYPE/NAME ...) KEY_1=VAL_1 ... KEY_N=VAL_N [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for delete
+  -h, --help   help for label
 ```
 
 ### Options inherited from parent commands

--- a/go.sum
+++ b/go.sum
@@ -512,6 +512,7 @@ gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/redskyapi/experiments/v1alpha1/api.go
+++ b/redskyapi/experiments/v1alpha1/api.go
@@ -262,6 +262,8 @@ type Experiment struct {
 
 	// The display name of the experiment. Do not use for generating URLs!
 	DisplayName string `json:"displayName,omitempty"`
+	// The number of observations made for this experiment.
+	Observations int64 `json:"observations,omitempty"`
 	// Controls how the optimizer will generate trials.
 	Optimization []Optimization `json:"optimization,omitempty"`
 	// The metrics been optimized in the experiment.

--- a/redskyapi/experiments/v1alpha1/api.go
+++ b/redskyapi/experiments/v1alpha1/api.go
@@ -385,6 +385,10 @@ type TrialItem struct {
 
 	// The metadata for an individual trial.
 	Metadata Metadata `json:"_metadata,omitempty"`
+
+	// Experiment is a reference back to the experiment this trial item is associated with. This field is never
+	// populated by the API, but may be useful for consumers to maintain a connection between resources.
+	Experiment *Experiment `json:"-"`
 }
 
 type TrialListQuery struct {
@@ -409,6 +413,10 @@ func (p *TrialListQuery) Encode() string {
 type TrialList struct {
 	// The list of trials.
 	Trials []TrialItem `json:"trials"`
+
+	// Experiment is a reference back to the experiment this trial item is associated with. This field is never
+	// populated by the API, but may be useful for consumers to maintain a connection between resources.
+	Experiment *Experiment `json:"-"`
 }
 
 type TrialLabels struct {

--- a/redskyctl/internal/commander/printer.go
+++ b/redskyctl/internal/commander/printer.go
@@ -191,11 +191,19 @@ func (f *printFlags) toPrinter(printer *ResourcePrinter) error {
 			case "json", "yaml":
 				*printer = &marshalPrinter{outputFormat: outputFormat}
 				return nil
-			case "wide", "":
-				*printer = &tablePrinter{meta: f.meta, columns: f.columns, headers: !f.noHeader, showLabels: f.showLabels}
-				return nil
-			case "name":
-				*printer = &tablePrinter{meta: f.meta, columns: []string{"name"}, outputFormat: outputFormat, showLabels: f.showLabels}
+			case "wide", "name", "":
+				p := &tablePrinter{
+					meta:         f.meta,
+					columns:      f.columns,
+					headers:      !f.noHeader,
+					showLabels:   f.showLabels,
+					outputFormat: outputFormat,
+				}
+				if outputFormat == "name" {
+					p.columns = []string{"name"}
+					p.headers = false
+				}
+				*printer = p
 				return nil
 			case "csv":
 				*printer = &csvPrinter{meta: f.meta, headers: !f.noHeader, showLabels: f.showLabels}

--- a/redskyctl/internal/commands/commands.go
+++ b/redskyctl/internal/commands/commands.go
@@ -64,6 +64,7 @@ func NewRedskyctlCommand() *cobra.Command {
 	rootCmd.AddCommand(docs.NewCommand(&docs.Options{}))
 	rootCmd.AddCommand(experiments.NewDeleteCommand(&experiments.DeleteOptions{Options: experiments.Options{Config: cfg}}))
 	rootCmd.AddCommand(experiments.NewGetCommand(&experiments.GetOptions{Options: experiments.Options{Config: cfg}, ChunkSize: 500}))
+	rootCmd.AddCommand(experiments.NewLabelCommand(&experiments.LabelOptions{Options: experiments.Options{Config: cfg}}))
 	rootCmd.AddCommand(experiments.NewSuggestCommand(&experiments.SuggestOptions{Options: experiments.Options{Config: cfg}}))
 	rootCmd.AddCommand(generate.NewCommand(&generate.Options{Config: cfg}))
 	rootCmd.AddCommand(grant_permissions.NewCommand(&grant_permissions.Options{GeneratorOptions: grant_permissions.GeneratorOptions{Config: cfg}}))

--- a/redskyctl/internal/commands/experiments/delete.go
+++ b/redskyctl/internal/commands/experiments/delete.go
@@ -49,6 +49,7 @@ func NewDeleteCommand(o *DeleteOptions) *cobra.Command {
 	}
 
 	TypeAndNameArgs(cmd, &o.Options)
+	o.Printer = &verbPrinter{verb: "deleted"}
 	commander.ExitOnError(cmd)
 	return cmd
 }
@@ -85,7 +86,5 @@ func (o *DeleteOptions) deleteExperiment(ctx context.Context, name string) error
 		return err
 	}
 
-	// TODO We should make this go through the ResourcePrinter
-	_, _ = fmt.Fprintf(o.Out, "experiment \"%s\" deleted\n", name)
-	return nil
+	return o.Printer.PrintObj(&exp, o.Out)
 }

--- a/redskyctl/internal/commands/experiments/delete.go
+++ b/redskyctl/internal/commands/experiments/delete.go
@@ -37,33 +37,39 @@ type DeleteOptions struct {
 // NewDeleteCommand creates a new deletion command
 func NewDeleteCommand(o *DeleteOptions) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "delete",
+		Use:   "delete (TYPE NAME | TYPE/NAME ...)",
 		Short: "Delete a Red Sky resource",
 		Long:  "Delete Red Sky resources from the remote server",
 
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			commander.SetStreams(&o.IOStreams, cmd)
-			return commander.SetExperimentsAPI(&o.ExperimentsAPI, o.Config, cmd)
+			if err := commander.SetExperimentsAPI(&o.ExperimentsAPI, o.Config, cmd); err != nil {
+				return err
+			}
+			return o.setNames(args)
 		},
 		RunE: commander.WithContextE(o.delete),
 	}
 
-	TypeAndNameArgs(cmd, &o.Options)
 	o.Printer = &verbPrinter{verb: "deleted"}
 	commander.ExitOnError(cmd)
 	return cmd
 }
 
 func (o *DeleteOptions) delete(ctx context.Context) error {
-	switch o.GetType() {
-	case TypeExperiment:
-		for _, name := range o.Names {
-			if err := o.deleteExperiment(ctx, name); o.ignoreDeleteError(err) != nil {
+	for _, n := range o.Names {
+		if n.Name == "" {
+			return fmt.Errorf("name is required for delete")
+		}
+
+		switch n.Type {
+		case typeExperiment:
+			if err := o.deleteExperiment(ctx, n.experimentName()); o.ignoreDeleteError(err) != nil {
 				return err
 			}
+		default:
+			return fmt.Errorf("cannot delete \"%s\"", n.Type)
 		}
-	default:
-		return fmt.Errorf("cannot delete %s", o.GetType())
 	}
 	return nil
 }
@@ -76,8 +82,8 @@ func (o *DeleteOptions) ignoreDeleteError(err error) error {
 	return err
 }
 
-func (o *DeleteOptions) deleteExperiment(ctx context.Context, name string) error {
-	exp, err := o.ExperimentsAPI.GetExperimentByName(ctx, experimentsv1alpha1.NewExperimentName(name))
+func (o *DeleteOptions) deleteExperiment(ctx context.Context, name experimentsv1alpha1.ExperimentName) error {
+	exp, err := o.ExperimentsAPI.GetExperimentByName(ctx, name)
 	if err != nil {
 		return err
 	}

--- a/redskyctl/internal/commands/experiments/experiments.go
+++ b/redskyctl/internal/commands/experiments/experiments.go
@@ -71,6 +71,16 @@ func (o *Options) setNames(args []string) error {
 	return err
 }
 
+// hasTrialNumber checks to see if a trail's number is in the supplied list
+func hasTrialNumber(t *experimentsv1alpha1.TrialItem, nums []int64) bool {
+	for _, n := range nums {
+		if t.Number == n || n < 0 {
+			return true
+		}
+	}
+	return false
+}
+
 // name is construct for identifying an object in the Experiments API
 type name struct {
 	// Type is the normalized type name being named
@@ -139,7 +149,7 @@ func (v *verbPrinter) PrintObj(obj interface{}, w io.Writer) error {
 	case *experimentsv1alpha1.TrialItem:
 		_, _ = fmt.Fprintf(w, "trial \"%s-%03d\" %s\n", o.Experiment.DisplayName, o.Number, v.verb)
 	default:
-		return fmt.Errorf("%v %s", obj, v.verb)
+		return fmt.Errorf("could not print \"%s\" for: %T", v.verb, obj)
 	}
 	return nil
 }

--- a/redskyctl/internal/commands/experiments/experiments.go
+++ b/redskyctl/internal/commands/experiments/experiments.go
@@ -112,6 +112,23 @@ func (o *Options) GetType() string {
 	return t
 }
 
+// verbPrinter
+type verbPrinter struct {
+	verb string
+}
+
+func (v *verbPrinter) PrintObj(obj interface{}, w io.Writer) error {
+	switch o := obj.(type) {
+	case *experimentsv1alpha1.Experiment:
+		_, _ = fmt.Fprintf(w, "experiment \"%s\" %s\n", o.DisplayName, v.verb)
+	case *experimentsv1alpha1.TrialItem:
+		_, _ = fmt.Fprintf(w, "trial \"%s-%03d\" %s\n", o.Experiment.DisplayName, o.Number, v.verb)
+	default:
+		return fmt.Errorf("%v %s", obj, v.verb)
+	}
+	return nil
+}
+
 // experimentsMeta is the metadata extraction necessary for printing Red Sky Experiments API objects
 type experimentsMeta struct{}
 

--- a/redskyctl/internal/commands/experiments/experiments.go
+++ b/redskyctl/internal/commands/experiments/experiments.go
@@ -113,9 +113,7 @@ func (o *Options) GetType() string {
 }
 
 // experimentsMeta is the metadata extraction necessary for printing Red Sky Experiments API objects
-type experimentsMeta struct {
-	base interface{}
-}
+type experimentsMeta struct{}
 
 func (m *experimentsMeta) ExtractList(obj interface{}) ([]interface{}, error) {
 	if o, ok := obj.(*experimentsv1alpha1.ExperimentList); ok {
@@ -146,12 +144,12 @@ func (m *experimentsMeta) Columns(obj interface{}, outputFormat string, showLabe
 			columns = []string{"experiment", "number", "status"}
 
 			// CSV column names should correspond to the parameter and metric names
-			if exp, ok := m.base.(*experimentsv1alpha1.Experiment); ok {
-				for i := range exp.Parameters {
-					columns = append(columns, "parameter_"+exp.Parameters[i].Name)
+			if tl.Experiment != nil {
+				for i := range tl.Experiment.Parameters {
+					columns = append(columns, "parameter_"+tl.Experiment.Parameters[i].Name)
 				}
-				for i := range exp.Metrics {
-					columns = append(columns, "metric_"+exp.Metrics[i].Name)
+				for i := range tl.Experiment.Metrics {
+					columns = append(columns, "metric_"+tl.Experiment.Metrics[i].Name)
 				}
 			}
 
@@ -188,13 +186,13 @@ func (m *experimentsMeta) ExtractValue(obj interface{}, column string) (string, 
 	case *experimentsv1alpha1.TrialItem:
 		switch column {
 		case "experiment":
-			if exp, ok := m.base.(*experimentsv1alpha1.Experiment); ok {
-				return exp.DisplayName, nil
+			if o.Experiment != nil {
+				return o.Experiment.DisplayName, nil
 			}
 			return "", nil
 		case "name":
-			if exp, ok := m.base.(*experimentsv1alpha1.Experiment); ok {
-				return fmt.Sprintf("%s-%03d", exp.DisplayName, o.Number), nil
+			if o.Experiment != nil {
+				return fmt.Sprintf("%s-%03d", o.Experiment.DisplayName, o.Number), nil
 			}
 			return strconv.FormatInt(o.Number, 10), nil
 		case "number":

--- a/redskyctl/internal/commands/experiments/experiments.go
+++ b/redskyctl/internal/commands/experiments/experiments.go
@@ -87,7 +87,7 @@ func (n *name) experimentName() experimentsv1alpha1.ExperimentName {
 }
 
 // numberSuffixPattern matches the trailing digits, for example the number on the end of a trial name
-var numberSuffixPattern = regexp.MustCompile("(.*?)(?:/([[:digit:]]+))?$")
+var numberSuffixPattern = regexp.MustCompile("(.*?)(?:[\\/\\-]([[:digit:]]+))?$")
 
 // parseNames parses a list of arguments into structured names
 func parseNames(args []string) ([]name, error) {
@@ -101,16 +101,18 @@ func parseNames(args []string) ([]name, error) {
 		}
 
 		p := strings.SplitN(n.Name, "/", 2)
-		nt, err := normalizeType(p[0])
-		if err != nil {
-			return nil, err
-		}
-		if len(p) > 1 {
-			n.Type = nt
-			n.Name = p[1]
-		} else if t == "" {
-			t = nt
-			continue
+		if len(p) > 1 || t == "" {
+			nt, err := normalizeType(p[0])
+			if err != nil {
+				return nil, err
+			}
+			if len(p) > 1 {
+				n.Type = nt
+				n.Name = p[1]
+			} else if t == "" {
+				t = nt
+				continue
+			}
 		}
 		names = append(names, n)
 	}
@@ -119,7 +121,7 @@ func parseNames(args []string) ([]name, error) {
 		if t == "" {
 			return nil, fmt.Errorf("required resource not specified")
 		}
-		names = append(names, name{Type: t})
+		names = append(names, name{Type: t, Number: -1})
 	}
 
 	return names, nil

--- a/redskyctl/internal/commands/experiments/experiments.go
+++ b/redskyctl/internal/commands/experiments/experiments.go
@@ -157,6 +157,7 @@ func (v *verbPrinter) PrintObj(obj interface{}, w io.Writer) error {
 // experimentsMeta is the metadata extraction necessary for printing Red Sky Experiments API objects
 type experimentsMeta struct{}
 
+// ExtractList returns the items from an API list object
 func (m *experimentsMeta) ExtractList(obj interface{}) ([]interface{}, error) {
 	if o, ok := obj.(*experimentsv1alpha1.ExperimentList); ok {
 		list := make([]interface{}, len(o.Experiments))
@@ -165,6 +166,7 @@ func (m *experimentsMeta) ExtractList(obj interface{}) ([]interface{}, error) {
 		}
 		return list, nil
 	}
+
 	if o, ok := obj.(*experimentsv1alpha1.TrialList); ok {
 		list := make([]interface{}, len(o.Trials))
 		for i := range o.Trials {
@@ -172,12 +174,15 @@ func (m *experimentsMeta) ExtractList(obj interface{}) ([]interface{}, error) {
 		}
 		return list, nil
 	}
+
 	if obj != nil {
 		return []interface{}{obj}, nil
 	}
+
 	return nil, nil
 }
 
+// Columns returns the column names to use
 func (m *experimentsMeta) Columns(obj interface{}, outputFormat string, showLabels bool) []string {
 	// Special case for trial list CSV to include everything as columns
 	if tl, ok := obj.(*experimentsv1alpha1.TrialList); ok && outputFormat == "csv" {
@@ -229,6 +234,7 @@ func (m *experimentsMeta) Columns(obj interface{}, outputFormat string, showLabe
 	return columns
 }
 
+// ExtractValue returns a cell value
 func (m *experimentsMeta) ExtractValue(obj interface{}, column string) (string, error) {
 	switch o := obj.(type) {
 	case *experimentsv1alpha1.ExperimentItem:
@@ -296,6 +302,7 @@ func (m *experimentsMeta) ExtractValue(obj interface{}, column string) (string, 
 	return "", fmt.Errorf("unable to get value for column %s", column)
 }
 
+// Header returns the header name to use for a column
 func (m *experimentsMeta) Header(outputFormat string, column string) string {
 	if strings.ToLower(outputFormat) == "csv" {
 		return column

--- a/redskyctl/internal/commands/experiments/experiments_test.go
+++ b/redskyctl/internal/commands/experiments/experiments_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2020 GramLabs, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package experiments
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseNames(t *testing.T) {
+	cases := []struct {
+		desc  string
+		args  []string
+		names []name
+		err   string
+	}{
+		{
+			desc:  "ListType",
+			args:  []string{"exp"},
+			names: []name{{Type: typeExperiment, Number: -1}},
+		},
+		{
+			desc:  "SharedType",
+			args:  []string{"experiment", "foo", "bar"},
+			names: []name{{Type: typeExperiment, Name: "foo", Number: -1}, {Type: typeExperiment, Name: "bar", Number: -1}},
+		},
+		{
+			desc:  "IndividualType",
+			args:  []string{"experiment/foo", "trial/bar"},
+			names: []name{{Type: typeExperiment, Name: "foo", Number: -1}, {Type: typeTrial, Name: "bar", Number: -1}},
+		},
+		{
+			desc:  "OverrideSharedType",
+			args:  []string{"experiment", "foo", "trial/bar"},
+			names: []name{{Type: typeExperiment, Name: "foo", Number: -1}, {Type: typeTrial, Name: "bar", Number: -1}},
+		},
+		{
+			desc: "SharedTypeNumbered",
+			args: []string{"trial", "foo/1", "foo/002", "foo-3", "foo-004"},
+			names: []name{
+				{Type: typeTrial, Name: "foo", Number: 1},
+				{Type: typeTrial, Name: "foo", Number: 2},
+				{Type: typeTrial, Name: "foo", Number: 3},
+				{Type: typeTrial, Name: "foo", Number: 4},
+			},
+		},
+		{
+			desc: "TypeNumbered",
+			args: []string{"trial/foo/1", "trial/foo/002", "trial/foo-3", "trial/foo-004"},
+			names: []name{
+				{Type: typeTrial, Name: "foo", Number: 1},
+				{Type: typeTrial, Name: "foo", Number: 2},
+				{Type: typeTrial, Name: "foo", Number: 3},
+				{Type: typeTrial, Name: "foo", Number: 4},
+			},
+		},
+		{
+			desc:  "NotSpecified",
+			args:  nil,
+			names: nil,
+			err:   "required resource not specified",
+		},
+		{
+			desc:  "UnknownType",
+			args:  []string{"foo"},
+			names: nil,
+			err:   "unknown resource type \"foo\"",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			names, err := parseNames(c.args)
+			if c.err != "" {
+				assert.EqualError(t, err, c.err)
+			} else if assert.NoError(t, err) {
+				assert.Equal(t, names, c.names)
+			}
+		})
+	}
+}

--- a/redskyctl/internal/commands/experiments/get.go
+++ b/redskyctl/internal/commands/experiments/get.go
@@ -34,8 +34,6 @@ type GetOptions struct {
 	ChunkSize int
 	SortBy    string
 	Selector  string
-
-	meta experimentsMeta
 }
 
 // NewGetCommand creates a new get command
@@ -57,7 +55,7 @@ func NewGetCommand(o *GetOptions) *cobra.Command {
 	cmd.Flags().StringVar(&o.SortBy, "sort-by", o.SortBy, "Sort list types using this JSONPath `expression`.")
 
 	TypeAndNameArgs(cmd, &o.Options)
-	commander.SetPrinter(&o.meta, &o.Printer, cmd)
+	commander.SetPrinter(&experimentsMeta{}, &o.Printer, cmd)
 	commander.ExitOnError(cmd)
 	return cmd
 }
@@ -156,9 +154,6 @@ func (o *GetOptions) getTrialList(ctx context.Context, name string) error {
 	if err != nil {
 		return err
 	}
-
-	// Store the experiment in metadata
-	o.meta.base = &exp
 
 	// Fetch the trial data
 	q := &experimentsv1alpha1.TrialListQuery{Status: []experimentsv1alpha1.TrialStatus{

--- a/redskyctl/internal/commands/experiments/get.go
+++ b/redskyctl/internal/commands/experiments/get.go
@@ -34,6 +34,7 @@ type GetOptions struct {
 	ChunkSize int
 	SortBy    string
 	Selector  string
+	All       bool
 }
 
 // NewGetCommand creates a new get command
@@ -56,6 +57,7 @@ func NewGetCommand(o *GetOptions) *cobra.Command {
 	cmd.Flags().IntVar(&o.ChunkSize, "chunk-size", o.ChunkSize, "Fetch large lists in chunks rather then all at once.")
 	cmd.Flags().StringVarP(&o.Selector, "selector", "l", o.Selector, "Selector (label `query`) to filter on.")
 	cmd.Flags().StringVar(&o.SortBy, "sort-by", o.SortBy, "Sort list types using this JSONPath `expression`.")
+	cmd.Flags().BoolVarP(&o.All, "all", "A", false, "Include all resources.")
 
 	commander.SetPrinter(&experimentsMeta{}, &o.Printer, cmd)
 	commander.ExitOnError(cmd)
@@ -83,6 +85,9 @@ func (o *GetOptions) get(ctx context.Context) error {
 			if n.Number < 0 {
 				q := &experimentsv1alpha1.TrialListQuery{
 					Status: []experimentsv1alpha1.TrialStatus{experimentsv1alpha1.TrialActive, experimentsv1alpha1.TrialCompleted, experimentsv1alpha1.TrialFailed},
+				}
+				if o.All {
+					q.Status = append(q.Status, experimentsv1alpha1.TrialStaged)
 				}
 				return o.getTrialList(ctx, n.experimentName(), q)
 			} else {

--- a/redskyctl/internal/commands/experiments/get.go
+++ b/redskyctl/internal/commands/experiments/get.go
@@ -182,6 +182,11 @@ func (o *GetOptions) getTrials(ctx context.Context, numbers map[experimentsv1alp
 		}
 	}
 
+	// If this was a request for a single object, just print it out (e.g. don't produce a JSON list for a single element)
+	if len(numbers) == 1 && len(l.Trials) == 1 { // TODO Also should check the length of the map value...
+		return o.Printer.PrintObj(&l.Trials[0], o.Out)
+	}
+
 	if err := o.filterAndSortTrials(l); err != nil {
 		return err
 	}
@@ -236,8 +241,9 @@ func (o *GetOptions) filterAndSortExperiments(l *experimentsv1alpha1.ExperimentL
 
 // sortableExperimentData slightly modifies the schema of the experiment item to make it easier to specify sort orders
 func sortableExperimentData(item *experimentsv1alpha1.ExperimentItem) map[string]interface{} {
-	d := make(map[string]interface{}, 1)
+	d := make(map[string]interface{}, 2)
 	d["name"] = item.DisplayName
+	d["observations"] = item.Observations
 	return d
 }
 

--- a/redskyctl/internal/commands/experiments/get.go
+++ b/redskyctl/internal/commands/experiments/get.go
@@ -259,15 +259,6 @@ func (o *GetOptions) filterAndSortTrials(l *experimentsv1alpha1.TrialList) error
 	return nil
 }
 
-func hasTrialNumber(t *experimentsv1alpha1.TrialItem, nums []int64) bool {
-	for _, n := range nums {
-		if t.Number == n {
-			return true
-		}
-	}
-	return false
-}
-
 // sortableTrialData slightly modifies the schema of the trial item to make it easier to specify sort orders
 func sortableTrialData(item *experimentsv1alpha1.TrialItem) map[string]interface{} {
 	assignments := make(map[string]int64, len(item.Assignments))

--- a/redskyctl/internal/commands/experiments/label.go
+++ b/redskyctl/internal/commands/experiments/label.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2020 GramLabs, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package experiments
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	experimentsv1alpha1 "github.com/redskyops/redskyops-controller/redskyapi/experiments/v1alpha1"
+	"github.com/redskyops/redskyops-controller/redskyctl/internal/commander"
+	"github.com/spf13/cobra"
+)
+
+// LabelOptions includes the configuration for deleting experiment API objects
+type LabelOptions struct {
+	Options
+
+	// Labels to apply
+	Labels map[string]string
+}
+
+// NewLabelCommand creates a new label command
+func NewLabelCommand(o *LabelOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "label (TYPE NAME | TYPE/NAME ...) KEY_1=VAL_1 ... KEY_N=VAL_N",
+		Short: "Label a Red Sky resource",
+		Long:  "Label Red Sky resources on the remote server",
+
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			commander.SetStreams(&o.IOStreams, cmd)
+			if err := commander.SetExperimentsAPI(&o.ExperimentsAPI, o.Config, cmd); err != nil {
+				return err
+			}
+			return o.setNamesAndLabels(args)
+		},
+		RunE: commander.WithContextE(o.label),
+	}
+
+	o.Printer = &verbPrinter{verb: "labeled"}
+	commander.ExitOnError(cmd)
+	return cmd
+}
+
+func (o *LabelOptions) setNamesAndLabels(args []string) error {
+	o.Labels = make(map[string]string, len(args))
+	nameArgs := make([]string, 0, len(args))
+	for _, arg := range args {
+		if p := strings.SplitN(arg, "=", 2); len(p) == 2 {
+			o.Labels[p[0]] = p[1]
+		} else if strings.HasSuffix(arg, "-") && strings.Trim(arg, "-") != "" {
+			o.Labels[strings.TrimSuffix(arg, "-")] = ""
+		} else {
+			nameArgs = append(nameArgs, arg)
+		}
+	}
+	return o.setNames(nameArgs)
+}
+
+func (o *LabelOptions) label(ctx context.Context) error {
+	t := make(map[experimentsv1alpha1.ExperimentName][]int64)
+	for _, n := range o.Names {
+		switch n.Type {
+		case typeTrial:
+			key := n.experimentName()
+			t[key] = append(t[key], n.Number)
+
+		default:
+			return fmt.Errorf("cannot label %s", n.Type)
+		}
+	}
+
+	if len(t) > 0 {
+		return o.labelTrial(ctx, t)
+	}
+
+	return nil
+}
+
+func (o *LabelOptions) labelTrial(ctx context.Context, numbers map[experimentsv1alpha1.ExperimentName][]int64) error {
+	for n, nums := range numbers {
+		exp, err := o.ExperimentsAPI.GetExperimentByName(ctx, n)
+		if err != nil {
+			return err
+		}
+
+		// TODO Check `exp.Trials != ""`
+		tl, err := o.ExperimentsAPI.GetAllTrials(ctx, exp.Trials, nil)
+		if err != nil {
+			return err
+		}
+
+		for i := range tl.Trials {
+			if hasTrialNumber(&tl.Trials[i], nums) {
+				t := tl.Trials[i]
+				t.Experiment = &exp
+
+				// TODO Check `t.TrialLabels != ""`
+				if err := o.ExperimentsAPI.LabelTrial(ctx, t.TrialLabels, experimentsv1alpha1.TrialLabels{Labels: o.Labels}); err != nil {
+					return err
+				}
+				if err := o.Printer.PrintObj(&t, o.Out); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/redskyctl/internal/commands/experiments/suggest.go
+++ b/redskyctl/internal/commands/experiments/suggest.go
@@ -50,7 +50,7 @@ func NewSuggestCommand(o *SuggestOptions) *cobra.Command {
 		Args: cobra.ExactArgs(1),
 
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			o.Options.Names = args
+			o.Names = []name{{Type: typeExperiment, Name: args[0]}}
 			commander.SetStreams(&o.IOStreams, cmd)
 			return commander.SetExperimentsAPI(&o.ExperimentsAPI, o.Config, cmd)
 		},
@@ -66,7 +66,7 @@ func NewSuggestCommand(o *SuggestOptions) *cobra.Command {
 }
 
 func (o *SuggestOptions) suggest(ctx context.Context) error {
-	exp, err := o.ExperimentsAPI.GetExperimentByName(ctx, experimentsv1alpha1.NewExperimentName(o.Names[0]))
+	exp, err := o.ExperimentsAPI.GetExperimentByName(ctx, o.Names[0].experimentName())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This started as a just "add the label" command. It quickly expanded to include "add in all the missing Experiment API bindings". Then I realized we were in kind of an uncanny valley with `redskyctl (get|delete)` and `kubectl (get|delete)` so it also includes "make the Experiment API commands work more like kubectl". And finally "fix all those output bugs" because when I switched the printer from Kube API objects to Experiment API objects I forgot a few things.