### PR TITLE
Clean up some error messages

### DIFF
--- a/redskyctl/internal/commands/experiments/suggest.go
+++ b/redskyctl/internal/commands/experiments/suggest.go
@@ -178,7 +178,7 @@ func checkValue(p *experimentsv1alpha1.Parameter, n json.Number) (json.Number, e
 			return "0", err
 		}
 		if v < min || v > max {
-			return "0", fmt.Errorf("")
+			return "0", fmt.Errorf("value is not within experiment bounds [%d-%d]: %d", min, max, v)
 		}
 	case experimentsv1alpha1.ParameterTypeDouble:
 		min, max, err := floatBounds(&p.Bounds)
@@ -190,7 +190,7 @@ func checkValue(p *experimentsv1alpha1.Parameter, n json.Number) (json.Number, e
 			return "0.0", err
 		}
 		if v < min || v > max {
-			return "0.0", fmt.Errorf("")
+			return "0.0", fmt.Errorf("value is not within experiment bounds [%f-%f]: %f", min, max, v)
 		}
 	}
 	return n, nil

--- a/redskyctl/internal/commands/generate/trial.go
+++ b/redskyctl/internal/commands/generate/trial.go
@@ -50,11 +50,13 @@ func NewTrialCommand(o *TrialOptions) *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&o.Filename, "filename", "f", o.Filename, "File that contains the experiment to generate trials for.")
+
 	cmd.Flags().StringToStringVarP(&o.Assignments, "assign", "A", nil, "Assign an explicit value to a parameter.")
 	cmd.Flags().BoolVar(&o.AllowInteractive, "interactive", o.AllowInteractive, "Allow interactive prompts for unspecified parameter assignments.")
 	cmd.Flags().StringVar(&o.DefaultBehavior, "default", "", "Select the behavior for default values; one of: none|min|max|rand.")
 
 	_ = cmd.MarkFlagFilename("filename", "yml", "yaml")
+	_ = cmd.MarkFlagRequired("filename")
 
 	commander.SetKubePrinter(&o.Printer, cmd)
 	commander.ExitOnError(cmd)


### PR DESCRIPTION
- Mark filename flag required for `redskyctl generate trial`
- Return an error message when supplied value is out of bounds for the experiment