### PR TITLE
Last call for v1alpha1

### DIFF
--- a/api/v1alpha1/experiment_types.go
+++ b/api/v1alpha1/experiment_types.go
@@ -77,33 +77,22 @@ type SumConstraint struct {
 	Parameters []SumConstraintParameter `json:"parameters"`
 }
 
-// PatchType represents the allowable types of patches
-type PatchType string
-
 // MetricType represents the allowable types of metrics
 type MetricType string
 
 const (
-	// Strategic merge patch
-	PatchStrategic PatchType = "strategic"
-	// Merge patch
-	PatchMerge = "merge"
-	// JSON patch (RFC 6902)
-	PatchJSON = "json"
-
-	// Local metrics are Go Templates evaluated against the trial itself. No external service is consulted, primarily
+	// MetricLocal metrics are Go Templates evaluated against the trial itself. No external service is consulted, primarily
 	// useful for extracting start and completion times.
 	MetricLocal MetricType = "local"
-	// Pod metrics are similar to local metrics, however the list of pods in the trial namespace matched by the selector
+	// MetricPods metrics are similar to local metrics, however the list of pods in the trial namespace matched by the selector
 	// is also available.
-	MetricPods = "pods"
-	// Prometheus metrics issue PromQL queries to a matched service. Queries MUST evaluate to a scalar value.
-	MetricPrometheus = "prometheus"
-	// Datadog metrics issue queries to the Datadog service. Requires API and application key configuration.
-	MetricDatadog = "datadog"
-	// JSON path metrics fetch a JSON resource from the matched service. Queries are JSON path expression evaluated against the resource.
-	MetricJSONPath = "jsonpath"
-	// TODO "regex"?
+	MetricPods MetricType = "pods"
+	// MetricPrometheus metrics issue PromQL queries to a matched service. Queries MUST evaluate to a scalar value.
+	MetricPrometheus MetricType = "prometheus"
+	// MetricDatadog metrics issue queries to the Datadog service. Requires API and application key configuration.
+	MetricDatadog MetricType = "datadog"
+	// MetricJSONPath metrics fetch a JSON resource from the matched service. Queries are JSON path expression evaluated against the resource.
+	MetricJSONPath MetricType = "jsonpath"
 )
 
 // Metric represents an observable outcome from a trial run
@@ -113,7 +102,7 @@ type Metric struct {
 	// Indicator that the goal of the experiment is to minimize the value of this metric
 	Minimize bool `json:"minimize,omitempty"`
 
-	// The metric collection type, one of: local|prometheus|datadog|jsonpath, default: local
+	// The metric collection type, one of: local|pods|prometheus|datadog|jsonpath, default: local
 	Type MetricType `json:"type,omitempty"`
 	// Collection type specific query, e.g. Go template for "local", PromQL for "prometheus" or a JSON pointer expression (with curly braces) for "jsonpath"
 	Query string `json:"query"`
@@ -136,13 +125,25 @@ type PatchReadinessGate struct {
 	ConditionType string `json:"conditionType"`
 }
 
+// PatchType represents the allowable types of patches
+type PatchType string
+
+const (
+	// PatchStrategic is the patch type for a strategic merge patch
+	PatchStrategic PatchType = "strategic"
+	// PatchMerge is the patch type for a merge patch
+	PatchMerge PatchType = "merge"
+	// PatchJSON is the patch type for aJSON patch (RFC 6902)
+	PatchJSON PatchType = "json"
+)
+
 // PatchTemplate defines a target resource and a patch template to apply
 type PatchTemplate struct {
-	// The patch type, one of: json|merge|strategic, default: strategic
+	// The patch type, one of: strategic|merge|json, default: strategic
 	Type PatchType `json:"type,omitempty"`
-	// A Go Template that evaluates to valid patch.
+	// A Go Template that evaluates to valid patch
 	Patch string `json:"patch"`
-	// Direct reference to the object the patch should be applied to.
+	// Direct reference to the object the patch should be applied to
 	TargetRef *corev1.ObjectReference `json:"targetRef,omitempty"`
 	// ReadinessGates will be evaluated for patch target readiness. A patch target is ready if all conditions specified
 	// in the readiness gates have a status equal to "True". If no readiness gates are specified, some target types may

--- a/api/v1alpha1/experiment_types.go
+++ b/api/v1alpha1/experiment_types.go
@@ -175,11 +175,11 @@ type ExperimentSpec struct {
 	// Optimization defines additional configuration for the optimization
 	Optimization []Optimization `json:"optimization,omitempty"`
 	// Parameters defines the search space for the experiment
-	Parameters []Parameter `json:"parameters,omitempty"`
+	Parameters []Parameter `json:"parameters"`
 	// Constraints defines restrictions on the parameter domain for the experiment
 	Constraints []Constraint `json:"constraints,omitempty"`
 	// Metrics defines the outcomes for the experiment
-	Metrics []Metric `json:"metrics,omitempty"`
+	Metrics []Metric `json:"metrics"`
 	// Patches is a sequence of templates written against the experiment parameters that will be used to put the
 	// cluster into the desired state
 	Patches []PatchTemplate `json:"patches,omitempty"`
@@ -193,7 +193,7 @@ type ExperimentSpec struct {
 	// Template for creating a new trial. The resulting trial must be matched by Selector. The template can provide an
 	// initial namespace, however other namespaces (matched by NamespaceSelector) will be used if the effective
 	// replica count is more then one
-	Template TrialTemplateSpec `json:"template"`
+	Template TrialTemplateSpec `json:"template,omitempty"`
 }
 
 // ExperimentStatus defines the observed state of Experiment

--- a/api/v1alpha1/trial.go
+++ b/api/v1alpha1/trial.go
@@ -40,12 +40,12 @@ func (in *Trial) ExperimentNamespacedName() types.NamespacedName {
 	return nn
 }
 
-// Checks to see if the trial has an initializer
+// HasInitializer checks to see if the trial has an initializer
 func (in *Trial) HasInitializer() bool {
 	return strings.TrimSpace(in.GetAnnotations()[AnnotationInitializer]) != ""
 }
 
-// Returns an assignment value by name
+// GetAssignment returns an assignment value by name
 func (in *Trial) GetAssignment(name string) (int64, bool) {
 	for i := range in.Spec.Assignments {
 		if in.Spec.Assignments[i].Name == name {
@@ -55,7 +55,7 @@ func (in *Trial) GetAssignment(name string) (int64, bool) {
 	return 0, false
 }
 
-// Returns the job selector
+// GetJobSelector returns the job selector
 func (in *Trial) GetJobSelector() *metav1.LabelSelector {
 	if in.Spec.Selector != nil {
 		return in.Spec.Selector

--- a/api/v1alpha1/trial_types.go
+++ b/api/v1alpha1/trial_types.go
@@ -85,7 +85,7 @@ type ParameterSelector struct {
 	// TODO Offer simple manipulations via "percent", "delta", "scale"? Allow string references to other parameters
 }
 
-// HelmValueFromSource represents a source of a values mapping
+// HelmValuesFromSource represents a source of a values mapping
 type HelmValuesFromSource struct {
 	// The ConfigMap to select from
 	ConfigMap *ConfigMapHelmValuesFromSource `json:"configMap,omitempty"`
@@ -170,26 +170,25 @@ type Value struct {
 	// The number of remaining attempts to observer the value, will be automatically set
 	// to zero if the metric is successfully collected
 	AttemptsRemaining int `json:"attemptsRemaining,omitempty"`
-	// TODO Initial value captured prior to job execution for local metrics?
 }
 
 // TrialConditionType represents the possible observable conditions for a trial
 type TrialConditionType string
 
 const (
-	// Condition that indicates a successful trial run
+	// TrialComplete is a condition that indicates a successful trial run
 	TrialComplete TrialConditionType = "redskyops.dev/trial-complete"
-	// Condition that indicates a failed trial run
+	// TrialFailed is a condition that indicates a failed trial run
 	TrialFailed TrialConditionType = "redskyops.dev/trial-failed"
-	// Condition that indicates all "create" setup tasks have finished
+	// TrialSetupCreated is a condition that indicates all "create" setup tasks have finished
 	TrialSetupCreated TrialConditionType = "redskyops.dev/trial-setup-created"
-	// Condition that indicates all "delete" setup tasks have finished
+	// TrialSetupDeleted is a condition that indicates all "delete" setup tasks have finished
 	TrialSetupDeleted TrialConditionType = "redskyops.dev/trial-setup-deleted"
-	// Condition that indicates patches have been applied for a trial
+	// TrialPatched is a condition that indicates patches have been applied for a trial
 	TrialPatched TrialConditionType = "redskyops.dev/trial-patched"
-	// Condition that indicates a trail has stabilized after patches
+	// TrialReady is a condition that indicates the application is ready after patches were applied
 	TrialReady TrialConditionType = "redskyops.dev/trial-ready"
-	// Condition that indicates a trial has had metrics collected
+	// TrialObserved is a condition that indicates a trial has had metrics collected
 	TrialObserved TrialConditionType = "redskyops.dev/trial-observed"
 )
 

--- a/config/crd/bases/redskyops.dev_experiments.yaml
+++ b/config/crd/bases/redskyops.dev_experiments.yaml
@@ -3804,7 +3804,8 @@ spec:
                   type: object
               type: object
           required:
-          - template
+          - metrics
+          - parameters
           type: object
         status:
           properties:

--- a/docs/api/experiment.md
+++ b/docs/api/experiment.md
@@ -63,14 +63,14 @@ ExperimentSpec defines the desired state of Experiment
 | ----- | ----------- | ------ | -------- |
 | `replicas` | Replicas is the number of trials to execute concurrently, defaults to 1 | _*int32_ | false |
 | `optimization` | Optimization defines additional configuration for the optimization | _[][Optimization](#optimization)_ | false |
-| `parameters` | Parameters defines the search space for the experiment | _[][Parameter](#parameter)_ | false |
+| `parameters` | Parameters defines the search space for the experiment | _[][Parameter](#parameter)_ | true |
 | `constraints` | Constraints defines restrictions on the parameter domain for the experiment | _[][Constraint](#constraint)_ | false |
-| `metrics` | Metrics defines the outcomes for the experiment | _[][Metric](#metric)_ | false |
+| `metrics` | Metrics defines the outcomes for the experiment | _[][Metric](#metric)_ | true |
 | `patches` | Patches is a sequence of templates written against the experiment parameters that will be used to put the cluster into the desired state | _[][PatchTemplate](#patchtemplate)_ | false |
 | `namespaceSelector` | NamespaceSelector is used to locate existing namespaces for trials | _*[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#labelselector-v1-meta)_ | false |
 | `namespaceTemplate` | NamespaceTemplate can be specified to create new namespaces for trials; if specified created namespaces must be matched by the namespace selector | _*[NamespaceTemplateSpec](#namespacetemplatespec)_ | false |
 | `selector` | Selector locates trial resources that are part of this experiment | _*[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#labelselector-v1-meta)_ | false |
-| `template` | Template for creating a new trial. The resulting trial must be matched by Selector. The template can provide an initial namespace, however other namespaces (matched by NamespaceSelector) will be used if the effective replica count is more then one | _[TrialTemplateSpec](#trialtemplatespec)_ | true |
+| `template` | Template for creating a new trial. The resulting trial must be matched by Selector. The template can provide an initial namespace, however other namespaces (matched by NamespaceSelector) will be used if the effective replica count is more then one | _[TrialTemplateSpec](#trialtemplatespec)_ | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/docs/api/experiment.md
+++ b/docs/api/experiment.md
@@ -93,7 +93,7 @@ Metric represents an observable outcome from a trial run
 | ----- | ----------- | ------ | -------- |
 | `name` | The name of the metric | _string_ | true |
 | `minimize` | Indicator that the goal of the experiment is to minimize the value of this metric | _bool_ | false |
-| `type` | The metric collection type, one of: local\|prometheus\|datadog\|jsonpath, default: local | _MetricType_ | false |
+| `type` | The metric collection type, one of: local\|pods\|prometheus\|datadog\|jsonpath, default: local | _MetricType_ | false |
 | `query` | Collection type specific query, e.g. Go template for "local", PromQL for "prometheus" or a JSON pointer expression (with curly braces) for "jsonpath" | _string_ | true |
 | `errorQuery` | Collection type specific query for the error associated with collected metric value | _string_ | false |
 | `scheme` | The scheme to use when collecting metrics | _string_ | false |
@@ -164,9 +164,9 @@ PatchTemplate defines a target resource and a patch template to apply
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| `type` | The patch type, one of: json\|merge\|strategic, default: strategic | _PatchType_ | false |
-| `patch` | A Go Template that evaluates to valid patch. | _string_ | true |
-| `targetRef` | Direct reference to the object the patch should be applied to. | _*[ObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectreference-v1-core)_ | false |
+| `type` | The patch type, one of: strategic\|merge\|json, default: strategic | _PatchType_ | false |
+| `patch` | A Go Template that evaluates to valid patch | _string_ | true |
+| `targetRef` | Direct reference to the object the patch should be applied to | _*[ObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectreference-v1-core)_ | false |
 | `readinessGates` | ReadinessGates will be evaluated for patch target readiness. A patch target is ready if all conditions specified in the readiness gates have a status equal to "True". If no readiness gates are specified, some target types may have default gates assigned to them. Some condition checks may result in errors, e.g. a condition type of "Ready" is not allowed for a ConfigMap. Condition types starting with "redskyops.dev/" may not appear in the patched target's condition list, but are still evaluated against the resource's state. | _[][PatchReadinessGate](#patchreadinessgate)_ | false |
 
 [Back to TOC](#table-of-contents)

--- a/docs/api/trial.md
+++ b/docs/api/trial.md
@@ -67,7 +67,7 @@ HelmValueSource represents a source for a Helm value
 
 ## HelmValuesFromSource
 
-HelmValueFromSource represents a source of a values mapping
+HelmValuesFromSource represents a source of a values mapping
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |


### PR DESCRIPTION
This is the last call for _minor_ changes to v1alpha1 in the 1.5.x series.

Basically I fixed the comments that are generating lint warnings so we are not eternally plagued by them once we "lock" v1alpha1.

Additionally, after a conversation with Steph, it appears that the some of the "required/optional" flags are a little off. I suspect things like parameters and metrics have always been "required" however they were marked as optional to get the Kubebuilder scaffolded tests to pass (those tests have since been removed altogether). Likewise, the "template" has always been optional, however we represent it as a struct (not a pointer to a struct) so it is always going to be there (thus the lack of an `omitempty` that would otherwise trigger the documentation to claim it is not necessary).