### PR TITLE
Detect unschedulable trial jobs

### DIFF
--- a/controllers/trial_job_controller.go
+++ b/controllers/trial_job_controller.go
@@ -193,6 +193,13 @@ func (r *TrialJobReconciler) applyJobStatus(ctx context.Context, t *redskyv1alph
 					trial.ApplyCondition(&t.Status, redskyv1alpha1.TrialFailed, corev1.ConditionTrue, s.Reason, "", time)
 					dirty = true
 				}
+				// TODO We should consolidate this with `internal/ready/podFailed`
+				for _, c := range s.Conditions {
+					if c.Type == corev1.PodScheduled && c.Status == corev1.ConditionFalse && c.Reason == corev1.PodReasonUnschedulable {
+						trial.ApplyCondition(&t.Status, redskyv1alpha1.TrialFailed, corev1.ConditionTrue, c.Reason, c.Message, time)
+						dirty = true
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
We should tie this in to the ready checks for consistency and reuse.