### PR TITLE
Fix Helm chart bootstrap role

### DIFF
--- a/config/chart/redskyops/README.md
+++ b/config/chart/redskyops/README.md
@@ -14,7 +14,7 @@ helm repo update
 The Red Sky Ops manager can be installed using the Helm command:
 
 ```sh
-helm install --namespace redsky-system --name redsky redsky/redskyops
+helm install redsky redsky/redskyops --namespace redsky-system
 ```
 
 The recommended namespace (`redsky-system`) and release name (`redsky`) are consistent with an install performed using the `redskyctl` tool (see the [install guide](https://redskyops.dev/docs/install/) for more information).
@@ -23,12 +23,14 @@ The recommended namespace (`redsky-system`) and release name (`redsky`) are cons
 
 The following configuration options are available:
 
-| Parameter            | Description                                      |
-| -------------------- | ------------------------------------------------ |
-| `redskyImage`        | Docker image name                                |
-| `redskyTag`          | Docker image tag                                 |
-| `address`            | Fully qualified URL of the remote server         |
-| `oauth2ClientID`     | OAuth2 client identifier                         |
-| `oauth2ClientSecret` | OAuth2 client secret                             |
-| `oauth2TokenURL`     | Override default OAuth2 token URL                |
-| `rbac.create`        | Specify whether RBAC resources should be created |
+| Parameter                   | Description                                               |
+| --------------------------- | --------------------------------------------------------- |
+| `redskyImage`               | Docker image name                                         |
+| `redskyTag`                 | Docker image tag                                          |
+| `redskyImagePullPolicy`     | Pull policy for the Docker image                          |
+| `remoteServer.enabled`      | Flag indicating that the remote server should be used     |
+| `remoteServer.clientID`     | OAuth2 client identifier                                  |
+| `remoteServer.clientSecret` | OAuth2 client secret                                      |
+| `rbac.create`               | Specify whether RBAC resources should be created          |
+| `rbac.bootstrapPermissions` | Flag indicating default permissions should be included    |
+| `rbac.extraPermissions`     | Flag indicating additional permissions should be included |

--- a/config/chart/redskyops/templates/bootstrap_cluster_role.yaml
+++ b/config/chart/redskyops/templates/bootstrap_cluster_role.yaml
@@ -2,9 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: "{{ .Release.Name }}-aggregate-to-patching"
-  labels:
-    "redskyops.dev/aggregate-to-patching": "true"
+  name: "{{ .Release.Name }}-patching-role"
 rules:
   - apiGroups:
       - ""
@@ -30,4 +28,17 @@ rules:
     verbs:
       - create
 {{- end -}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: "{{ .Release.Name }}-patching-rolebinding"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: "{{ .Release.Name }}-patching-role"
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: "{{ .Release.Namespace }}"
 {{- end -}}


### PR DESCRIPTION
The bootstrap role was not updated to reflect the removal of the aggregating role rule. Also, it looks like the README never got updated for Helm 3.