### PR TITLE
Show unique experiment name instead of display name

### DIFF
--- a/redskyapi/experiments/v1alpha1/api.go
+++ b/redskyapi/experiments/v1alpha1/api.go
@@ -274,6 +274,19 @@ type Experiment struct {
 	Parameters []Parameter `json:"parameters"`
 }
 
+// Name allows an experiment to be used as an ExperimentName
+func (e *Experiment) Name() string {
+	u, err := url.Parse(e.Self)
+	if err != nil {
+		return ""
+	}
+	i := strings.Index(u.Path, endpointExperiment)
+	if i < 0 {
+		return ""
+	}
+	return u.Path[len(endpointExperiment)+i:]
+}
+
 type ExperimentItem struct {
 	Experiment
 
@@ -520,7 +533,7 @@ func (h *httpAPI) GetAllExperimentsByPage(ctx context.Context, u string) (Experi
 }
 
 func (h *httpAPI) GetExperimentByName(ctx context.Context, n ExperimentName) (Experiment, error) {
-	u := h.client.URL(endpointExperiment + url.PathEscape(n.Name()))
+	u := h.client.URL(endpointExperiment + n.Name())
 	return h.GetExperiment(ctx, u.String())
 }
 

--- a/redskyctl/internal/commands/experiments/experiments.go
+++ b/redskyctl/internal/commands/experiments/experiments.go
@@ -240,6 +240,8 @@ func (m *experimentsMeta) ExtractValue(obj interface{}, column string) (string, 
 	case *experimentsv1alpha1.ExperimentItem:
 		switch column {
 		case "name":
+			return o.Name(), nil
+		case "Name":
 			return o.DisplayName, nil
 		case "observations":
 			return strconv.FormatInt(o.Observations, 10), nil

--- a/redskyctl/internal/commands/experiments/experiments_test.go
+++ b/redskyctl/internal/commands/experiments/experiments_test.go
@@ -70,6 +70,11 @@ func TestParseNames(t *testing.T) {
 			},
 		},
 		{
+			desc:  "Spaced",
+			args:  []string{"experiment", "Foo Bar"},
+			names: []name{{Type: typeExperiment, Name: "Foo Bar", Number: -1}},
+		},
+		{
 			desc:  "NotSpecified",
 			args:  nil,
 			names: nil,


### PR DESCRIPTION
James first saw this as "experiment-not-found" when trying to get or delete an experiment. It turns out the problem was that we were showing the wrong name.