### PR TITLE
Do not add readiness checks when patching the trial job itself

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -31,6 +31,7 @@ rules:
   - jobs
   verbs:
   - create
+  - get
   - list
   - watch
 - apiGroups:

--- a/controllers/patch_controller.go
+++ b/controllers/patch_controller.go
@@ -153,7 +153,7 @@ func (r *PatchReconciler) evaluatePatchOperations(ctx context.Context, t *redsky
 		}
 
 		// Add a readiness check if necessary
-		if rc, err := r.createReadinessCheck(p, ref); err != nil {
+		if rc, err := r.createReadinessCheck(t, p, ref); err != nil {
 			return &ctrl.Result{}, err
 		} else if rc != nil {
 			t.Spec.ReadinessChecks = append(t.Spec.ReadinessChecks, *rc)
@@ -285,7 +285,12 @@ func (r *PatchReconciler) createPatchOperation(t *redskyv1alpha1.Trial, p *redsk
 }
 
 // createReadinessCheck creates a readiness check for a patch operation
-func (r *PatchReconciler) createReadinessCheck(p *redskyv1alpha1.PatchTemplate, ref *corev1.ObjectReference) (*redskyv1alpha1.ReadinessCheck, error) {
+func (r *PatchReconciler) createReadinessCheck(t *redskyv1alpha1.Trial, p *redskyv1alpha1.PatchTemplate, ref *corev1.ObjectReference) (*redskyv1alpha1.ReadinessCheck, error) {
+	// Do not create a readiness check on the trial job
+	if trial.IsTrialJobReference(t, ref) {
+		return nil, nil
+	}
+
 	// NOTE: There is a cardinality mismatch between the `PatchReadinessGate` type and the `ReadinessCheck` type in
 	// regard to condition types. We purposely do not expose user facing configuration for these checks (users can
 	// skip patch readiness checks and specify them manually for fine grained control).

--- a/controllers/trial_job_controller.go
+++ b/controllers/trial_job_controller.go
@@ -42,7 +42,7 @@ type TrialJobReconciler struct {
 }
 
 // +kubebuilder:rbac:groups=redskyops.dev,resources=trials,verbs=get;list;watch;update
-// +kubebuilder:rbac:groups=batch;extensions,resources=jobs,verbs=list;watch;create
+// +kubebuilder:rbac:groups=batch;extensions,resources=jobs,verbs=get;list;watch;create
 // +kubebuilder:rbac:groups="",resources=pods,verbs=list
 
 func (r *TrialJobReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {


### PR DESCRIPTION
This also ensures we have permission to get individual jobs.