### PR TITLE
fix: dont remove label from generated trial

### DIFF
--- a/redskyctl/internal/commands/generate/trial.go
+++ b/redskyctl/internal/commands/generate/trial.go
@@ -91,7 +91,6 @@ func (o *TrialOptions) generate() error {
 	// Clear out some values we do not need
 	t.Finalizers = nil
 	t.Annotations = nil
-	t.Labels = nil
 
 	return o.Printer.PrintObj(t, o.Out)
 }


### PR DESCRIPTION
This fixes an issue where the experiment and trial wont get linked up because
of missing labels in the trail.

Signed-off-by: Brad Beam <brad@carbonrelay.com>