### PR TITLE
Add the ability to label an experiment

### DIFF
--- a/redskyapi/experiments/v1alpha1/api.go
+++ b/redskyapi/experiments/v1alpha1/api.go
@@ -239,7 +239,7 @@ type ExperimentMeta struct {
 	Self         string    `json:"-"`
 	Trials       string    `json:"-"`
 	NextTrial    string    `json:"-"`
-	Labels       string    `json:"-"`
+	LabelsURL    string    `json:"-"`
 }
 
 func (m *ExperimentMeta) SetLocation(string) {}
@@ -255,7 +255,7 @@ func (m *ExperimentMeta) SetLink(rel, link string) {
 	case relationNextTrial:
 		m.NextTrial = link
 	case relationLabels:
-		m.Labels = link
+		m.LabelsURL = link
 	}
 }
 
@@ -358,8 +358,6 @@ type ExperimentLabels struct {
 type TrialMeta struct {
 	ReportTrial string `json:"-"`
 	LabelsURL   string `json:"-"`
-
-	// TODO Add "URL" suffixes on links / rename "ReportTrial" to "SelfURL"
 }
 
 func (m *TrialMeta) SetLocation(location string) { m.ReportTrial = location }

--- a/redskyapi/experiments/v1alpha1/api.go
+++ b/redskyapi/experiments/v1alpha1/api.go
@@ -275,6 +275,8 @@ type Experiment struct {
 	Constraints []Constraint `json:"constraints,omitempty"`
 	// The search space of the experiment.
 	Parameters []Parameter `json:"parameters"`
+	// Labels for this experiment.
+	Labels map[string]string `json:"labels,omitempty"`
 }
 
 // Name allows an experiment to be used as an ExperimentName

--- a/redskyapi/experiments/v1alpha1/fake/fake_api.go
+++ b/redskyapi/experiments/v1alpha1/fake/fake_api.go
@@ -98,6 +98,10 @@ func (f *FakeAPI) AbandonRunningTrial(ctx context.Context, u string) error {
 	panic("implement me")
 }
 
+func (f *FakeAPI) LabelExperiment(ctx context.Context, u string, lbl v1alpha1.ExperimentLabels) error {
+	panic("implement me")
+}
+
 func (f *FakeAPI) LabelTrial(ctx context.Context, u string, lbl v1alpha1.TrialLabels) error {
 	panic("implement me")
 }

--- a/redskyctl/internal/commands/experiments/experiments.go
+++ b/redskyctl/internal/commands/experiments/experiments.go
@@ -251,7 +251,11 @@ func (m *experimentsMeta) ExtractValue(obj interface{}, column string) (string, 
 		case "observations":
 			return strconv.FormatInt(o.Observations, 10), nil
 		case "labels":
-			return "", nil // Experiments do not have labels, we still want to show an empty column
+			var labels []string
+			for k, v := range o.Labels {
+				labels = append(labels, fmt.Sprintf("%s=%s", k, v))
+			}
+			return strings.Join(labels, ","), nil
 		}
 	case *experimentsv1alpha1.TrialItem:
 		switch column {

--- a/redskyctl/internal/commands/experiments/label.go
+++ b/redskyctl/internal/commands/experiments/label.go
@@ -110,7 +110,7 @@ func (o *LabelOptions) labelExperiments(ctx context.Context, names []experiments
 			return err
 		}
 
-		if err := o.ExperimentsAPI.LabelExperiment(ctx, exp.Labels, experimentsv1alpha1.ExperimentLabels{Labels: o.Labels}); err != nil {
+		if err := o.ExperimentsAPI.LabelExperiment(ctx, exp.LabelsURL, experimentsv1alpha1.ExperimentLabels{Labels: o.Labels}); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
Three bits of tech debt I'll address next regarding the Experiments API implementation:
1. All of the metadata URLs should use Hungarian notation to avoid conflicts
2. All of the API methods that accept a URL should explicitly return an error if the URL is empty
3. The `api.go` file is too big, it needs to get split up