### PR TITLE
Switch to a full checkout for tag history

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -15,8 +15,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v2
-      - name: Fetch tags
-        run: git fetch --tags --depth=1
+        with:
+          fetch-depth: 0
       - name: Set up Go
         uses: actions/setup-go@v2
         with:

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -15,8 +15,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+      - name: Unshallow
+        run: git fetch --prune --unshallow
       - name: Set up Go
         uses: actions/setup-go@v2
         with:

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -13,8 +13,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+      - name: Unshallow
+        run: git fetch --prune --unshallow
       - name: Verify Header
         uses: talos-systems/conform@v0.1.0-alpha.19
       - name: Set up Go

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -13,8 +13,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v2
-      - name: Fetch tags
-        run: git fetch --tags --depth=1
+        with:
+          fetch-depth: 0
       - name: Verify Header
         uses: talos-systems/conform@v0.1.0-alpha.19
       - name: Set up Go


### PR DESCRIPTION
We need `git describe` to work in order to get correct version numbers inside the build. Just fetching tags with a depth of 1 is insufficient.