### PR TITLE
Trigger a Netlify deploy on release

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,10 @@
+name: Documentation workflow
+on:
+  release:
+    types: [published]
+jobs:
+  build:
+    name: Trigger Deploy
+    steps:
+      - name: Invoke build hook
+        run: curl -X POST -d '{}' https://api.netlify.com/build_hooks/${{ secrets.NETLIFY_BUILD_HOOK }}?trigger_title=GitHub+release

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -3,7 +3,7 @@ on:
   release:
     types: [published]
 jobs:
-  build:
+  triggerDeploy:
     name: Trigger Deploy
     steps:
       - name: Invoke build hook


### PR DESCRIPTION
In case you haven't noticed, doing a release _does not_ trigger the documentation site to update. Currently that happens later: generally once the Helm chart is generated, it gets merged to `staging`. Then we manually merge `staging` into `master` and that triggers the update to the site.

This changes that: now once the release gets published we trigger Netlify to re-build the site, this will in turn see the just released tag without a change on the `redskyops-www` `master` branch.

I opted to trigger on release rather than push/tag since there is a brief time where the `redskyctl` binaries are just sitting in a "draft release" waiting for someone to hit the "Publish" button.