### PR TITLE
Allow authorize cluster to generate Helm values

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -20,7 +20,7 @@ curl -s https://api.github.com/repos/redskyops/redskyops-controller/releases/lat
 sudo mv redskyctl /usr/local/bin/
 ```
 
-## Using Homebrew
+### Using Homebrew
 
 For macOS users, you can install `redskyctl` using Homebrew:
 
@@ -38,10 +38,6 @@ To perform an easy install, simply run `redskyctl init`. This will run a pod in 
 
 Using `redskyctl init` is safe for multiple invocations; in fact re-running it with a new version of `redskyctl` is also the easiest way to upgrade your in cluster components or configuration.
 
-### Easy Enterprise Install
-
-If you are subscribing to the Enterprise product, please contact your sales representative for additional configuration prior to running `redskyctl init`. If you just want to get started, you can always apply the additional configuration later.
-
 ### Helm Install
 
 If you cannot use `redskyctl` to install, a basic Helm chart exists. To install using Helm, add the Red Sky Ops repository and install the `redskyops` chart:
@@ -53,6 +49,12 @@ helm install --namespace redsky-system --name redsky redsky/redskyops
 ```
 
 The latest release of the Helm chart may not reference the latest application version, use the `redskyTag` value to override the application version.
+
+### Enterprise Installation
+
+If you are subscribing to the Enterprise product, please contact your sales representative prior to running `redskyctl init` or installing via Helm. If you just want to get started, you can always apply the additional configuration later.
+
+Additional information can be found in the [Server Configuration](remote.md) section.
 
 ### RBAC Requirements
 

--- a/docs/redskyctl/redskyctl_authorize-cluster.md
+++ b/docs/redskyctl/redskyctl_authorize-cluster.md
@@ -14,6 +14,7 @@ redskyctl authorize-cluster [flags]
 
 ```
       --client-name string   Client name to use for registration.
+      --helm-values          Generate a Helm values file instead of a secret.
   -h, --help                 help for authorize-cluster
 ```
 

--- a/docs/redskyctl/redskyctl_generate_secret.md
+++ b/docs/redskyctl/redskyctl_generate_secret.md
@@ -14,6 +14,7 @@ redskyctl generate secret [flags]
 
 ```
       --client-name string   Client name to use for registration.
+      --helm-values          Generate a Helm values file instead of a secret.
   -h, --help                 help for secret
   -o, --output format        Output format. One of: json|yaml (default "yaml")
 ```

--- a/docs/remote.md
+++ b/docs/remote.md
@@ -35,3 +35,7 @@ redskyctl init
 ```
 
 Alternately, you can store your configuration in the `redsky-manager` secret of the `redsky-system` namespace. You can also view this secret to verify the effective configuration values.
+
+## Helm Values
+
+If you are installing the Red Sky Ops Controller in your cluster using Helm, you can run `redskyctl authorize-cluster --helm-values` to produce a `values.yaml` file with the necessary extra configuration.

--- a/redskyctl/internal/commands/authorize_cluster/authorize_cluster.go
+++ b/redskyctl/internal/commands/authorize_cluster/authorize_cluster.go
@@ -51,6 +51,11 @@ func NewCommand(o *Options) *cobra.Command {
 }
 
 func (o *Options) authorizeCluster(ctx context.Context) error {
+	// If we are generating Helm values, just call the generator directly and return
+	if o.HelmValues {
+		return o.generate(ctx)
+	}
+
 	// Fork `kubectl apply` and get a pipe to write manifests to
 	kubectlApply, err := o.Config.Kubectl(ctx, "apply", "-f", "-")
 	if err != nil {

--- a/redskyctl/internal/commands/authorize_cluster/generator.go
+++ b/redskyctl/internal/commands/authorize_cluster/generator.go
@@ -197,25 +197,25 @@ type helmValuesPrinter struct {
 }
 
 func (h helmValuesPrinter) PrintObj(i interface{}, w io.Writer) error {
-	if secret, ok := i.(*corev1.Secret); ok {
-		vals := map[string]interface{}{
-			"remoteServer": map[string]interface{}{
-				"enabled":      true,
-				"identifier":   string(secret.Data["REDSKY_SERVER_IDENTIFIER"]),
-				"issuer":       string(secret.Data["REDSKY_SERVER_ISSUER"]),
-				"clientID":     string(secret.Data["REDSKY_AUTHORIZATION_CLIENT_ID"]),
-				"clientSecret": string(secret.Data["REDSKY_AUTHORIZATION_CLIENT_SECRET"]),
-			},
-		}
-
-		b, err := yaml.Marshal(vals)
-		if err != nil {
-			return err
-		}
-		_, err = w.Write(b)
-		if err != nil {
-			return err
-		}
+	secret, ok := i.(*corev1.Secret)
+	if !ok {
+		return nil
 	}
-	return nil
+
+	vals := map[string]interface{}{
+		"remoteServer": map[string]interface{}{
+			"enabled":      true,
+			"identifier":   string(secret.Data["REDSKY_SERVER_IDENTIFIER"]),
+			"issuer":       string(secret.Data["REDSKY_SERVER_ISSUER"]),
+			"clientID":     string(secret.Data["REDSKY_AUTHORIZATION_CLIENT_ID"]),
+			"clientSecret": string(secret.Data["REDSKY_AUTHORIZATION_CLIENT_SECRET"]),
+		},
+	}
+
+	b, err := yaml.Marshal(vals)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(b)
+	return err
 }

--- a/redskyctl/internal/commands/authorize_cluster/generator.go
+++ b/redskyctl/internal/commands/authorize_cluster/generator.go
@@ -19,6 +19,7 @@ package authorize_cluster
 import (
 	"context"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/redskyops/redskyops-controller/internal/config"
@@ -28,6 +29,7 @@ import (
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
 )
 
 // TODO This should work like a kustomize secret generator for the extra env vars
@@ -51,6 +53,8 @@ type GeneratorOptions struct {
 	ClientName string
 	// AllowUnauthorized generates a secret with no authorization information
 	AllowUnauthorized bool
+	// HelmValues indicates that instead of generating a Kubernetes secret, we should generate a Helm values file
+	HelmValues bool
 }
 
 // NewGeneratorCommand creates a command for generating the cluster authorization secret
@@ -82,6 +86,7 @@ func NewGeneratorCommand(o *GeneratorOptions) *cobra.Command {
 func (o *GeneratorOptions) addFlags(cmd *cobra.Command) {
 	// TODO Allow name to be configurable?
 	cmd.Flags().StringVar(&o.ClientName, "client-name", o.ClientName, "Client name to use for registration.")
+	cmd.Flags().BoolVar(&o.HelmValues, "helm-values", o.HelmValues, "Generate a Helm values file instead of a secret.")
 	cmd.Flags().BoolVar(&o.AllowUnauthorized, "allow-unauthorized", o.AllowUnauthorized, "Generate a secret without authorization, if necessary.")
 	_ = cmd.Flags().MarkHidden("allow-unauthorized")
 }
@@ -144,6 +149,11 @@ func (o *GeneratorOptions) generate(ctx context.Context) error {
 	secret.Data["REDSKY_AUTHORIZATION_CLIENT_ID"] = []byte(info.ClientID)
 	secret.Data["REDSKY_AUTHORIZATION_CLIENT_SECRET"] = []byte(info.ClientSecret)
 
+	// Use an alternate printer just for Helm values
+	if o.HelmValues {
+		o.Printer = &helmValuesPrinter{}
+	}
+
 	return o.Printer.PrintObj(secret, o.Out)
 }
 
@@ -181,4 +191,31 @@ func (o *GeneratorOptions) clientInfo(ctx context.Context, ctrl *config.Controll
 		ResponseTypes: []string{},
 	}
 	return o.Config.RegisterClient(ctx, client)
+}
+
+type helmValuesPrinter struct {
+}
+
+func (h helmValuesPrinter) PrintObj(i interface{}, w io.Writer) error {
+	if secret, ok := i.(*corev1.Secret); ok {
+		vals := map[string]interface{}{
+			"remoteServer": map[string]interface{}{
+				"enabled":      true,
+				"identifier":   string(secret.Data["REDSKY_SERVER_IDENTIFIER"]),
+				"issuer":       string(secret.Data["REDSKY_SERVER_ISSUER"]),
+				"clientID":     string(secret.Data["REDSKY_AUTHORIZATION_CLIENT_ID"]),
+				"clientSecret": string(secret.Data["REDSKY_AUTHORIZATION_CLIENT_SECRET"]),
+			},
+		}
+
+		b, err := yaml.Marshal(vals)
+		if err != nil {
+			return err
+		}
+		_, err = w.Write(b)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
Just realized that there is no easy way for "enterprise customers" to install via Helm. This adds a `--helm-values` option to the `redskyctl authorize-cluster` command so instead of updating the secret directly in the cluster, it will print out a Helm `values.yaml` file for our chart.

Note that nothing prevents customers from running the regular `authorize-cluster` after a Helm install, but this might fit what they are expecting a little better.