### PR TITLE
fix: Ignore invalid git tags

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -15,8 +15,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v2
-      - name: Unshallow
-        run: git fetch --prune --unshallow
+      - name: Fetch tags
+        run: git fetch --depth=1 origin '+refs/tags/*:refs/tags/*'
       - name: Set up Go
         uses: actions/setup-go@v2
         with:

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -13,8 +13,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v2
-      - name: Unshallow
-        run: git fetch --prune --unshallow
+      - name: Fetch tags
+        run: git fetch --depth=1 origin '+refs/tags/*:refs/tags/*'
       - name: Verify Header
         uses: talos-systems/conform@v0.1.0-alpha.19
       - name: Set up Go

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ GOBIN=$(shell go env GOBIN)
 endif
 
 # Collect version information
-VERSION ?= $(shell git ls-remote --tags origin 'v*' | tail -1 | awk -F/ '{ print $$3 }')-next
+VERSION ?= $(shell git ls-remote --tags --refs origin 'v*' | awk -F/ '{ print $$3 }' | tail -1)-next
 BUILD_METADATA ?=
 GIT_COMMIT ?= $(shell git rev-parse HEAD)
 


### PR DESCRIPTION
This filters the tags we retrieve from git. Specifically we're ignoring ^{}
because they don't play nice with version metadata.

Minor change to the checkout workflow - fetch tags only instead of
entire history. Saw the example in the readme and seemed useful.

Signed-off-by: Brad Beam <brad.beam@carbonrelay.com>