### PR TITLE
Add type completion for API commands

### DIFF
--- a/redskyctl/internal/commands/completion/completion.go
+++ b/redskyctl/internal/commands/completion/completion.go
@@ -34,6 +34,11 @@ func NewCommand(o *Options) *cobra.Command {
 		Short: "Output shell completion code",
 		Long:  "Output shell completion code which can be evaluated to provide interactive completion of commands.",
 
+		Example: `# Load the completion code for zsh into the current shell
+source <(redskyctl completion zsh)
+# Set the completion code for zsh to autoload (assuming '$ZSH/completions' is part of 'fpath')
+redskyctl completion zsh > $ZSH/completions/_redskyctl`,
+
 		Args:      cobra.ExactValidArgs(1),
 		ValidArgs: []string{"bash", "zsh"},
 

--- a/redskyctl/internal/commands/experiments/delete.go
+++ b/redskyctl/internal/commands/experiments/delete.go
@@ -51,6 +51,8 @@ func NewDeleteCommand(o *DeleteOptions) *cobra.Command {
 		RunE: commander.WithContextE(o.delete),
 	}
 
+	_ = cmd.MarkZshCompPositionalArgumentWords(1, validTypes()...)
+
 	o.Printer = &verbPrinter{verb: "deleted"}
 	commander.ExitOnError(cmd)
 	return cmd

--- a/redskyctl/internal/commands/experiments/experiments.go
+++ b/redskyctl/internal/commands/experiments/experiments.go
@@ -36,8 +36,13 @@ const (
 	// typeExperiment is the type argument to use for experiments
 	typeExperiment resourceType = "experiment"
 	// typeTrial is the type argument to use for trials
-	typeTrial = "trial"
+	typeTrial resourceType = "trial"
 )
+
+// validTypes returns the supported object types as strings
+func validTypes() []string {
+	return []string{string(typeExperiment), string(typeTrial)}
+}
 
 // normalizeType returns a consistent value based on a user entered type
 func normalizeType(t string) (resourceType, error) {

--- a/redskyctl/internal/commands/experiments/get.go
+++ b/redskyctl/internal/commands/experiments/get.go
@@ -59,6 +59,8 @@ func NewGetCommand(o *GetOptions) *cobra.Command {
 	cmd.Flags().StringVar(&o.SortBy, "sort-by", o.SortBy, "Sort list types using this JSONPath `expression`.")
 	cmd.Flags().BoolVarP(&o.All, "all", "A", false, "Include all resources.")
 
+	_ = cmd.MarkZshCompPositionalArgumentWords(1, validTypes()...)
+
 	commander.SetPrinter(&experimentsMeta{}, &o.Printer, cmd)
 	commander.ExitOnError(cmd)
 	return cmd

--- a/redskyctl/internal/commands/experiments/label.go
+++ b/redskyctl/internal/commands/experiments/label.go
@@ -51,6 +51,8 @@ func NewLabelCommand(o *LabelOptions) *cobra.Command {
 		RunE: commander.WithContextE(o.label),
 	}
 
+	_ = cmd.MarkZshCompPositionalArgumentWords(1, validTypes()...)
+
 	o.Printer = &verbPrinter{verb: "labeled"}
 	commander.ExitOnError(cmd)
 	return cmd


### PR DESCRIPTION
There is a whole rabbit hole to go down here with Bash completions as well. Since Cobra doesn't allow function based suggestions for Zsh, it looks like a lot of projects generate the Bash completion and have Zsh use that. For now, I'm using Zsh and this is better then nothing.