### PR TITLE
Allow the default setup tools image name to be overridden

### DIFF
--- a/internal/setup/job.go
+++ b/internal/setup/job.go
@@ -19,6 +19,7 @@ package setup
 import (
 	"encoding/base64"
 	"fmt"
+	"os"
 	"path"
 
 	redskyv1alpha1 "github.com/redskyops/redskyops-controller/api/v1alpha1"
@@ -98,6 +99,12 @@ func NewJob(t *redskyv1alpha1.Trial, mode string) (*batchv1.Job, error) {
 				RunAsGroup:               &id,
 				AllowPrivilegeEscalation: &allowPrivilegeEscalation,
 			},
+		}
+
+		// Check the environment for a default setup tools image name
+		if c.Image == "" {
+			c.Image = os.Getenv("DEFAULT_SETUP_IMAGE")
+			c.ImagePullPolicy = corev1.PullPolicy(os.Getenv("DEFAULT_SETUP_IMAGE_PULL_POLICY"))
 		}
 
 		// Make sure we have an image


### PR DESCRIPTION
This is intended for special cases where the controller binaries are deployed without access to the public image repository.