### PR TITLE
Adjust generate rbac to produce cluster or scoped roles

### DIFF
--- a/redskyctl/internal/commands/generate/generate.go
+++ b/redskyctl/internal/commands/generate/generate.go
@@ -44,7 +44,7 @@ func NewCommand(o *Options) *cobra.Command {
 		Long:  "Generate Red Sky Ops object manifests",
 	}
 
-	cmd.AddCommand(NewRBACCommand(&RBACOptions{Config: o.Config}))
+	cmd.AddCommand(NewRBACCommand(&RBACOptions{Config: o.Config, ClusterRole: true, ClusterRoleBinding: true}))
 	cmd.AddCommand(NewTrialCommand(&TrialOptions{}))
 
 	// Also include plumbing generators used by other commands


### PR DESCRIPTION
Kept the core "find patches, generate roles" logic, but changed it so we can generate either:
1. ClusterRole/ClusterRoleBinding (default and current behavior)
2. ClusterRole/RoleBinding (similar to scoped installed for the manager role)
3. Role/RoleBinding (a new "experiment only" combination)

Most of these changes were just around grouping related bits of logic and having the ability to change the combination of object types that gets created.

Also new is that we need to consider the namespace for each experiment read in: if we are creating a Role or RoleBinding we need a namespace (even if it's an empty string which means the namespace will come from `kubectl apply/create` ultimately falling back to `default` if left unspecified). I opted to use the "cluster access" namespace as a default (this is the namespace that would typically get passed to every `kubectl` invocation).