### PR TITLE
Run all patch ready checks first

### DIFF
--- a/api/v1alpha1/trial_types.go
+++ b/api/v1alpha1/trial_types.go
@@ -145,7 +145,7 @@ type ReadinessCheck struct {
 	Selector *metav1.LabelSelector `json:"selector,omitempty"`
 	// ConditionTypes are the status conditions that must be "True"; in addition to conditions that appear in the
 	// status of the target object, additional special conditions starting with "redskyops.dev/" can be tested
-	ConditionTypes []string `json:"conditionTypes"`
+	ConditionTypes []string `json:"conditionTypes,omitempty"`
 	// InitialDelaySeconds is the approximate number of seconds after all of the patches have been applied to start
 	// evaluating this check
 	InitialDelaySeconds int32 `json:"initialDelaySeconds,omitempty"`

--- a/config/crd/bases/redskyops.dev_experiments.yaml
+++ b/config/crd/bases/redskyops.dev_experiments.yaml
@@ -376,7 +376,6 @@ spec:
                                 type: string
                             type: object
                         required:
-                        - conditionTypes
                         - targetRef
                         type: object
                       type: array

--- a/config/crd/bases/redskyops.dev_trials.yaml
+++ b/config/crd/bases/redskyops.dev_trials.yaml
@@ -165,7 +165,6 @@ spec:
                         type: string
                     type: object
                 required:
-                - conditionTypes
                 - targetRef
                 type: object
               type: array

--- a/docs/api/trial.md
+++ b/docs/api/trial.md
@@ -106,7 +106,7 @@ ReadinessCheck represents a check to determine when the patched application is "
 | ----- | ----------- | ------ | -------- |
 | `targetRef` | TargetRef is the reference to the object to test the readiness of | _[ObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectreference-v1-core)_ | true |
 | `selector` | Selector may be used to trigger a search for multiple related objects to search; this may have RBAC implications, in particular "list" permissions are required | _*[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#labelselector-v1-meta)_ | false |
-| `conditionTypes` | ConditionTypes are the status conditions that must be "True"; in addition to conditions that appear in the status of the target object, additional special conditions starting with "redskyops.dev/" can be tested | _[]string_ | true |
+| `conditionTypes` | ConditionTypes are the status conditions that must be "True"; in addition to conditions that appear in the status of the target object, additional special conditions starting with "redskyops.dev/" can be tested | _[]string_ | false |
 | `initialDelaySeconds` | InitialDelaySeconds is the approximate number of seconds after all of the patches have been applied to start evaluating this check | _int32_ | false |
 | `periodSeconds` | PeriodSeconds is the approximate amount of time in between evaluation attempts of this check | _int32_ | false |
 | `attemptsRemaining` | AttemptsRemaining is the number of failed attempts to allow before marking the entire trial as failed, will be automatically set to zero if the check has been successfully evaluated | _int32_ | false |


### PR DESCRIPTION
Patch readiness checks run first, then all gate readiness checks run sequentially after that.

Also, do not require condition types.