### PR TITLE
Fix missing validation schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ deploy: manifests
 # Generate manifests e.g. CRD, RBAC etc.
 manifests: controller-gen
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./api/...;./controllers/..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) schemapatch:manifests=config/crd/bases,maxDescLen=0  paths="./api/..." output:dir=./config/crd/bases
 
 # Run go fmt against code
 fmt:

--- a/config/crd/bases/redskyops.dev_experiments.yaml
+++ b/config/crd/bases/redskyops.dev_experiments.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -26,9 +24,7509 @@ spec:
   - name: v1alpha1
     served: true
     storage: false
+    "schema":
+      "openAPIV3Schema":
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            required:
+            - metrics
+            - parameters
+            properties:
+              constraints:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    order:
+                      type: object
+                      required:
+                      - lowerParameter
+                      - upperParameter
+                      properties:
+                        lowerParameter:
+                          type: string
+                        upperParameter:
+                          type: string
+                    sum:
+                      type: object
+                      required:
+                      - bound
+                      - parameters
+                      properties:
+                        bound:
+                          type: string
+                        isUpperBound:
+                          type: boolean
+                        parameters:
+                          type: array
+                          items:
+                            type: object
+                            required:
+                            - name
+                            - weight
+                            properties:
+                              name:
+                                type: string
+                              weight:
+                                type: string
+              metrics:
+                type: array
+                items:
+                  type: object
+                  required:
+                  - name
+                  - query
+                  properties:
+                    errorQuery:
+                      type: string
+                    minimize:
+                      type: boolean
+                    name:
+                      type: string
+                    path:
+                      type: string
+                    port:
+                      anyOf:
+                      - type: string
+                      - type: integer
+                    query:
+                      type: string
+                    scheme:
+                      type: string
+                    selector:
+                      type: object
+                      properties:
+                        matchExpressions:
+                          type: array
+                          items:
+                            type: object
+                            required:
+                            - key
+                            - operator
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                type: string
+                              values:
+                                type: array
+                                items:
+                                  type: string
+                        matchLabels:
+                          type: object
+                          additionalProperties:
+                            type: string
+                    type:
+                      type: string
+              namespaceSelector:
+                type: object
+                properties:
+                  matchExpressions:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                      - key
+                      - operator
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          type: string
+                        values:
+                          type: array
+                          items:
+                            type: string
+                  matchLabels:
+                    type: object
+                    additionalProperties:
+                      type: string
+              namespaceTemplate:
+                type: object
+                properties:
+                  metadata:
+                    type: object
+                  spec:
+                    type: object
+                    properties:
+                      finalizers:
+                        type: array
+                        items:
+                          type: string
+              optimization:
+                type: array
+                items:
+                  type: object
+                  required:
+                  - name
+                  - value
+                  properties:
+                    name:
+                      type: string
+                    value:
+                      type: string
+              parameters:
+                type: array
+                items:
+                  type: object
+                  required:
+                  - name
+                  properties:
+                    max:
+                      type: integer
+                      format: int64
+                    min:
+                      type: integer
+                      format: int64
+                    name:
+                      type: string
+              patches:
+                type: array
+                items:
+                  type: object
+                  required:
+                  - patch
+                  properties:
+                    patch:
+                      type: string
+                    readinessGates:
+                      type: array
+                      items:
+                        type: object
+                        required:
+                        - conditionType
+                        properties:
+                          conditionType:
+                            type: string
+                    targetRef:
+                      type: object
+                      properties:
+                        apiVersion:
+                          type: string
+                        fieldPath:
+                          type: string
+                        kind:
+                          type: string
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                        resourceVersion:
+                          type: string
+                        uid:
+                          type: string
+                    type:
+                      type: string
+              replicas:
+                type: integer
+                format: int32
+              selector:
+                type: object
+                properties:
+                  matchExpressions:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                      - key
+                      - operator
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          type: string
+                        values:
+                          type: array
+                          items:
+                            type: string
+                  matchLabels:
+                    type: object
+                    additionalProperties:
+                      type: string
+              template:
+                type: object
+                properties:
+                  metadata:
+                    type: object
+                  spec:
+                    type: object
+                    properties:
+                      approximateRuntime:
+                        type: string
+                      assignments:
+                        type: array
+                        items:
+                          type: object
+                          required:
+                          - name
+                          - value
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: integer
+                              format: int64
+                      experimentRef:
+                        type: object
+                        properties:
+                          apiVersion:
+                            type: string
+                          fieldPath:
+                            type: string
+                          kind:
+                            type: string
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                          resourceVersion:
+                            type: string
+                          uid:
+                            type: string
+                      initialDelaySeconds:
+                        type: integer
+                        format: int32
+                      patchOperations:
+                        type: array
+                        items:
+                          type: object
+                          required:
+                          - data
+                          - patchType
+                          - targetRef
+                          properties:
+                            attemptsRemaining:
+                              type: integer
+                            data:
+                              type: string
+                              format: byte
+                            patchType:
+                              type: string
+                            targetRef:
+                              type: object
+                              properties:
+                                apiVersion:
+                                  type: string
+                                fieldPath:
+                                  type: string
+                                kind:
+                                  type: string
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                                resourceVersion:
+                                  type: string
+                                uid:
+                                  type: string
+                      readinessChecks:
+                        type: array
+                        items:
+                          type: object
+                          required:
+                          - targetRef
+                          properties:
+                            attemptsRemaining:
+                              type: integer
+                              format: int32
+                            conditionTypes:
+                              type: array
+                              items:
+                                type: string
+                            initialDelaySeconds:
+                              type: integer
+                              format: int32
+                            lastCheckTime:
+                              type: string
+                              format: date-time
+                            periodSeconds:
+                              type: integer
+                              format: int32
+                            selector:
+                              type: object
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    required:
+                                    - key
+                                    - operator
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                                  additionalProperties:
+                                    type: string
+                            targetRef:
+                              type: object
+                              properties:
+                                apiVersion:
+                                  type: string
+                                fieldPath:
+                                  type: string
+                                kind:
+                                  type: string
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                                resourceVersion:
+                                  type: string
+                                uid:
+                                  type: string
+                      readinessGates:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            apiVersion:
+                              type: string
+                            conditionTypes:
+                              type: array
+                              items:
+                                type: string
+                            failureThreshold:
+                              type: integer
+                              format: int32
+                            initialDelaySeconds:
+                              type: integer
+                              format: int32
+                            kind:
+                              type: string
+                            name:
+                              type: string
+                            periodSeconds:
+                              type: integer
+                              format: int32
+                            selector:
+                              type: object
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    required:
+                                    - key
+                                    - operator
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                                  additionalProperties:
+                                    type: string
+                      selector:
+                        type: object
+                        properties:
+                          matchExpressions:
+                            type: array
+                            items:
+                              type: object
+                              required:
+                              - key
+                              - operator
+                              properties:
+                                key:
+                                  type: string
+                                operator:
+                                  type: string
+                                values:
+                                  type: array
+                                  items:
+                                    type: string
+                          matchLabels:
+                            type: object
+                            additionalProperties:
+                              type: string
+                      setupDefaultClusterRole:
+                        type: string
+                      setupDefaultRules:
+                        type: array
+                        items:
+                          type: object
+                          required:
+                          - verbs
+                          properties:
+                            apiGroups:
+                              type: array
+                              items:
+                                type: string
+                            nonResourceURLs:
+                              type: array
+                              items:
+                                type: string
+                            resourceNames:
+                              type: array
+                              items:
+                                type: string
+                            resources:
+                              type: array
+                              items:
+                                type: string
+                            verbs:
+                              type: array
+                              items:
+                                type: string
+                      setupServiceAccountName:
+                        type: string
+                      setupTasks:
+                        type: array
+                        items:
+                          type: object
+                          required:
+                          - name
+                          properties:
+                            helmChart:
+                              type: string
+                            helmChartVersion:
+                              type: string
+                            helmValues:
+                              type: array
+                              items:
+                                type: object
+                                required:
+                                - name
+                                properties:
+                                  forceString:
+                                    type: boolean
+                                  name:
+                                    type: string
+                                  value:
+                                    anyOf:
+                                    - type: string
+                                    - type: integer
+                                  valueFrom:
+                                    type: object
+                                    properties:
+                                      parameterRef:
+                                        type: object
+                                        required:
+                                        - name
+                                        properties:
+                                          name:
+                                            type: string
+                            helmValuesFrom:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  configMap:
+                                    type: object
+                                    properties:
+                                      name:
+                                        type: string
+                            image:
+                              type: string
+                            name:
+                              type: string
+                            skipCreate:
+                              type: boolean
+                            skipDelete:
+                              type: boolean
+                            volumeMounts:
+                              type: array
+                              items:
+                                type: object
+                                required:
+                                - mountPath
+                                - name
+                                properties:
+                                  mountPath:
+                                    type: string
+                                  mountPropagation:
+                                    type: string
+                                  name:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  subPath:
+                                    type: string
+                                  subPathExpr:
+                                    type: string
+                      setupVolumes:
+                        type: array
+                        items:
+                          type: object
+                          required:
+                          - name
+                          properties:
+                            awsElasticBlockStore:
+                              type: object
+                              required:
+                              - volumeID
+                              properties:
+                                fsType:
+                                  type: string
+                                partition:
+                                  type: integer
+                                  format: int32
+                                readOnly:
+                                  type: boolean
+                                volumeID:
+                                  type: string
+                            azureDisk:
+                              type: object
+                              required:
+                              - diskName
+                              - diskURI
+                              properties:
+                                cachingMode:
+                                  type: string
+                                diskName:
+                                  type: string
+                                diskURI:
+                                  type: string
+                                fsType:
+                                  type: string
+                                kind:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                            azureFile:
+                              type: object
+                              required:
+                              - secretName
+                              - shareName
+                              properties:
+                                readOnly:
+                                  type: boolean
+                                secretName:
+                                  type: string
+                                shareName:
+                                  type: string
+                            cephfs:
+                              type: object
+                              required:
+                              - monitors
+                              properties:
+                                monitors:
+                                  type: array
+                                  items:
+                                    type: string
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretFile:
+                                  type: string
+                                secretRef:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                user:
+                                  type: string
+                            cinder:
+                              type: object
+                              required:
+                              - volumeID
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                volumeID:
+                                  type: string
+                            configMap:
+                              type: object
+                              properties:
+                                defaultMode:
+                                  type: integer
+                                  format: int32
+                                items:
+                                  type: array
+                                  items:
+                                    type: object
+                                    required:
+                                    - key
+                                    - path
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        type: integer
+                                        format: int32
+                                      path:
+                                        type: string
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+                            csi:
+                              type: object
+                              required:
+                              - driver
+                              properties:
+                                driver:
+                                  type: string
+                                fsType:
+                                  type: string
+                                nodePublishSecretRef:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                readOnly:
+                                  type: boolean
+                                volumeAttributes:
+                                  type: object
+                                  additionalProperties:
+                                    type: string
+                            downwardAPI:
+                              type: object
+                              properties:
+                                defaultMode:
+                                  type: integer
+                                  format: int32
+                                items:
+                                  type: array
+                                  items:
+                                    type: object
+                                    required:
+                                    - path
+                                    properties:
+                                      fieldRef:
+                                        type: object
+                                        required:
+                                        - fieldPath
+                                        properties:
+                                          apiVersion:
+                                            type: string
+                                          fieldPath:
+                                            type: string
+                                      mode:
+                                        type: integer
+                                        format: int32
+                                      path:
+                                        type: string
+                                      resourceFieldRef:
+                                        type: object
+                                        required:
+                                        - resource
+                                        properties:
+                                          containerName:
+                                            type: string
+                                          divisor:
+                                            type: string
+                                          resource:
+                                            type: string
+                            emptyDir:
+                              type: object
+                              properties:
+                                medium:
+                                  type: string
+                                sizeLimit:
+                                  type: string
+                            fc:
+                              type: object
+                              properties:
+                                fsType:
+                                  type: string
+                                lun:
+                                  type: integer
+                                  format: int32
+                                readOnly:
+                                  type: boolean
+                                targetWWNs:
+                                  type: array
+                                  items:
+                                    type: string
+                                wwids:
+                                  type: array
+                                  items:
+                                    type: string
+                            flexVolume:
+                              type: object
+                              required:
+                              - driver
+                              properties:
+                                driver:
+                                  type: string
+                                fsType:
+                                  type: string
+                                options:
+                                  type: object
+                                  additionalProperties:
+                                    type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                            flocker:
+                              type: object
+                              properties:
+                                datasetName:
+                                  type: string
+                                datasetUUID:
+                                  type: string
+                            gcePersistentDisk:
+                              type: object
+                              required:
+                              - pdName
+                              properties:
+                                fsType:
+                                  type: string
+                                partition:
+                                  type: integer
+                                  format: int32
+                                pdName:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                            gitRepo:
+                              type: object
+                              required:
+                              - repository
+                              properties:
+                                directory:
+                                  type: string
+                                repository:
+                                  type: string
+                                revision:
+                                  type: string
+                            glusterfs:
+                              type: object
+                              required:
+                              - endpoints
+                              - path
+                              properties:
+                                endpoints:
+                                  type: string
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                            hostPath:
+                              type: object
+                              required:
+                              - path
+                              properties:
+                                path:
+                                  type: string
+                                type:
+                                  type: string
+                            iscsi:
+                              type: object
+                              required:
+                              - iqn
+                              - lun
+                              - targetPortal
+                              properties:
+                                chapAuthDiscovery:
+                                  type: boolean
+                                chapAuthSession:
+                                  type: boolean
+                                fsType:
+                                  type: string
+                                initiatorName:
+                                  type: string
+                                iqn:
+                                  type: string
+                                iscsiInterface:
+                                  type: string
+                                lun:
+                                  type: integer
+                                  format: int32
+                                portals:
+                                  type: array
+                                  items:
+                                    type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                targetPortal:
+                                  type: string
+                            name:
+                              type: string
+                            nfs:
+                              type: object
+                              required:
+                              - path
+                              - server
+                              properties:
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                server:
+                                  type: string
+                            persistentVolumeClaim:
+                              type: object
+                              required:
+                              - claimName
+                              properties:
+                                claimName:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                            photonPersistentDisk:
+                              type: object
+                              required:
+                              - pdID
+                              properties:
+                                fsType:
+                                  type: string
+                                pdID:
+                                  type: string
+                            portworxVolume:
+                              type: object
+                              required:
+                              - volumeID
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                volumeID:
+                                  type: string
+                            projected:
+                              type: object
+                              required:
+                              - sources
+                              properties:
+                                defaultMode:
+                                  type: integer
+                                  format: int32
+                                sources:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      configMap:
+                                        type: object
+                                        properties:
+                                          items:
+                                            type: array
+                                            items:
+                                              type: object
+                                              required:
+                                              - key
+                                              - path
+                                              properties:
+                                                key:
+                                                  type: string
+                                                mode:
+                                                  type: integer
+                                                  format: int32
+                                                path:
+                                                  type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                      downwardAPI:
+                                        type: object
+                                        properties:
+                                          items:
+                                            type: array
+                                            items:
+                                              type: object
+                                              required:
+                                              - path
+                                              properties:
+                                                fieldRef:
+                                                  type: object
+                                                  required:
+                                                  - fieldPath
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                mode:
+                                                  type: integer
+                                                  format: int32
+                                                path:
+                                                  type: string
+                                                resourceFieldRef:
+                                                  type: object
+                                                  required:
+                                                  - resource
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      type: string
+                                                    resource:
+                                                      type: string
+                                      secret:
+                                        type: object
+                                        properties:
+                                          items:
+                                            type: array
+                                            items:
+                                              type: object
+                                              required:
+                                              - key
+                                              - path
+                                              properties:
+                                                key:
+                                                  type: string
+                                                mode:
+                                                  type: integer
+                                                  format: int32
+                                                path:
+                                                  type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                      serviceAccountToken:
+                                        type: object
+                                        required:
+                                        - path
+                                        properties:
+                                          audience:
+                                            type: string
+                                          expirationSeconds:
+                                            type: integer
+                                            format: int64
+                                          path:
+                                            type: string
+                            quobyte:
+                              type: object
+                              required:
+                              - registry
+                              - volume
+                              properties:
+                                group:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                registry:
+                                  type: string
+                                tenant:
+                                  type: string
+                                user:
+                                  type: string
+                                volume:
+                                  type: string
+                            rbd:
+                              type: object
+                              required:
+                              - image
+                              - monitors
+                              properties:
+                                fsType:
+                                  type: string
+                                image:
+                                  type: string
+                                keyring:
+                                  type: string
+                                monitors:
+                                  type: array
+                                  items:
+                                    type: string
+                                pool:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                user:
+                                  type: string
+                            scaleIO:
+                              type: object
+                              required:
+                              - gateway
+                              - secretRef
+                              - system
+                              properties:
+                                fsType:
+                                  type: string
+                                gateway:
+                                  type: string
+                                protectionDomain:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                sslEnabled:
+                                  type: boolean
+                                storageMode:
+                                  type: string
+                                storagePool:
+                                  type: string
+                                system:
+                                  type: string
+                                volumeName:
+                                  type: string
+                            secret:
+                              type: object
+                              properties:
+                                defaultMode:
+                                  type: integer
+                                  format: int32
+                                items:
+                                  type: array
+                                  items:
+                                    type: object
+                                    required:
+                                    - key
+                                    - path
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        type: integer
+                                        format: int32
+                                      path:
+                                        type: string
+                                optional:
+                                  type: boolean
+                                secretName:
+                                  type: string
+                            storageos:
+                              type: object
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                volumeName:
+                                  type: string
+                                volumeNamespace:
+                                  type: string
+                            vsphereVolume:
+                              type: object
+                              required:
+                              - volumePath
+                              properties:
+                                fsType:
+                                  type: string
+                                storagePolicyID:
+                                  type: string
+                                storagePolicyName:
+                                  type: string
+                                volumePath:
+                                  type: string
+                      startTimeOffset:
+                        type: string
+                      template:
+                        type: object
+                        properties:
+                          metadata:
+                            type: object
+                          spec:
+                            type: object
+                            required:
+                            - template
+                            properties:
+                              activeDeadlineSeconds:
+                                type: integer
+                                format: int64
+                              backoffLimit:
+                                type: integer
+                                format: int32
+                              completions:
+                                type: integer
+                                format: int32
+                              manualSelector:
+                                type: boolean
+                              parallelism:
+                                type: integer
+                                format: int32
+                              selector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      required:
+                                      - key
+                                      - operator
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                                    additionalProperties:
+                                      type: string
+                              template:
+                                type: object
+                                properties:
+                                  metadata:
+                                    type: object
+                                  spec:
+                                    type: object
+                                    required:
+                                    - containers
+                                    properties:
+                                      activeDeadlineSeconds:
+                                        type: integer
+                                        format: int64
+                                      affinity:
+                                        type: object
+                                        properties:
+                                          nodeAffinity:
+                                            type: object
+                                            properties:
+                                              preferredDuringSchedulingIgnoredDuringExecution:
+                                                type: array
+                                                items:
+                                                  type: object
+                                                  required:
+                                                  - preference
+                                                  - weight
+                                                  properties:
+                                                    preference:
+                                                      type: object
+                                                      properties:
+                                                        matchExpressions:
+                                                          type: array
+                                                          items:
+                                                            type: object
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              operator:
+                                                                type: string
+                                                              values:
+                                                                type: array
+                                                                items:
+                                                                  type: string
+                                                        matchFields:
+                                                          type: array
+                                                          items:
+                                                            type: object
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              operator:
+                                                                type: string
+                                                              values:
+                                                                type: array
+                                                                items:
+                                                                  type: string
+                                                    weight:
+                                                      type: integer
+                                                      format: int32
+                                              requiredDuringSchedulingIgnoredDuringExecution:
+                                                type: object
+                                                required:
+                                                - nodeSelectorTerms
+                                                properties:
+                                                  nodeSelectorTerms:
+                                                    type: array
+                                                    items:
+                                                      type: object
+                                                      properties:
+                                                        matchExpressions:
+                                                          type: array
+                                                          items:
+                                                            type: object
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              operator:
+                                                                type: string
+                                                              values:
+                                                                type: array
+                                                                items:
+                                                                  type: string
+                                                        matchFields:
+                                                          type: array
+                                                          items:
+                                                            type: object
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              operator:
+                                                                type: string
+                                                              values:
+                                                                type: array
+                                                                items:
+                                                                  type: string
+                                          podAffinity:
+                                            type: object
+                                            properties:
+                                              preferredDuringSchedulingIgnoredDuringExecution:
+                                                type: array
+                                                items:
+                                                  type: object
+                                                  required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                  properties:
+                                                    podAffinityTerm:
+                                                      type: object
+                                                      required:
+                                                      - topologyKey
+                                                      properties:
+                                                        labelSelector:
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              type: array
+                                                              items:
+                                                                type: object
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                properties:
+                                                                  key:
+                                                                    type: string
+                                                                  operator:
+                                                                    type: string
+                                                                  values:
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                        namespaces:
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                        topologyKey:
+                                                          type: string
+                                                    weight:
+                                                      type: integer
+                                                      format: int32
+                                              requiredDuringSchedulingIgnoredDuringExecution:
+                                                type: array
+                                                items:
+                                                  type: object
+                                                  required:
+                                                  - topologyKey
+                                                  properties:
+                                                    labelSelector:
+                                                      type: object
+                                                      properties:
+                                                        matchExpressions:
+                                                          type: array
+                                                          items:
+                                                            type: object
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              operator:
+                                                                type: string
+                                                              values:
+                                                                type: array
+                                                                items:
+                                                                  type: string
+                                                        matchLabels:
+                                                          type: object
+                                                          additionalProperties:
+                                                            type: string
+                                                    namespaces:
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                                    topologyKey:
+                                                      type: string
+                                          podAntiAffinity:
+                                            type: object
+                                            properties:
+                                              preferredDuringSchedulingIgnoredDuringExecution:
+                                                type: array
+                                                items:
+                                                  type: object
+                                                  required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                  properties:
+                                                    podAffinityTerm:
+                                                      type: object
+                                                      required:
+                                                      - topologyKey
+                                                      properties:
+                                                        labelSelector:
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              type: array
+                                                              items:
+                                                                type: object
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                properties:
+                                                                  key:
+                                                                    type: string
+                                                                  operator:
+                                                                    type: string
+                                                                  values:
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                        namespaces:
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                        topologyKey:
+                                                          type: string
+                                                    weight:
+                                                      type: integer
+                                                      format: int32
+                                              requiredDuringSchedulingIgnoredDuringExecution:
+                                                type: array
+                                                items:
+                                                  type: object
+                                                  required:
+                                                  - topologyKey
+                                                  properties:
+                                                    labelSelector:
+                                                      type: object
+                                                      properties:
+                                                        matchExpressions:
+                                                          type: array
+                                                          items:
+                                                            type: object
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              operator:
+                                                                type: string
+                                                              values:
+                                                                type: array
+                                                                items:
+                                                                  type: string
+                                                        matchLabels:
+                                                          type: object
+                                                          additionalProperties:
+                                                            type: string
+                                                    namespaces:
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                                    topologyKey:
+                                                      type: string
+                                      automountServiceAccountToken:
+                                        type: boolean
+                                      containers:
+                                        type: array
+                                        items:
+                                          type: object
+                                          required:
+                                          - name
+                                          properties:
+                                            args:
+                                              type: array
+                                              items:
+                                                type: string
+                                            command:
+                                              type: array
+                                              items:
+                                                type: string
+                                            env:
+                                              type: array
+                                              items:
+                                                type: object
+                                                required:
+                                                - name
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                  valueFrom:
+                                                    type: object
+                                                    properties:
+                                                      configMapKeyRef:
+                                                        type: object
+                                                        required:
+                                                        - key
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          name:
+                                                            type: string
+                                                          optional:
+                                                            type: boolean
+                                                      fieldRef:
+                                                        type: object
+                                                        required:
+                                                        - fieldPath
+                                                        properties:
+                                                          apiVersion:
+                                                            type: string
+                                                          fieldPath:
+                                                            type: string
+                                                      resourceFieldRef:
+                                                        type: object
+                                                        required:
+                                                        - resource
+                                                        properties:
+                                                          containerName:
+                                                            type: string
+                                                          divisor:
+                                                            type: string
+                                                          resource:
+                                                            type: string
+                                                      secretKeyRef:
+                                                        type: object
+                                                        required:
+                                                        - key
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          name:
+                                                            type: string
+                                                          optional:
+                                                            type: boolean
+                                            envFrom:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  configMapRef:
+                                                    type: object
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                  prefix:
+                                                    type: string
+                                                  secretRef:
+                                                    type: object
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                            image:
+                                              type: string
+                                            imagePullPolicy:
+                                              type: string
+                                            lifecycle:
+                                              type: object
+                                              properties:
+                                                postStart:
+                                                  type: object
+                                                  properties:
+                                                    exec:
+                                                      type: object
+                                                      properties:
+                                                        command:
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                    httpGet:
+                                                      type: object
+                                                      required:
+                                                      - port
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        httpHeaders:
+                                                          type: array
+                                                          items:
+                                                            type: object
+                                                            required:
+                                                            - name
+                                                            - value
+                                                            properties:
+                                                              name:
+                                                                type: string
+                                                              value:
+                                                                type: string
+                                                        path:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                        scheme:
+                                                          type: string
+                                                    tcpSocket:
+                                                      type: object
+                                                      required:
+                                                      - port
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                preStop:
+                                                  type: object
+                                                  properties:
+                                                    exec:
+                                                      type: object
+                                                      properties:
+                                                        command:
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                    httpGet:
+                                                      type: object
+                                                      required:
+                                                      - port
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        httpHeaders:
+                                                          type: array
+                                                          items:
+                                                            type: object
+                                                            required:
+                                                            - name
+                                                            - value
+                                                            properties:
+                                                              name:
+                                                                type: string
+                                                              value:
+                                                                type: string
+                                                        path:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                        scheme:
+                                                          type: string
+                                                    tcpSocket:
+                                                      type: object
+                                                      required:
+                                                      - port
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                            livenessProbe:
+                                              type: object
+                                              properties:
+                                                exec:
+                                                  type: object
+                                                  properties:
+                                                    command:
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                                failureThreshold:
+                                                  type: integer
+                                                  format: int32
+                                                httpGet:
+                                                  type: object
+                                                  required:
+                                                  - port
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      type: array
+                                                      items:
+                                                        type: object
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                    scheme:
+                                                      type: string
+                                                initialDelaySeconds:
+                                                  type: integer
+                                                  format: int32
+                                                periodSeconds:
+                                                  type: integer
+                                                  format: int32
+                                                successThreshold:
+                                                  type: integer
+                                                  format: int32
+                                                tcpSocket:
+                                                  type: object
+                                                  required:
+                                                  - port
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                timeoutSeconds:
+                                                  type: integer
+                                                  format: int32
+                                            name:
+                                              type: string
+                                            ports:
+                                              type: array
+                                              items:
+                                                type: object
+                                                required:
+                                                - containerPort
+                                                properties:
+                                                  containerPort:
+                                                    type: integer
+                                                    format: int32
+                                                  hostIP:
+                                                    type: string
+                                                  hostPort:
+                                                    type: integer
+                                                    format: int32
+                                                  name:
+                                                    type: string
+                                                  protocol:
+                                                    type: string
+                                            readinessProbe:
+                                              type: object
+                                              properties:
+                                                exec:
+                                                  type: object
+                                                  properties:
+                                                    command:
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                                failureThreshold:
+                                                  type: integer
+                                                  format: int32
+                                                httpGet:
+                                                  type: object
+                                                  required:
+                                                  - port
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      type: array
+                                                      items:
+                                                        type: object
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                    scheme:
+                                                      type: string
+                                                initialDelaySeconds:
+                                                  type: integer
+                                                  format: int32
+                                                periodSeconds:
+                                                  type: integer
+                                                  format: int32
+                                                successThreshold:
+                                                  type: integer
+                                                  format: int32
+                                                tcpSocket:
+                                                  type: object
+                                                  required:
+                                                  - port
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                timeoutSeconds:
+                                                  type: integer
+                                                  format: int32
+                                            resources:
+                                              type: object
+                                              properties:
+                                                limits:
+                                                  type: object
+                                                  additionalProperties:
+                                                    type: string
+                                                requests:
+                                                  type: object
+                                                  additionalProperties:
+                                                    type: string
+                                            securityContext:
+                                              type: object
+                                              properties:
+                                                allowPrivilegeEscalation:
+                                                  type: boolean
+                                                capabilities:
+                                                  type: object
+                                                  properties:
+                                                    add:
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                                    drop:
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                                privileged:
+                                                  type: boolean
+                                                procMount:
+                                                  type: string
+                                                readOnlyRootFilesystem:
+                                                  type: boolean
+                                                runAsGroup:
+                                                  type: integer
+                                                  format: int64
+                                                runAsNonRoot:
+                                                  type: boolean
+                                                runAsUser:
+                                                  type: integer
+                                                  format: int64
+                                                seLinuxOptions:
+                                                  type: object
+                                                  properties:
+                                                    level:
+                                                      type: string
+                                                    role:
+                                                      type: string
+                                                    type:
+                                                      type: string
+                                                    user:
+                                                      type: string
+                                                windowsOptions:
+                                                  type: object
+                                                  properties:
+                                                    gmsaCredentialSpec:
+                                                      type: string
+                                                    gmsaCredentialSpecName:
+                                                      type: string
+                                                    runAsUserName:
+                                                      type: string
+                                            startupProbe:
+                                              type: object
+                                              properties:
+                                                exec:
+                                                  type: object
+                                                  properties:
+                                                    command:
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                                failureThreshold:
+                                                  type: integer
+                                                  format: int32
+                                                httpGet:
+                                                  type: object
+                                                  required:
+                                                  - port
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      type: array
+                                                      items:
+                                                        type: object
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                    scheme:
+                                                      type: string
+                                                initialDelaySeconds:
+                                                  type: integer
+                                                  format: int32
+                                                periodSeconds:
+                                                  type: integer
+                                                  format: int32
+                                                successThreshold:
+                                                  type: integer
+                                                  format: int32
+                                                tcpSocket:
+                                                  type: object
+                                                  required:
+                                                  - port
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                timeoutSeconds:
+                                                  type: integer
+                                                  format: int32
+                                            stdin:
+                                              type: boolean
+                                            stdinOnce:
+                                              type: boolean
+                                            terminationMessagePath:
+                                              type: string
+                                            terminationMessagePolicy:
+                                              type: string
+                                            tty:
+                                              type: boolean
+                                            volumeDevices:
+                                              type: array
+                                              items:
+                                                type: object
+                                                required:
+                                                - devicePath
+                                                - name
+                                                properties:
+                                                  devicePath:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                            volumeMounts:
+                                              type: array
+                                              items:
+                                                type: object
+                                                required:
+                                                - mountPath
+                                                - name
+                                                properties:
+                                                  mountPath:
+                                                    type: string
+                                                  mountPropagation:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  readOnly:
+                                                    type: boolean
+                                                  subPath:
+                                                    type: string
+                                                  subPathExpr:
+                                                    type: string
+                                            workingDir:
+                                              type: string
+                                      dnsConfig:
+                                        type: object
+                                        properties:
+                                          nameservers:
+                                            type: array
+                                            items:
+                                              type: string
+                                          options:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                          searches:
+                                            type: array
+                                            items:
+                                              type: string
+                                      dnsPolicy:
+                                        type: string
+                                      enableServiceLinks:
+                                        type: boolean
+                                      ephemeralContainers:
+                                        type: array
+                                        items:
+                                          type: object
+                                          required:
+                                          - name
+                                          properties:
+                                            args:
+                                              type: array
+                                              items:
+                                                type: string
+                                            command:
+                                              type: array
+                                              items:
+                                                type: string
+                                            env:
+                                              type: array
+                                              items:
+                                                type: object
+                                                required:
+                                                - name
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                  valueFrom:
+                                                    type: object
+                                                    properties:
+                                                      configMapKeyRef:
+                                                        type: object
+                                                        required:
+                                                        - key
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          name:
+                                                            type: string
+                                                          optional:
+                                                            type: boolean
+                                                      fieldRef:
+                                                        type: object
+                                                        required:
+                                                        - fieldPath
+                                                        properties:
+                                                          apiVersion:
+                                                            type: string
+                                                          fieldPath:
+                                                            type: string
+                                                      resourceFieldRef:
+                                                        type: object
+                                                        required:
+                                                        - resource
+                                                        properties:
+                                                          containerName:
+                                                            type: string
+                                                          divisor:
+                                                            type: string
+                                                          resource:
+                                                            type: string
+                                                      secretKeyRef:
+                                                        type: object
+                                                        required:
+                                                        - key
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          name:
+                                                            type: string
+                                                          optional:
+                                                            type: boolean
+                                            envFrom:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  configMapRef:
+                                                    type: object
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                  prefix:
+                                                    type: string
+                                                  secretRef:
+                                                    type: object
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                            image:
+                                              type: string
+                                            imagePullPolicy:
+                                              type: string
+                                            lifecycle:
+                                              type: object
+                                              properties:
+                                                postStart:
+                                                  type: object
+                                                  properties:
+                                                    exec:
+                                                      type: object
+                                                      properties:
+                                                        command:
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                    httpGet:
+                                                      type: object
+                                                      required:
+                                                      - port
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        httpHeaders:
+                                                          type: array
+                                                          items:
+                                                            type: object
+                                                            required:
+                                                            - name
+                                                            - value
+                                                            properties:
+                                                              name:
+                                                                type: string
+                                                              value:
+                                                                type: string
+                                                        path:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                        scheme:
+                                                          type: string
+                                                    tcpSocket:
+                                                      type: object
+                                                      required:
+                                                      - port
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                preStop:
+                                                  type: object
+                                                  properties:
+                                                    exec:
+                                                      type: object
+                                                      properties:
+                                                        command:
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                    httpGet:
+                                                      type: object
+                                                      required:
+                                                      - port
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        httpHeaders:
+                                                          type: array
+                                                          items:
+                                                            type: object
+                                                            required:
+                                                            - name
+                                                            - value
+                                                            properties:
+                                                              name:
+                                                                type: string
+                                                              value:
+                                                                type: string
+                                                        path:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                        scheme:
+                                                          type: string
+                                                    tcpSocket:
+                                                      type: object
+                                                      required:
+                                                      - port
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                            livenessProbe:
+                                              type: object
+                                              properties:
+                                                exec:
+                                                  type: object
+                                                  properties:
+                                                    command:
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                                failureThreshold:
+                                                  type: integer
+                                                  format: int32
+                                                httpGet:
+                                                  type: object
+                                                  required:
+                                                  - port
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      type: array
+                                                      items:
+                                                        type: object
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                    scheme:
+                                                      type: string
+                                                initialDelaySeconds:
+                                                  type: integer
+                                                  format: int32
+                                                periodSeconds:
+                                                  type: integer
+                                                  format: int32
+                                                successThreshold:
+                                                  type: integer
+                                                  format: int32
+                                                tcpSocket:
+                                                  type: object
+                                                  required:
+                                                  - port
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                timeoutSeconds:
+                                                  type: integer
+                                                  format: int32
+                                            name:
+                                              type: string
+                                            ports:
+                                              type: array
+                                              items:
+                                                type: object
+                                                required:
+                                                - containerPort
+                                                properties:
+                                                  containerPort:
+                                                    type: integer
+                                                    format: int32
+                                                  hostIP:
+                                                    type: string
+                                                  hostPort:
+                                                    type: integer
+                                                    format: int32
+                                                  name:
+                                                    type: string
+                                                  protocol:
+                                                    type: string
+                                            readinessProbe:
+                                              type: object
+                                              properties:
+                                                exec:
+                                                  type: object
+                                                  properties:
+                                                    command:
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                                failureThreshold:
+                                                  type: integer
+                                                  format: int32
+                                                httpGet:
+                                                  type: object
+                                                  required:
+                                                  - port
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      type: array
+                                                      items:
+                                                        type: object
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                    scheme:
+                                                      type: string
+                                                initialDelaySeconds:
+                                                  type: integer
+                                                  format: int32
+                                                periodSeconds:
+                                                  type: integer
+                                                  format: int32
+                                                successThreshold:
+                                                  type: integer
+                                                  format: int32
+                                                tcpSocket:
+                                                  type: object
+                                                  required:
+                                                  - port
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                timeoutSeconds:
+                                                  type: integer
+                                                  format: int32
+                                            resources:
+                                              type: object
+                                              properties:
+                                                limits:
+                                                  type: object
+                                                  additionalProperties:
+                                                    type: string
+                                                requests:
+                                                  type: object
+                                                  additionalProperties:
+                                                    type: string
+                                            securityContext:
+                                              type: object
+                                              properties:
+                                                allowPrivilegeEscalation:
+                                                  type: boolean
+                                                capabilities:
+                                                  type: object
+                                                  properties:
+                                                    add:
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                                    drop:
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                                privileged:
+                                                  type: boolean
+                                                procMount:
+                                                  type: string
+                                                readOnlyRootFilesystem:
+                                                  type: boolean
+                                                runAsGroup:
+                                                  type: integer
+                                                  format: int64
+                                                runAsNonRoot:
+                                                  type: boolean
+                                                runAsUser:
+                                                  type: integer
+                                                  format: int64
+                                                seLinuxOptions:
+                                                  type: object
+                                                  properties:
+                                                    level:
+                                                      type: string
+                                                    role:
+                                                      type: string
+                                                    type:
+                                                      type: string
+                                                    user:
+                                                      type: string
+                                                windowsOptions:
+                                                  type: object
+                                                  properties:
+                                                    gmsaCredentialSpec:
+                                                      type: string
+                                                    gmsaCredentialSpecName:
+                                                      type: string
+                                                    runAsUserName:
+                                                      type: string
+                                            startupProbe:
+                                              type: object
+                                              properties:
+                                                exec:
+                                                  type: object
+                                                  properties:
+                                                    command:
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                                failureThreshold:
+                                                  type: integer
+                                                  format: int32
+                                                httpGet:
+                                                  type: object
+                                                  required:
+                                                  - port
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      type: array
+                                                      items:
+                                                        type: object
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                    scheme:
+                                                      type: string
+                                                initialDelaySeconds:
+                                                  type: integer
+                                                  format: int32
+                                                periodSeconds:
+                                                  type: integer
+                                                  format: int32
+                                                successThreshold:
+                                                  type: integer
+                                                  format: int32
+                                                tcpSocket:
+                                                  type: object
+                                                  required:
+                                                  - port
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                timeoutSeconds:
+                                                  type: integer
+                                                  format: int32
+                                            stdin:
+                                              type: boolean
+                                            stdinOnce:
+                                              type: boolean
+                                            targetContainerName:
+                                              type: string
+                                            terminationMessagePath:
+                                              type: string
+                                            terminationMessagePolicy:
+                                              type: string
+                                            tty:
+                                              type: boolean
+                                            volumeDevices:
+                                              type: array
+                                              items:
+                                                type: object
+                                                required:
+                                                - devicePath
+                                                - name
+                                                properties:
+                                                  devicePath:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                            volumeMounts:
+                                              type: array
+                                              items:
+                                                type: object
+                                                required:
+                                                - mountPath
+                                                - name
+                                                properties:
+                                                  mountPath:
+                                                    type: string
+                                                  mountPropagation:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  readOnly:
+                                                    type: boolean
+                                                  subPath:
+                                                    type: string
+                                                  subPathExpr:
+                                                    type: string
+                                            workingDir:
+                                              type: string
+                                      hostAliases:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            hostnames:
+                                              type: array
+                                              items:
+                                                type: string
+                                            ip:
+                                              type: string
+                                      hostIPC:
+                                        type: boolean
+                                      hostNetwork:
+                                        type: boolean
+                                      hostPID:
+                                        type: boolean
+                                      hostname:
+                                        type: string
+                                      imagePullSecrets:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            name:
+                                              type: string
+                                      initContainers:
+                                        type: array
+                                        items:
+                                          type: object
+                                          required:
+                                          - name
+                                          properties:
+                                            args:
+                                              type: array
+                                              items:
+                                                type: string
+                                            command:
+                                              type: array
+                                              items:
+                                                type: string
+                                            env:
+                                              type: array
+                                              items:
+                                                type: object
+                                                required:
+                                                - name
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                  valueFrom:
+                                                    type: object
+                                                    properties:
+                                                      configMapKeyRef:
+                                                        type: object
+                                                        required:
+                                                        - key
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          name:
+                                                            type: string
+                                                          optional:
+                                                            type: boolean
+                                                      fieldRef:
+                                                        type: object
+                                                        required:
+                                                        - fieldPath
+                                                        properties:
+                                                          apiVersion:
+                                                            type: string
+                                                          fieldPath:
+                                                            type: string
+                                                      resourceFieldRef:
+                                                        type: object
+                                                        required:
+                                                        - resource
+                                                        properties:
+                                                          containerName:
+                                                            type: string
+                                                          divisor:
+                                                            type: string
+                                                          resource:
+                                                            type: string
+                                                      secretKeyRef:
+                                                        type: object
+                                                        required:
+                                                        - key
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          name:
+                                                            type: string
+                                                          optional:
+                                                            type: boolean
+                                            envFrom:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  configMapRef:
+                                                    type: object
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                  prefix:
+                                                    type: string
+                                                  secretRef:
+                                                    type: object
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                            image:
+                                              type: string
+                                            imagePullPolicy:
+                                              type: string
+                                            lifecycle:
+                                              type: object
+                                              properties:
+                                                postStart:
+                                                  type: object
+                                                  properties:
+                                                    exec:
+                                                      type: object
+                                                      properties:
+                                                        command:
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                    httpGet:
+                                                      type: object
+                                                      required:
+                                                      - port
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        httpHeaders:
+                                                          type: array
+                                                          items:
+                                                            type: object
+                                                            required:
+                                                            - name
+                                                            - value
+                                                            properties:
+                                                              name:
+                                                                type: string
+                                                              value:
+                                                                type: string
+                                                        path:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                        scheme:
+                                                          type: string
+                                                    tcpSocket:
+                                                      type: object
+                                                      required:
+                                                      - port
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                preStop:
+                                                  type: object
+                                                  properties:
+                                                    exec:
+                                                      type: object
+                                                      properties:
+                                                        command:
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                    httpGet:
+                                                      type: object
+                                                      required:
+                                                      - port
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        httpHeaders:
+                                                          type: array
+                                                          items:
+                                                            type: object
+                                                            required:
+                                                            - name
+                                                            - value
+                                                            properties:
+                                                              name:
+                                                                type: string
+                                                              value:
+                                                                type: string
+                                                        path:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                        scheme:
+                                                          type: string
+                                                    tcpSocket:
+                                                      type: object
+                                                      required:
+                                                      - port
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                            livenessProbe:
+                                              type: object
+                                              properties:
+                                                exec:
+                                                  type: object
+                                                  properties:
+                                                    command:
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                                failureThreshold:
+                                                  type: integer
+                                                  format: int32
+                                                httpGet:
+                                                  type: object
+                                                  required:
+                                                  - port
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      type: array
+                                                      items:
+                                                        type: object
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                    scheme:
+                                                      type: string
+                                                initialDelaySeconds:
+                                                  type: integer
+                                                  format: int32
+                                                periodSeconds:
+                                                  type: integer
+                                                  format: int32
+                                                successThreshold:
+                                                  type: integer
+                                                  format: int32
+                                                tcpSocket:
+                                                  type: object
+                                                  required:
+                                                  - port
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                timeoutSeconds:
+                                                  type: integer
+                                                  format: int32
+                                            name:
+                                              type: string
+                                            ports:
+                                              type: array
+                                              items:
+                                                type: object
+                                                required:
+                                                - containerPort
+                                                properties:
+                                                  containerPort:
+                                                    type: integer
+                                                    format: int32
+                                                  hostIP:
+                                                    type: string
+                                                  hostPort:
+                                                    type: integer
+                                                    format: int32
+                                                  name:
+                                                    type: string
+                                                  protocol:
+                                                    type: string
+                                            readinessProbe:
+                                              type: object
+                                              properties:
+                                                exec:
+                                                  type: object
+                                                  properties:
+                                                    command:
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                                failureThreshold:
+                                                  type: integer
+                                                  format: int32
+                                                httpGet:
+                                                  type: object
+                                                  required:
+                                                  - port
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      type: array
+                                                      items:
+                                                        type: object
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                    scheme:
+                                                      type: string
+                                                initialDelaySeconds:
+                                                  type: integer
+                                                  format: int32
+                                                periodSeconds:
+                                                  type: integer
+                                                  format: int32
+                                                successThreshold:
+                                                  type: integer
+                                                  format: int32
+                                                tcpSocket:
+                                                  type: object
+                                                  required:
+                                                  - port
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                timeoutSeconds:
+                                                  type: integer
+                                                  format: int32
+                                            resources:
+                                              type: object
+                                              properties:
+                                                limits:
+                                                  type: object
+                                                  additionalProperties:
+                                                    type: string
+                                                requests:
+                                                  type: object
+                                                  additionalProperties:
+                                                    type: string
+                                            securityContext:
+                                              type: object
+                                              properties:
+                                                allowPrivilegeEscalation:
+                                                  type: boolean
+                                                capabilities:
+                                                  type: object
+                                                  properties:
+                                                    add:
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                                    drop:
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                                privileged:
+                                                  type: boolean
+                                                procMount:
+                                                  type: string
+                                                readOnlyRootFilesystem:
+                                                  type: boolean
+                                                runAsGroup:
+                                                  type: integer
+                                                  format: int64
+                                                runAsNonRoot:
+                                                  type: boolean
+                                                runAsUser:
+                                                  type: integer
+                                                  format: int64
+                                                seLinuxOptions:
+                                                  type: object
+                                                  properties:
+                                                    level:
+                                                      type: string
+                                                    role:
+                                                      type: string
+                                                    type:
+                                                      type: string
+                                                    user:
+                                                      type: string
+                                                windowsOptions:
+                                                  type: object
+                                                  properties:
+                                                    gmsaCredentialSpec:
+                                                      type: string
+                                                    gmsaCredentialSpecName:
+                                                      type: string
+                                                    runAsUserName:
+                                                      type: string
+                                            startupProbe:
+                                              type: object
+                                              properties:
+                                                exec:
+                                                  type: object
+                                                  properties:
+                                                    command:
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                                failureThreshold:
+                                                  type: integer
+                                                  format: int32
+                                                httpGet:
+                                                  type: object
+                                                  required:
+                                                  - port
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      type: array
+                                                      items:
+                                                        type: object
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                    scheme:
+                                                      type: string
+                                                initialDelaySeconds:
+                                                  type: integer
+                                                  format: int32
+                                                periodSeconds:
+                                                  type: integer
+                                                  format: int32
+                                                successThreshold:
+                                                  type: integer
+                                                  format: int32
+                                                tcpSocket:
+                                                  type: object
+                                                  required:
+                                                  - port
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                timeoutSeconds:
+                                                  type: integer
+                                                  format: int32
+                                            stdin:
+                                              type: boolean
+                                            stdinOnce:
+                                              type: boolean
+                                            terminationMessagePath:
+                                              type: string
+                                            terminationMessagePolicy:
+                                              type: string
+                                            tty:
+                                              type: boolean
+                                            volumeDevices:
+                                              type: array
+                                              items:
+                                                type: object
+                                                required:
+                                                - devicePath
+                                                - name
+                                                properties:
+                                                  devicePath:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                            volumeMounts:
+                                              type: array
+                                              items:
+                                                type: object
+                                                required:
+                                                - mountPath
+                                                - name
+                                                properties:
+                                                  mountPath:
+                                                    type: string
+                                                  mountPropagation:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  readOnly:
+                                                    type: boolean
+                                                  subPath:
+                                                    type: string
+                                                  subPathExpr:
+                                                    type: string
+                                            workingDir:
+                                              type: string
+                                      nodeName:
+                                        type: string
+                                      nodeSelector:
+                                        type: object
+                                        additionalProperties:
+                                          type: string
+                                      overhead:
+                                        type: object
+                                        additionalProperties:
+                                          type: string
+                                      preemptionPolicy:
+                                        type: string
+                                      priority:
+                                        type: integer
+                                        format: int32
+                                      priorityClassName:
+                                        type: string
+                                      readinessGates:
+                                        type: array
+                                        items:
+                                          type: object
+                                          required:
+                                          - conditionType
+                                          properties:
+                                            conditionType:
+                                              type: string
+                                      restartPolicy:
+                                        type: string
+                                      runtimeClassName:
+                                        type: string
+                                      schedulerName:
+                                        type: string
+                                      securityContext:
+                                        type: object
+                                        properties:
+                                          fsGroup:
+                                            type: integer
+                                            format: int64
+                                          runAsGroup:
+                                            type: integer
+                                            format: int64
+                                          runAsNonRoot:
+                                            type: boolean
+                                          runAsUser:
+                                            type: integer
+                                            format: int64
+                                          seLinuxOptions:
+                                            type: object
+                                            properties:
+                                              level:
+                                                type: string
+                                              role:
+                                                type: string
+                                              type:
+                                                type: string
+                                              user:
+                                                type: string
+                                          supplementalGroups:
+                                            type: array
+                                            items:
+                                              type: integer
+                                              format: int64
+                                          sysctls:
+                                            type: array
+                                            items:
+                                              type: object
+                                              required:
+                                              - name
+                                              - value
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                          windowsOptions:
+                                            type: object
+                                            properties:
+                                              gmsaCredentialSpec:
+                                                type: string
+                                              gmsaCredentialSpecName:
+                                                type: string
+                                              runAsUserName:
+                                                type: string
+                                      serviceAccount:
+                                        type: string
+                                      serviceAccountName:
+                                        type: string
+                                      shareProcessNamespace:
+                                        type: boolean
+                                      subdomain:
+                                        type: string
+                                      terminationGracePeriodSeconds:
+                                        type: integer
+                                        format: int64
+                                      tolerations:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            effect:
+                                              type: string
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            tolerationSeconds:
+                                              type: integer
+                                              format: int64
+                                            value:
+                                              type: string
+                                      topologySpreadConstraints:
+                                        type: array
+                                        items:
+                                          type: object
+                                          required:
+                                          - maxSkew
+                                          - topologyKey
+                                          - whenUnsatisfiable
+                                          properties:
+                                            labelSelector:
+                                              type: object
+                                              properties:
+                                                matchExpressions:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        type: array
+                                                        items:
+                                                          type: string
+                                                matchLabels:
+                                                  type: object
+                                                  additionalProperties:
+                                                    type: string
+                                            maxSkew:
+                                              type: integer
+                                              format: int32
+                                            topologyKey:
+                                              type: string
+                                            whenUnsatisfiable:
+                                              type: string
+                                      volumes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          required:
+                                          - name
+                                          properties:
+                                            awsElasticBlockStore:
+                                              type: object
+                                              required:
+                                              - volumeID
+                                              properties:
+                                                fsType:
+                                                  type: string
+                                                partition:
+                                                  type: integer
+                                                  format: int32
+                                                readOnly:
+                                                  type: boolean
+                                                volumeID:
+                                                  type: string
+                                            azureDisk:
+                                              type: object
+                                              required:
+                                              - diskName
+                                              - diskURI
+                                              properties:
+                                                cachingMode:
+                                                  type: string
+                                                diskName:
+                                                  type: string
+                                                diskURI:
+                                                  type: string
+                                                fsType:
+                                                  type: string
+                                                kind:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                            azureFile:
+                                              type: object
+                                              required:
+                                              - secretName
+                                              - shareName
+                                              properties:
+                                                readOnly:
+                                                  type: boolean
+                                                secretName:
+                                                  type: string
+                                                shareName:
+                                                  type: string
+                                            cephfs:
+                                              type: object
+                                              required:
+                                              - monitors
+                                              properties:
+                                                monitors:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                                path:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                                secretFile:
+                                                  type: string
+                                                secretRef:
+                                                  type: object
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                user:
+                                                  type: string
+                                            cinder:
+                                              type: object
+                                              required:
+                                              - volumeID
+                                              properties:
+                                                fsType:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                                secretRef:
+                                                  type: object
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                volumeID:
+                                                  type: string
+                                            configMap:
+                                              type: object
+                                              properties:
+                                                defaultMode:
+                                                  type: integer
+                                                  format: int32
+                                                items:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                    required:
+                                                    - key
+                                                    - path
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      mode:
+                                                        type: integer
+                                                        format: int32
+                                                      path:
+                                                        type: string
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                            csi:
+                                              type: object
+                                              required:
+                                              - driver
+                                              properties:
+                                                driver:
+                                                  type: string
+                                                fsType:
+                                                  type: string
+                                                nodePublishSecretRef:
+                                                  type: object
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                readOnly:
+                                                  type: boolean
+                                                volumeAttributes:
+                                                  type: object
+                                                  additionalProperties:
+                                                    type: string
+                                            downwardAPI:
+                                              type: object
+                                              properties:
+                                                defaultMode:
+                                                  type: integer
+                                                  format: int32
+                                                items:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                    required:
+                                                    - path
+                                                    properties:
+                                                      fieldRef:
+                                                        type: object
+                                                        required:
+                                                        - fieldPath
+                                                        properties:
+                                                          apiVersion:
+                                                            type: string
+                                                          fieldPath:
+                                                            type: string
+                                                      mode:
+                                                        type: integer
+                                                        format: int32
+                                                      path:
+                                                        type: string
+                                                      resourceFieldRef:
+                                                        type: object
+                                                        required:
+                                                        - resource
+                                                        properties:
+                                                          containerName:
+                                                            type: string
+                                                          divisor:
+                                                            type: string
+                                                          resource:
+                                                            type: string
+                                            emptyDir:
+                                              type: object
+                                              properties:
+                                                medium:
+                                                  type: string
+                                                sizeLimit:
+                                                  type: string
+                                            fc:
+                                              type: object
+                                              properties:
+                                                fsType:
+                                                  type: string
+                                                lun:
+                                                  type: integer
+                                                  format: int32
+                                                readOnly:
+                                                  type: boolean
+                                                targetWWNs:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                                wwids:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                            flexVolume:
+                                              type: object
+                                              required:
+                                              - driver
+                                              properties:
+                                                driver:
+                                                  type: string
+                                                fsType:
+                                                  type: string
+                                                options:
+                                                  type: object
+                                                  additionalProperties:
+                                                    type: string
+                                                readOnly:
+                                                  type: boolean
+                                                secretRef:
+                                                  type: object
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                            flocker:
+                                              type: object
+                                              properties:
+                                                datasetName:
+                                                  type: string
+                                                datasetUUID:
+                                                  type: string
+                                            gcePersistentDisk:
+                                              type: object
+                                              required:
+                                              - pdName
+                                              properties:
+                                                fsType:
+                                                  type: string
+                                                partition:
+                                                  type: integer
+                                                  format: int32
+                                                pdName:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                            gitRepo:
+                                              type: object
+                                              required:
+                                              - repository
+                                              properties:
+                                                directory:
+                                                  type: string
+                                                repository:
+                                                  type: string
+                                                revision:
+                                                  type: string
+                                            glusterfs:
+                                              type: object
+                                              required:
+                                              - endpoints
+                                              - path
+                                              properties:
+                                                endpoints:
+                                                  type: string
+                                                path:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                            hostPath:
+                                              type: object
+                                              required:
+                                              - path
+                                              properties:
+                                                path:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                            iscsi:
+                                              type: object
+                                              required:
+                                              - iqn
+                                              - lun
+                                              - targetPortal
+                                              properties:
+                                                chapAuthDiscovery:
+                                                  type: boolean
+                                                chapAuthSession:
+                                                  type: boolean
+                                                fsType:
+                                                  type: string
+                                                initiatorName:
+                                                  type: string
+                                                iqn:
+                                                  type: string
+                                                iscsiInterface:
+                                                  type: string
+                                                lun:
+                                                  type: integer
+                                                  format: int32
+                                                portals:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                                readOnly:
+                                                  type: boolean
+                                                secretRef:
+                                                  type: object
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                targetPortal:
+                                                  type: string
+                                            name:
+                                              type: string
+                                            nfs:
+                                              type: object
+                                              required:
+                                              - path
+                                              - server
+                                              properties:
+                                                path:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                                server:
+                                                  type: string
+                                            persistentVolumeClaim:
+                                              type: object
+                                              required:
+                                              - claimName
+                                              properties:
+                                                claimName:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                            photonPersistentDisk:
+                                              type: object
+                                              required:
+                                              - pdID
+                                              properties:
+                                                fsType:
+                                                  type: string
+                                                pdID:
+                                                  type: string
+                                            portworxVolume:
+                                              type: object
+                                              required:
+                                              - volumeID
+                                              properties:
+                                                fsType:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                                volumeID:
+                                                  type: string
+                                            projected:
+                                              type: object
+                                              required:
+                                              - sources
+                                              properties:
+                                                defaultMode:
+                                                  type: integer
+                                                  format: int32
+                                                sources:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                    properties:
+                                                      configMap:
+                                                        type: object
+                                                        properties:
+                                                          items:
+                                                            type: array
+                                                            items:
+                                                              type: object
+                                                              required:
+                                                              - key
+                                                              - path
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                mode:
+                                                                  type: integer
+                                                                  format: int32
+                                                                path:
+                                                                  type: string
+                                                          name:
+                                                            type: string
+                                                          optional:
+                                                            type: boolean
+                                                      downwardAPI:
+                                                        type: object
+                                                        properties:
+                                                          items:
+                                                            type: array
+                                                            items:
+                                                              type: object
+                                                              required:
+                                                              - path
+                                                              properties:
+                                                                fieldRef:
+                                                                  type: object
+                                                                  required:
+                                                                  - fieldPath
+                                                                  properties:
+                                                                    apiVersion:
+                                                                      type: string
+                                                                    fieldPath:
+                                                                      type: string
+                                                                mode:
+                                                                  type: integer
+                                                                  format: int32
+                                                                path:
+                                                                  type: string
+                                                                resourceFieldRef:
+                                                                  type: object
+                                                                  required:
+                                                                  - resource
+                                                                  properties:
+                                                                    containerName:
+                                                                      type: string
+                                                                    divisor:
+                                                                      type: string
+                                                                    resource:
+                                                                      type: string
+                                                      secret:
+                                                        type: object
+                                                        properties:
+                                                          items:
+                                                            type: array
+                                                            items:
+                                                              type: object
+                                                              required:
+                                                              - key
+                                                              - path
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                mode:
+                                                                  type: integer
+                                                                  format: int32
+                                                                path:
+                                                                  type: string
+                                                          name:
+                                                            type: string
+                                                          optional:
+                                                            type: boolean
+                                                      serviceAccountToken:
+                                                        type: object
+                                                        required:
+                                                        - path
+                                                        properties:
+                                                          audience:
+                                                            type: string
+                                                          expirationSeconds:
+                                                            type: integer
+                                                            format: int64
+                                                          path:
+                                                            type: string
+                                            quobyte:
+                                              type: object
+                                              required:
+                                              - registry
+                                              - volume
+                                              properties:
+                                                group:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                                registry:
+                                                  type: string
+                                                tenant:
+                                                  type: string
+                                                user:
+                                                  type: string
+                                                volume:
+                                                  type: string
+                                            rbd:
+                                              type: object
+                                              required:
+                                              - image
+                                              - monitors
+                                              properties:
+                                                fsType:
+                                                  type: string
+                                                image:
+                                                  type: string
+                                                keyring:
+                                                  type: string
+                                                monitors:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                                pool:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                                secretRef:
+                                                  type: object
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                user:
+                                                  type: string
+                                            scaleIO:
+                                              type: object
+                                              required:
+                                              - gateway
+                                              - secretRef
+                                              - system
+                                              properties:
+                                                fsType:
+                                                  type: string
+                                                gateway:
+                                                  type: string
+                                                protectionDomain:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                                secretRef:
+                                                  type: object
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                sslEnabled:
+                                                  type: boolean
+                                                storageMode:
+                                                  type: string
+                                                storagePool:
+                                                  type: string
+                                                system:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                            secret:
+                                              type: object
+                                              properties:
+                                                defaultMode:
+                                                  type: integer
+                                                  format: int32
+                                                items:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                    required:
+                                                    - key
+                                                    - path
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      mode:
+                                                        type: integer
+                                                        format: int32
+                                                      path:
+                                                        type: string
+                                                optional:
+                                                  type: boolean
+                                                secretName:
+                                                  type: string
+                                            storageos:
+                                              type: object
+                                              properties:
+                                                fsType:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                                secretRef:
+                                                  type: object
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                volumeName:
+                                                  type: string
+                                                volumeNamespace:
+                                                  type: string
+                                            vsphereVolume:
+                                              type: object
+                                              required:
+                                              - volumePath
+                                              properties:
+                                                fsType:
+                                                  type: string
+                                                storagePolicyID:
+                                                  type: string
+                                                storagePolicyName:
+                                                  type: string
+                                                volumePath:
+                                                  type: string
+                              ttlSecondsAfterFinished:
+                                type: integer
+                                format: int32
+                      ttlSecondsAfterFailure:
+                        type: integer
+                        format: int32
+                      ttlSecondsAfterFinished:
+                        type: integer
+                        format: int32
+                      values:
+                        type: array
+                        items:
+                          type: object
+                          required:
+                          - name
+                          - value
+                          properties:
+                            attemptsRemaining:
+                              type: integer
+                            error:
+                              type: string
+                            name:
+                              type: string
+                            value:
+                              type: string
+          status:
+            type: object
+            required:
+            - activeTrials
+            - phase
+            properties:
+              activeTrials:
+                type: integer
+                format: int32
+              phase:
+                type: string
   - name: v1beta1
     served: true
     storage: true
+    "schema":
+      "openAPIV3Schema":
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            required:
+            - metrics
+            - parameters
+            properties:
+              constraints:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    order:
+                      type: object
+                      required:
+                      - lowerParameter
+                      - upperParameter
+                      properties:
+                        lowerParameter:
+                          type: string
+                        upperParameter:
+                          type: string
+                    sum:
+                      type: object
+                      required:
+                      - bound
+                      - parameters
+                      properties:
+                        bound:
+                          type: string
+                        isUpperBound:
+                          type: boolean
+                        parameters:
+                          type: array
+                          items:
+                            type: object
+                            required:
+                            - name
+                            - weight
+                            properties:
+                              name:
+                                type: string
+                              weight:
+                                type: string
+              metrics:
+                type: array
+                items:
+                  type: object
+                  required:
+                  - name
+                  - query
+                  properties:
+                    errorQuery:
+                      type: string
+                    minimize:
+                      type: boolean
+                    name:
+                      type: string
+                    path:
+                      type: string
+                    port:
+                      anyOf:
+                      - type: string
+                      - type: integer
+                    query:
+                      type: string
+                    scheme:
+                      type: string
+                    selector:
+                      type: object
+                      properties:
+                        matchExpressions:
+                          type: array
+                          items:
+                            type: object
+                            required:
+                            - key
+                            - operator
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                type: string
+                              values:
+                                type: array
+                                items:
+                                  type: string
+                        matchLabels:
+                          type: object
+                          additionalProperties:
+                            type: string
+                    type:
+                      type: string
+              namespaceSelector:
+                type: object
+                properties:
+                  matchExpressions:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                      - key
+                      - operator
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          type: string
+                        values:
+                          type: array
+                          items:
+                            type: string
+                  matchLabels:
+                    type: object
+                    additionalProperties:
+                      type: string
+              namespaceTemplate:
+                type: object
+                properties:
+                  metadata:
+                    type: object
+                  spec:
+                    type: object
+                    properties:
+                      finalizers:
+                        type: array
+                        items:
+                          type: string
+              optimization:
+                type: array
+                items:
+                  type: object
+                  required:
+                  - name
+                  - value
+                  properties:
+                    name:
+                      type: string
+                    value:
+                      type: string
+              parameters:
+                type: array
+                items:
+                  type: object
+                  required:
+                  - name
+                  properties:
+                    max:
+                      type: integer
+                      format: int64
+                    min:
+                      type: integer
+                      format: int64
+                    name:
+                      type: string
+              patches:
+                type: array
+                items:
+                  type: object
+                  required:
+                  - patch
+                  properties:
+                    patch:
+                      type: string
+                    readinessGates:
+                      type: array
+                      items:
+                        type: object
+                        required:
+                        - conditionType
+                        properties:
+                          conditionType:
+                            type: string
+                    targetRef:
+                      type: object
+                      properties:
+                        apiVersion:
+                          type: string
+                        fieldPath:
+                          type: string
+                        kind:
+                          type: string
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                        resourceVersion:
+                          type: string
+                        uid:
+                          type: string
+                    type:
+                      type: string
+              replicas:
+                type: integer
+                format: int32
+              selector:
+                type: object
+                properties:
+                  matchExpressions:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                      - key
+                      - operator
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          type: string
+                        values:
+                          type: array
+                          items:
+                            type: string
+                  matchLabels:
+                    type: object
+                    additionalProperties:
+                      type: string
+              trialTemplate:
+                type: object
+                properties:
+                  metadata:
+                    type: object
+                  spec:
+                    type: object
+                    properties:
+                      approximateRuntime:
+                        type: string
+                      assignments:
+                        type: array
+                        items:
+                          type: object
+                          required:
+                          - name
+                          - value
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: integer
+                              format: int64
+                      experimentRef:
+                        type: object
+                        properties:
+                          apiVersion:
+                            type: string
+                          fieldPath:
+                            type: string
+                          kind:
+                            type: string
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                          resourceVersion:
+                            type: string
+                          uid:
+                            type: string
+                      initialDelaySeconds:
+                        type: integer
+                        format: int32
+                      jobTemplate:
+                        type: object
+                        properties:
+                          metadata:
+                            type: object
+                          spec:
+                            type: object
+                            required:
+                            - template
+                            properties:
+                              activeDeadlineSeconds:
+                                type: integer
+                                format: int64
+                              backoffLimit:
+                                type: integer
+                                format: int32
+                              completions:
+                                type: integer
+                                format: int32
+                              manualSelector:
+                                type: boolean
+                              parallelism:
+                                type: integer
+                                format: int32
+                              selector:
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    type: array
+                                    items:
+                                      type: object
+                                      required:
+                                      - key
+                                      - operator
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    type: object
+                                    additionalProperties:
+                                      type: string
+                              template:
+                                type: object
+                                properties:
+                                  metadata:
+                                    type: object
+                                  spec:
+                                    type: object
+                                    required:
+                                    - containers
+                                    properties:
+                                      activeDeadlineSeconds:
+                                        type: integer
+                                        format: int64
+                                      affinity:
+                                        type: object
+                                        properties:
+                                          nodeAffinity:
+                                            type: object
+                                            properties:
+                                              preferredDuringSchedulingIgnoredDuringExecution:
+                                                type: array
+                                                items:
+                                                  type: object
+                                                  required:
+                                                  - preference
+                                                  - weight
+                                                  properties:
+                                                    preference:
+                                                      type: object
+                                                      properties:
+                                                        matchExpressions:
+                                                          type: array
+                                                          items:
+                                                            type: object
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              operator:
+                                                                type: string
+                                                              values:
+                                                                type: array
+                                                                items:
+                                                                  type: string
+                                                        matchFields:
+                                                          type: array
+                                                          items:
+                                                            type: object
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              operator:
+                                                                type: string
+                                                              values:
+                                                                type: array
+                                                                items:
+                                                                  type: string
+                                                    weight:
+                                                      type: integer
+                                                      format: int32
+                                              requiredDuringSchedulingIgnoredDuringExecution:
+                                                type: object
+                                                required:
+                                                - nodeSelectorTerms
+                                                properties:
+                                                  nodeSelectorTerms:
+                                                    type: array
+                                                    items:
+                                                      type: object
+                                                      properties:
+                                                        matchExpressions:
+                                                          type: array
+                                                          items:
+                                                            type: object
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              operator:
+                                                                type: string
+                                                              values:
+                                                                type: array
+                                                                items:
+                                                                  type: string
+                                                        matchFields:
+                                                          type: array
+                                                          items:
+                                                            type: object
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              operator:
+                                                                type: string
+                                                              values:
+                                                                type: array
+                                                                items:
+                                                                  type: string
+                                          podAffinity:
+                                            type: object
+                                            properties:
+                                              preferredDuringSchedulingIgnoredDuringExecution:
+                                                type: array
+                                                items:
+                                                  type: object
+                                                  required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                  properties:
+                                                    podAffinityTerm:
+                                                      type: object
+                                                      required:
+                                                      - topologyKey
+                                                      properties:
+                                                        labelSelector:
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              type: array
+                                                              items:
+                                                                type: object
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                properties:
+                                                                  key:
+                                                                    type: string
+                                                                  operator:
+                                                                    type: string
+                                                                  values:
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                        namespaces:
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                        topologyKey:
+                                                          type: string
+                                                    weight:
+                                                      type: integer
+                                                      format: int32
+                                              requiredDuringSchedulingIgnoredDuringExecution:
+                                                type: array
+                                                items:
+                                                  type: object
+                                                  required:
+                                                  - topologyKey
+                                                  properties:
+                                                    labelSelector:
+                                                      type: object
+                                                      properties:
+                                                        matchExpressions:
+                                                          type: array
+                                                          items:
+                                                            type: object
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              operator:
+                                                                type: string
+                                                              values:
+                                                                type: array
+                                                                items:
+                                                                  type: string
+                                                        matchLabels:
+                                                          type: object
+                                                          additionalProperties:
+                                                            type: string
+                                                    namespaces:
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                                    topologyKey:
+                                                      type: string
+                                          podAntiAffinity:
+                                            type: object
+                                            properties:
+                                              preferredDuringSchedulingIgnoredDuringExecution:
+                                                type: array
+                                                items:
+                                                  type: object
+                                                  required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                  properties:
+                                                    podAffinityTerm:
+                                                      type: object
+                                                      required:
+                                                      - topologyKey
+                                                      properties:
+                                                        labelSelector:
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              type: array
+                                                              items:
+                                                                type: object
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                properties:
+                                                                  key:
+                                                                    type: string
+                                                                  operator:
+                                                                    type: string
+                                                                  values:
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                        namespaces:
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                        topologyKey:
+                                                          type: string
+                                                    weight:
+                                                      type: integer
+                                                      format: int32
+                                              requiredDuringSchedulingIgnoredDuringExecution:
+                                                type: array
+                                                items:
+                                                  type: object
+                                                  required:
+                                                  - topologyKey
+                                                  properties:
+                                                    labelSelector:
+                                                      type: object
+                                                      properties:
+                                                        matchExpressions:
+                                                          type: array
+                                                          items:
+                                                            type: object
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              operator:
+                                                                type: string
+                                                              values:
+                                                                type: array
+                                                                items:
+                                                                  type: string
+                                                        matchLabels:
+                                                          type: object
+                                                          additionalProperties:
+                                                            type: string
+                                                    namespaces:
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                                    topologyKey:
+                                                      type: string
+                                      automountServiceAccountToken:
+                                        type: boolean
+                                      containers:
+                                        type: array
+                                        items:
+                                          type: object
+                                          required:
+                                          - name
+                                          properties:
+                                            args:
+                                              type: array
+                                              items:
+                                                type: string
+                                            command:
+                                              type: array
+                                              items:
+                                                type: string
+                                            env:
+                                              type: array
+                                              items:
+                                                type: object
+                                                required:
+                                                - name
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                  valueFrom:
+                                                    type: object
+                                                    properties:
+                                                      configMapKeyRef:
+                                                        type: object
+                                                        required:
+                                                        - key
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          name:
+                                                            type: string
+                                                          optional:
+                                                            type: boolean
+                                                      fieldRef:
+                                                        type: object
+                                                        required:
+                                                        - fieldPath
+                                                        properties:
+                                                          apiVersion:
+                                                            type: string
+                                                          fieldPath:
+                                                            type: string
+                                                      resourceFieldRef:
+                                                        type: object
+                                                        required:
+                                                        - resource
+                                                        properties:
+                                                          containerName:
+                                                            type: string
+                                                          divisor:
+                                                            type: string
+                                                          resource:
+                                                            type: string
+                                                      secretKeyRef:
+                                                        type: object
+                                                        required:
+                                                        - key
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          name:
+                                                            type: string
+                                                          optional:
+                                                            type: boolean
+                                            envFrom:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  configMapRef:
+                                                    type: object
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                  prefix:
+                                                    type: string
+                                                  secretRef:
+                                                    type: object
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                            image:
+                                              type: string
+                                            imagePullPolicy:
+                                              type: string
+                                            lifecycle:
+                                              type: object
+                                              properties:
+                                                postStart:
+                                                  type: object
+                                                  properties:
+                                                    exec:
+                                                      type: object
+                                                      properties:
+                                                        command:
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                    httpGet:
+                                                      type: object
+                                                      required:
+                                                      - port
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        httpHeaders:
+                                                          type: array
+                                                          items:
+                                                            type: object
+                                                            required:
+                                                            - name
+                                                            - value
+                                                            properties:
+                                                              name:
+                                                                type: string
+                                                              value:
+                                                                type: string
+                                                        path:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                        scheme:
+                                                          type: string
+                                                    tcpSocket:
+                                                      type: object
+                                                      required:
+                                                      - port
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                preStop:
+                                                  type: object
+                                                  properties:
+                                                    exec:
+                                                      type: object
+                                                      properties:
+                                                        command:
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                    httpGet:
+                                                      type: object
+                                                      required:
+                                                      - port
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        httpHeaders:
+                                                          type: array
+                                                          items:
+                                                            type: object
+                                                            required:
+                                                            - name
+                                                            - value
+                                                            properties:
+                                                              name:
+                                                                type: string
+                                                              value:
+                                                                type: string
+                                                        path:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                        scheme:
+                                                          type: string
+                                                    tcpSocket:
+                                                      type: object
+                                                      required:
+                                                      - port
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                            livenessProbe:
+                                              type: object
+                                              properties:
+                                                exec:
+                                                  type: object
+                                                  properties:
+                                                    command:
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                                failureThreshold:
+                                                  type: integer
+                                                  format: int32
+                                                httpGet:
+                                                  type: object
+                                                  required:
+                                                  - port
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      type: array
+                                                      items:
+                                                        type: object
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                    scheme:
+                                                      type: string
+                                                initialDelaySeconds:
+                                                  type: integer
+                                                  format: int32
+                                                periodSeconds:
+                                                  type: integer
+                                                  format: int32
+                                                successThreshold:
+                                                  type: integer
+                                                  format: int32
+                                                tcpSocket:
+                                                  type: object
+                                                  required:
+                                                  - port
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                timeoutSeconds:
+                                                  type: integer
+                                                  format: int32
+                                            name:
+                                              type: string
+                                            ports:
+                                              type: array
+                                              items:
+                                                type: object
+                                                required:
+                                                - containerPort
+                                                properties:
+                                                  containerPort:
+                                                    type: integer
+                                                    format: int32
+                                                  hostIP:
+                                                    type: string
+                                                  hostPort:
+                                                    type: integer
+                                                    format: int32
+                                                  name:
+                                                    type: string
+                                                  protocol:
+                                                    type: string
+                                            readinessProbe:
+                                              type: object
+                                              properties:
+                                                exec:
+                                                  type: object
+                                                  properties:
+                                                    command:
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                                failureThreshold:
+                                                  type: integer
+                                                  format: int32
+                                                httpGet:
+                                                  type: object
+                                                  required:
+                                                  - port
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      type: array
+                                                      items:
+                                                        type: object
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                    scheme:
+                                                      type: string
+                                                initialDelaySeconds:
+                                                  type: integer
+                                                  format: int32
+                                                periodSeconds:
+                                                  type: integer
+                                                  format: int32
+                                                successThreshold:
+                                                  type: integer
+                                                  format: int32
+                                                tcpSocket:
+                                                  type: object
+                                                  required:
+                                                  - port
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                timeoutSeconds:
+                                                  type: integer
+                                                  format: int32
+                                            resources:
+                                              type: object
+                                              properties:
+                                                limits:
+                                                  type: object
+                                                  additionalProperties:
+                                                    type: string
+                                                requests:
+                                                  type: object
+                                                  additionalProperties:
+                                                    type: string
+                                            securityContext:
+                                              type: object
+                                              properties:
+                                                allowPrivilegeEscalation:
+                                                  type: boolean
+                                                capabilities:
+                                                  type: object
+                                                  properties:
+                                                    add:
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                                    drop:
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                                privileged:
+                                                  type: boolean
+                                                procMount:
+                                                  type: string
+                                                readOnlyRootFilesystem:
+                                                  type: boolean
+                                                runAsGroup:
+                                                  type: integer
+                                                  format: int64
+                                                runAsNonRoot:
+                                                  type: boolean
+                                                runAsUser:
+                                                  type: integer
+                                                  format: int64
+                                                seLinuxOptions:
+                                                  type: object
+                                                  properties:
+                                                    level:
+                                                      type: string
+                                                    role:
+                                                      type: string
+                                                    type:
+                                                      type: string
+                                                    user:
+                                                      type: string
+                                                windowsOptions:
+                                                  type: object
+                                                  properties:
+                                                    gmsaCredentialSpec:
+                                                      type: string
+                                                    gmsaCredentialSpecName:
+                                                      type: string
+                                                    runAsUserName:
+                                                      type: string
+                                            startupProbe:
+                                              type: object
+                                              properties:
+                                                exec:
+                                                  type: object
+                                                  properties:
+                                                    command:
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                                failureThreshold:
+                                                  type: integer
+                                                  format: int32
+                                                httpGet:
+                                                  type: object
+                                                  required:
+                                                  - port
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      type: array
+                                                      items:
+                                                        type: object
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                    scheme:
+                                                      type: string
+                                                initialDelaySeconds:
+                                                  type: integer
+                                                  format: int32
+                                                periodSeconds:
+                                                  type: integer
+                                                  format: int32
+                                                successThreshold:
+                                                  type: integer
+                                                  format: int32
+                                                tcpSocket:
+                                                  type: object
+                                                  required:
+                                                  - port
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                timeoutSeconds:
+                                                  type: integer
+                                                  format: int32
+                                            stdin:
+                                              type: boolean
+                                            stdinOnce:
+                                              type: boolean
+                                            terminationMessagePath:
+                                              type: string
+                                            terminationMessagePolicy:
+                                              type: string
+                                            tty:
+                                              type: boolean
+                                            volumeDevices:
+                                              type: array
+                                              items:
+                                                type: object
+                                                required:
+                                                - devicePath
+                                                - name
+                                                properties:
+                                                  devicePath:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                            volumeMounts:
+                                              type: array
+                                              items:
+                                                type: object
+                                                required:
+                                                - mountPath
+                                                - name
+                                                properties:
+                                                  mountPath:
+                                                    type: string
+                                                  mountPropagation:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  readOnly:
+                                                    type: boolean
+                                                  subPath:
+                                                    type: string
+                                                  subPathExpr:
+                                                    type: string
+                                            workingDir:
+                                              type: string
+                                      dnsConfig:
+                                        type: object
+                                        properties:
+                                          nameservers:
+                                            type: array
+                                            items:
+                                              type: string
+                                          options:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                          searches:
+                                            type: array
+                                            items:
+                                              type: string
+                                      dnsPolicy:
+                                        type: string
+                                      enableServiceLinks:
+                                        type: boolean
+                                      ephemeralContainers:
+                                        type: array
+                                        items:
+                                          type: object
+                                          required:
+                                          - name
+                                          properties:
+                                            args:
+                                              type: array
+                                              items:
+                                                type: string
+                                            command:
+                                              type: array
+                                              items:
+                                                type: string
+                                            env:
+                                              type: array
+                                              items:
+                                                type: object
+                                                required:
+                                                - name
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                  valueFrom:
+                                                    type: object
+                                                    properties:
+                                                      configMapKeyRef:
+                                                        type: object
+                                                        required:
+                                                        - key
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          name:
+                                                            type: string
+                                                          optional:
+                                                            type: boolean
+                                                      fieldRef:
+                                                        type: object
+                                                        required:
+                                                        - fieldPath
+                                                        properties:
+                                                          apiVersion:
+                                                            type: string
+                                                          fieldPath:
+                                                            type: string
+                                                      resourceFieldRef:
+                                                        type: object
+                                                        required:
+                                                        - resource
+                                                        properties:
+                                                          containerName:
+                                                            type: string
+                                                          divisor:
+                                                            type: string
+                                                          resource:
+                                                            type: string
+                                                      secretKeyRef:
+                                                        type: object
+                                                        required:
+                                                        - key
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          name:
+                                                            type: string
+                                                          optional:
+                                                            type: boolean
+                                            envFrom:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  configMapRef:
+                                                    type: object
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                  prefix:
+                                                    type: string
+                                                  secretRef:
+                                                    type: object
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                            image:
+                                              type: string
+                                            imagePullPolicy:
+                                              type: string
+                                            lifecycle:
+                                              type: object
+                                              properties:
+                                                postStart:
+                                                  type: object
+                                                  properties:
+                                                    exec:
+                                                      type: object
+                                                      properties:
+                                                        command:
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                    httpGet:
+                                                      type: object
+                                                      required:
+                                                      - port
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        httpHeaders:
+                                                          type: array
+                                                          items:
+                                                            type: object
+                                                            required:
+                                                            - name
+                                                            - value
+                                                            properties:
+                                                              name:
+                                                                type: string
+                                                              value:
+                                                                type: string
+                                                        path:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                        scheme:
+                                                          type: string
+                                                    tcpSocket:
+                                                      type: object
+                                                      required:
+                                                      - port
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                preStop:
+                                                  type: object
+                                                  properties:
+                                                    exec:
+                                                      type: object
+                                                      properties:
+                                                        command:
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                    httpGet:
+                                                      type: object
+                                                      required:
+                                                      - port
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        httpHeaders:
+                                                          type: array
+                                                          items:
+                                                            type: object
+                                                            required:
+                                                            - name
+                                                            - value
+                                                            properties:
+                                                              name:
+                                                                type: string
+                                                              value:
+                                                                type: string
+                                                        path:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                        scheme:
+                                                          type: string
+                                                    tcpSocket:
+                                                      type: object
+                                                      required:
+                                                      - port
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                            livenessProbe:
+                                              type: object
+                                              properties:
+                                                exec:
+                                                  type: object
+                                                  properties:
+                                                    command:
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                                failureThreshold:
+                                                  type: integer
+                                                  format: int32
+                                                httpGet:
+                                                  type: object
+                                                  required:
+                                                  - port
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      type: array
+                                                      items:
+                                                        type: object
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                    scheme:
+                                                      type: string
+                                                initialDelaySeconds:
+                                                  type: integer
+                                                  format: int32
+                                                periodSeconds:
+                                                  type: integer
+                                                  format: int32
+                                                successThreshold:
+                                                  type: integer
+                                                  format: int32
+                                                tcpSocket:
+                                                  type: object
+                                                  required:
+                                                  - port
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                timeoutSeconds:
+                                                  type: integer
+                                                  format: int32
+                                            name:
+                                              type: string
+                                            ports:
+                                              type: array
+                                              items:
+                                                type: object
+                                                required:
+                                                - containerPort
+                                                properties:
+                                                  containerPort:
+                                                    type: integer
+                                                    format: int32
+                                                  hostIP:
+                                                    type: string
+                                                  hostPort:
+                                                    type: integer
+                                                    format: int32
+                                                  name:
+                                                    type: string
+                                                  protocol:
+                                                    type: string
+                                            readinessProbe:
+                                              type: object
+                                              properties:
+                                                exec:
+                                                  type: object
+                                                  properties:
+                                                    command:
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                                failureThreshold:
+                                                  type: integer
+                                                  format: int32
+                                                httpGet:
+                                                  type: object
+                                                  required:
+                                                  - port
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      type: array
+                                                      items:
+                                                        type: object
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                    scheme:
+                                                      type: string
+                                                initialDelaySeconds:
+                                                  type: integer
+                                                  format: int32
+                                                periodSeconds:
+                                                  type: integer
+                                                  format: int32
+                                                successThreshold:
+                                                  type: integer
+                                                  format: int32
+                                                tcpSocket:
+                                                  type: object
+                                                  required:
+                                                  - port
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                timeoutSeconds:
+                                                  type: integer
+                                                  format: int32
+                                            resources:
+                                              type: object
+                                              properties:
+                                                limits:
+                                                  type: object
+                                                  additionalProperties:
+                                                    type: string
+                                                requests:
+                                                  type: object
+                                                  additionalProperties:
+                                                    type: string
+                                            securityContext:
+                                              type: object
+                                              properties:
+                                                allowPrivilegeEscalation:
+                                                  type: boolean
+                                                capabilities:
+                                                  type: object
+                                                  properties:
+                                                    add:
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                                    drop:
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                                privileged:
+                                                  type: boolean
+                                                procMount:
+                                                  type: string
+                                                readOnlyRootFilesystem:
+                                                  type: boolean
+                                                runAsGroup:
+                                                  type: integer
+                                                  format: int64
+                                                runAsNonRoot:
+                                                  type: boolean
+                                                runAsUser:
+                                                  type: integer
+                                                  format: int64
+                                                seLinuxOptions:
+                                                  type: object
+                                                  properties:
+                                                    level:
+                                                      type: string
+                                                    role:
+                                                      type: string
+                                                    type:
+                                                      type: string
+                                                    user:
+                                                      type: string
+                                                windowsOptions:
+                                                  type: object
+                                                  properties:
+                                                    gmsaCredentialSpec:
+                                                      type: string
+                                                    gmsaCredentialSpecName:
+                                                      type: string
+                                                    runAsUserName:
+                                                      type: string
+                                            startupProbe:
+                                              type: object
+                                              properties:
+                                                exec:
+                                                  type: object
+                                                  properties:
+                                                    command:
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                                failureThreshold:
+                                                  type: integer
+                                                  format: int32
+                                                httpGet:
+                                                  type: object
+                                                  required:
+                                                  - port
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      type: array
+                                                      items:
+                                                        type: object
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                    scheme:
+                                                      type: string
+                                                initialDelaySeconds:
+                                                  type: integer
+                                                  format: int32
+                                                periodSeconds:
+                                                  type: integer
+                                                  format: int32
+                                                successThreshold:
+                                                  type: integer
+                                                  format: int32
+                                                tcpSocket:
+                                                  type: object
+                                                  required:
+                                                  - port
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                timeoutSeconds:
+                                                  type: integer
+                                                  format: int32
+                                            stdin:
+                                              type: boolean
+                                            stdinOnce:
+                                              type: boolean
+                                            targetContainerName:
+                                              type: string
+                                            terminationMessagePath:
+                                              type: string
+                                            terminationMessagePolicy:
+                                              type: string
+                                            tty:
+                                              type: boolean
+                                            volumeDevices:
+                                              type: array
+                                              items:
+                                                type: object
+                                                required:
+                                                - devicePath
+                                                - name
+                                                properties:
+                                                  devicePath:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                            volumeMounts:
+                                              type: array
+                                              items:
+                                                type: object
+                                                required:
+                                                - mountPath
+                                                - name
+                                                properties:
+                                                  mountPath:
+                                                    type: string
+                                                  mountPropagation:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  readOnly:
+                                                    type: boolean
+                                                  subPath:
+                                                    type: string
+                                                  subPathExpr:
+                                                    type: string
+                                            workingDir:
+                                              type: string
+                                      hostAliases:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            hostnames:
+                                              type: array
+                                              items:
+                                                type: string
+                                            ip:
+                                              type: string
+                                      hostIPC:
+                                        type: boolean
+                                      hostNetwork:
+                                        type: boolean
+                                      hostPID:
+                                        type: boolean
+                                      hostname:
+                                        type: string
+                                      imagePullSecrets:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            name:
+                                              type: string
+                                      initContainers:
+                                        type: array
+                                        items:
+                                          type: object
+                                          required:
+                                          - name
+                                          properties:
+                                            args:
+                                              type: array
+                                              items:
+                                                type: string
+                                            command:
+                                              type: array
+                                              items:
+                                                type: string
+                                            env:
+                                              type: array
+                                              items:
+                                                type: object
+                                                required:
+                                                - name
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                  valueFrom:
+                                                    type: object
+                                                    properties:
+                                                      configMapKeyRef:
+                                                        type: object
+                                                        required:
+                                                        - key
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          name:
+                                                            type: string
+                                                          optional:
+                                                            type: boolean
+                                                      fieldRef:
+                                                        type: object
+                                                        required:
+                                                        - fieldPath
+                                                        properties:
+                                                          apiVersion:
+                                                            type: string
+                                                          fieldPath:
+                                                            type: string
+                                                      resourceFieldRef:
+                                                        type: object
+                                                        required:
+                                                        - resource
+                                                        properties:
+                                                          containerName:
+                                                            type: string
+                                                          divisor:
+                                                            type: string
+                                                          resource:
+                                                            type: string
+                                                      secretKeyRef:
+                                                        type: object
+                                                        required:
+                                                        - key
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          name:
+                                                            type: string
+                                                          optional:
+                                                            type: boolean
+                                            envFrom:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  configMapRef:
+                                                    type: object
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                  prefix:
+                                                    type: string
+                                                  secretRef:
+                                                    type: object
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                            image:
+                                              type: string
+                                            imagePullPolicy:
+                                              type: string
+                                            lifecycle:
+                                              type: object
+                                              properties:
+                                                postStart:
+                                                  type: object
+                                                  properties:
+                                                    exec:
+                                                      type: object
+                                                      properties:
+                                                        command:
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                    httpGet:
+                                                      type: object
+                                                      required:
+                                                      - port
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        httpHeaders:
+                                                          type: array
+                                                          items:
+                                                            type: object
+                                                            required:
+                                                            - name
+                                                            - value
+                                                            properties:
+                                                              name:
+                                                                type: string
+                                                              value:
+                                                                type: string
+                                                        path:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                        scheme:
+                                                          type: string
+                                                    tcpSocket:
+                                                      type: object
+                                                      required:
+                                                      - port
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                preStop:
+                                                  type: object
+                                                  properties:
+                                                    exec:
+                                                      type: object
+                                                      properties:
+                                                        command:
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                    httpGet:
+                                                      type: object
+                                                      required:
+                                                      - port
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        httpHeaders:
+                                                          type: array
+                                                          items:
+                                                            type: object
+                                                            required:
+                                                            - name
+                                                            - value
+                                                            properties:
+                                                              name:
+                                                                type: string
+                                                              value:
+                                                                type: string
+                                                        path:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                                        scheme:
+                                                          type: string
+                                                    tcpSocket:
+                                                      type: object
+                                                      required:
+                                                      - port
+                                                      properties:
+                                                        host:
+                                                          type: string
+                                                        port:
+                                                          anyOf:
+                                                          - type: string
+                                                          - type: integer
+                                            livenessProbe:
+                                              type: object
+                                              properties:
+                                                exec:
+                                                  type: object
+                                                  properties:
+                                                    command:
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                                failureThreshold:
+                                                  type: integer
+                                                  format: int32
+                                                httpGet:
+                                                  type: object
+                                                  required:
+                                                  - port
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      type: array
+                                                      items:
+                                                        type: object
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                    scheme:
+                                                      type: string
+                                                initialDelaySeconds:
+                                                  type: integer
+                                                  format: int32
+                                                periodSeconds:
+                                                  type: integer
+                                                  format: int32
+                                                successThreshold:
+                                                  type: integer
+                                                  format: int32
+                                                tcpSocket:
+                                                  type: object
+                                                  required:
+                                                  - port
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                timeoutSeconds:
+                                                  type: integer
+                                                  format: int32
+                                            name:
+                                              type: string
+                                            ports:
+                                              type: array
+                                              items:
+                                                type: object
+                                                required:
+                                                - containerPort
+                                                properties:
+                                                  containerPort:
+                                                    type: integer
+                                                    format: int32
+                                                  hostIP:
+                                                    type: string
+                                                  hostPort:
+                                                    type: integer
+                                                    format: int32
+                                                  name:
+                                                    type: string
+                                                  protocol:
+                                                    type: string
+                                            readinessProbe:
+                                              type: object
+                                              properties:
+                                                exec:
+                                                  type: object
+                                                  properties:
+                                                    command:
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                                failureThreshold:
+                                                  type: integer
+                                                  format: int32
+                                                httpGet:
+                                                  type: object
+                                                  required:
+                                                  - port
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      type: array
+                                                      items:
+                                                        type: object
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                    scheme:
+                                                      type: string
+                                                initialDelaySeconds:
+                                                  type: integer
+                                                  format: int32
+                                                periodSeconds:
+                                                  type: integer
+                                                  format: int32
+                                                successThreshold:
+                                                  type: integer
+                                                  format: int32
+                                                tcpSocket:
+                                                  type: object
+                                                  required:
+                                                  - port
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                timeoutSeconds:
+                                                  type: integer
+                                                  format: int32
+                                            resources:
+                                              type: object
+                                              properties:
+                                                limits:
+                                                  type: object
+                                                  additionalProperties:
+                                                    type: string
+                                                requests:
+                                                  type: object
+                                                  additionalProperties:
+                                                    type: string
+                                            securityContext:
+                                              type: object
+                                              properties:
+                                                allowPrivilegeEscalation:
+                                                  type: boolean
+                                                capabilities:
+                                                  type: object
+                                                  properties:
+                                                    add:
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                                    drop:
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                                privileged:
+                                                  type: boolean
+                                                procMount:
+                                                  type: string
+                                                readOnlyRootFilesystem:
+                                                  type: boolean
+                                                runAsGroup:
+                                                  type: integer
+                                                  format: int64
+                                                runAsNonRoot:
+                                                  type: boolean
+                                                runAsUser:
+                                                  type: integer
+                                                  format: int64
+                                                seLinuxOptions:
+                                                  type: object
+                                                  properties:
+                                                    level:
+                                                      type: string
+                                                    role:
+                                                      type: string
+                                                    type:
+                                                      type: string
+                                                    user:
+                                                      type: string
+                                                windowsOptions:
+                                                  type: object
+                                                  properties:
+                                                    gmsaCredentialSpec:
+                                                      type: string
+                                                    gmsaCredentialSpecName:
+                                                      type: string
+                                                    runAsUserName:
+                                                      type: string
+                                            startupProbe:
+                                              type: object
+                                              properties:
+                                                exec:
+                                                  type: object
+                                                  properties:
+                                                    command:
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                                failureThreshold:
+                                                  type: integer
+                                                  format: int32
+                                                httpGet:
+                                                  type: object
+                                                  required:
+                                                  - port
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      type: array
+                                                      items:
+                                                        type: object
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                    scheme:
+                                                      type: string
+                                                initialDelaySeconds:
+                                                  type: integer
+                                                  format: int32
+                                                periodSeconds:
+                                                  type: integer
+                                                  format: int32
+                                                successThreshold:
+                                                  type: integer
+                                                  format: int32
+                                                tcpSocket:
+                                                  type: object
+                                                  required:
+                                                  - port
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: string
+                                                      - type: integer
+                                                timeoutSeconds:
+                                                  type: integer
+                                                  format: int32
+                                            stdin:
+                                              type: boolean
+                                            stdinOnce:
+                                              type: boolean
+                                            terminationMessagePath:
+                                              type: string
+                                            terminationMessagePolicy:
+                                              type: string
+                                            tty:
+                                              type: boolean
+                                            volumeDevices:
+                                              type: array
+                                              items:
+                                                type: object
+                                                required:
+                                                - devicePath
+                                                - name
+                                                properties:
+                                                  devicePath:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                            volumeMounts:
+                                              type: array
+                                              items:
+                                                type: object
+                                                required:
+                                                - mountPath
+                                                - name
+                                                properties:
+                                                  mountPath:
+                                                    type: string
+                                                  mountPropagation:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  readOnly:
+                                                    type: boolean
+                                                  subPath:
+                                                    type: string
+                                                  subPathExpr:
+                                                    type: string
+                                            workingDir:
+                                              type: string
+                                      nodeName:
+                                        type: string
+                                      nodeSelector:
+                                        type: object
+                                        additionalProperties:
+                                          type: string
+                                      overhead:
+                                        type: object
+                                        additionalProperties:
+                                          type: string
+                                      preemptionPolicy:
+                                        type: string
+                                      priority:
+                                        type: integer
+                                        format: int32
+                                      priorityClassName:
+                                        type: string
+                                      readinessGates:
+                                        type: array
+                                        items:
+                                          type: object
+                                          required:
+                                          - conditionType
+                                          properties:
+                                            conditionType:
+                                              type: string
+                                      restartPolicy:
+                                        type: string
+                                      runtimeClassName:
+                                        type: string
+                                      schedulerName:
+                                        type: string
+                                      securityContext:
+                                        type: object
+                                        properties:
+                                          fsGroup:
+                                            type: integer
+                                            format: int64
+                                          runAsGroup:
+                                            type: integer
+                                            format: int64
+                                          runAsNonRoot:
+                                            type: boolean
+                                          runAsUser:
+                                            type: integer
+                                            format: int64
+                                          seLinuxOptions:
+                                            type: object
+                                            properties:
+                                              level:
+                                                type: string
+                                              role:
+                                                type: string
+                                              type:
+                                                type: string
+                                              user:
+                                                type: string
+                                          supplementalGroups:
+                                            type: array
+                                            items:
+                                              type: integer
+                                              format: int64
+                                          sysctls:
+                                            type: array
+                                            items:
+                                              type: object
+                                              required:
+                                              - name
+                                              - value
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                          windowsOptions:
+                                            type: object
+                                            properties:
+                                              gmsaCredentialSpec:
+                                                type: string
+                                              gmsaCredentialSpecName:
+                                                type: string
+                                              runAsUserName:
+                                                type: string
+                                      serviceAccount:
+                                        type: string
+                                      serviceAccountName:
+                                        type: string
+                                      shareProcessNamespace:
+                                        type: boolean
+                                      subdomain:
+                                        type: string
+                                      terminationGracePeriodSeconds:
+                                        type: integer
+                                        format: int64
+                                      tolerations:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            effect:
+                                              type: string
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            tolerationSeconds:
+                                              type: integer
+                                              format: int64
+                                            value:
+                                              type: string
+                                      topologySpreadConstraints:
+                                        type: array
+                                        items:
+                                          type: object
+                                          required:
+                                          - maxSkew
+                                          - topologyKey
+                                          - whenUnsatisfiable
+                                          properties:
+                                            labelSelector:
+                                              type: object
+                                              properties:
+                                                matchExpressions:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        type: array
+                                                        items:
+                                                          type: string
+                                                matchLabels:
+                                                  type: object
+                                                  additionalProperties:
+                                                    type: string
+                                            maxSkew:
+                                              type: integer
+                                              format: int32
+                                            topologyKey:
+                                              type: string
+                                            whenUnsatisfiable:
+                                              type: string
+                                      volumes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          required:
+                                          - name
+                                          properties:
+                                            awsElasticBlockStore:
+                                              type: object
+                                              required:
+                                              - volumeID
+                                              properties:
+                                                fsType:
+                                                  type: string
+                                                partition:
+                                                  type: integer
+                                                  format: int32
+                                                readOnly:
+                                                  type: boolean
+                                                volumeID:
+                                                  type: string
+                                            azureDisk:
+                                              type: object
+                                              required:
+                                              - diskName
+                                              - diskURI
+                                              properties:
+                                                cachingMode:
+                                                  type: string
+                                                diskName:
+                                                  type: string
+                                                diskURI:
+                                                  type: string
+                                                fsType:
+                                                  type: string
+                                                kind:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                            azureFile:
+                                              type: object
+                                              required:
+                                              - secretName
+                                              - shareName
+                                              properties:
+                                                readOnly:
+                                                  type: boolean
+                                                secretName:
+                                                  type: string
+                                                shareName:
+                                                  type: string
+                                            cephfs:
+                                              type: object
+                                              required:
+                                              - monitors
+                                              properties:
+                                                monitors:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                                path:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                                secretFile:
+                                                  type: string
+                                                secretRef:
+                                                  type: object
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                user:
+                                                  type: string
+                                            cinder:
+                                              type: object
+                                              required:
+                                              - volumeID
+                                              properties:
+                                                fsType:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                                secretRef:
+                                                  type: object
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                volumeID:
+                                                  type: string
+                                            configMap:
+                                              type: object
+                                              properties:
+                                                defaultMode:
+                                                  type: integer
+                                                  format: int32
+                                                items:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                    required:
+                                                    - key
+                                                    - path
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      mode:
+                                                        type: integer
+                                                        format: int32
+                                                      path:
+                                                        type: string
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                            csi:
+                                              type: object
+                                              required:
+                                              - driver
+                                              properties:
+                                                driver:
+                                                  type: string
+                                                fsType:
+                                                  type: string
+                                                nodePublishSecretRef:
+                                                  type: object
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                readOnly:
+                                                  type: boolean
+                                                volumeAttributes:
+                                                  type: object
+                                                  additionalProperties:
+                                                    type: string
+                                            downwardAPI:
+                                              type: object
+                                              properties:
+                                                defaultMode:
+                                                  type: integer
+                                                  format: int32
+                                                items:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                    required:
+                                                    - path
+                                                    properties:
+                                                      fieldRef:
+                                                        type: object
+                                                        required:
+                                                        - fieldPath
+                                                        properties:
+                                                          apiVersion:
+                                                            type: string
+                                                          fieldPath:
+                                                            type: string
+                                                      mode:
+                                                        type: integer
+                                                        format: int32
+                                                      path:
+                                                        type: string
+                                                      resourceFieldRef:
+                                                        type: object
+                                                        required:
+                                                        - resource
+                                                        properties:
+                                                          containerName:
+                                                            type: string
+                                                          divisor:
+                                                            type: string
+                                                          resource:
+                                                            type: string
+                                            emptyDir:
+                                              type: object
+                                              properties:
+                                                medium:
+                                                  type: string
+                                                sizeLimit:
+                                                  type: string
+                                            fc:
+                                              type: object
+                                              properties:
+                                                fsType:
+                                                  type: string
+                                                lun:
+                                                  type: integer
+                                                  format: int32
+                                                readOnly:
+                                                  type: boolean
+                                                targetWWNs:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                                wwids:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                            flexVolume:
+                                              type: object
+                                              required:
+                                              - driver
+                                              properties:
+                                                driver:
+                                                  type: string
+                                                fsType:
+                                                  type: string
+                                                options:
+                                                  type: object
+                                                  additionalProperties:
+                                                    type: string
+                                                readOnly:
+                                                  type: boolean
+                                                secretRef:
+                                                  type: object
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                            flocker:
+                                              type: object
+                                              properties:
+                                                datasetName:
+                                                  type: string
+                                                datasetUUID:
+                                                  type: string
+                                            gcePersistentDisk:
+                                              type: object
+                                              required:
+                                              - pdName
+                                              properties:
+                                                fsType:
+                                                  type: string
+                                                partition:
+                                                  type: integer
+                                                  format: int32
+                                                pdName:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                            gitRepo:
+                                              type: object
+                                              required:
+                                              - repository
+                                              properties:
+                                                directory:
+                                                  type: string
+                                                repository:
+                                                  type: string
+                                                revision:
+                                                  type: string
+                                            glusterfs:
+                                              type: object
+                                              required:
+                                              - endpoints
+                                              - path
+                                              properties:
+                                                endpoints:
+                                                  type: string
+                                                path:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                            hostPath:
+                                              type: object
+                                              required:
+                                              - path
+                                              properties:
+                                                path:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                            iscsi:
+                                              type: object
+                                              required:
+                                              - iqn
+                                              - lun
+                                              - targetPortal
+                                              properties:
+                                                chapAuthDiscovery:
+                                                  type: boolean
+                                                chapAuthSession:
+                                                  type: boolean
+                                                fsType:
+                                                  type: string
+                                                initiatorName:
+                                                  type: string
+                                                iqn:
+                                                  type: string
+                                                iscsiInterface:
+                                                  type: string
+                                                lun:
+                                                  type: integer
+                                                  format: int32
+                                                portals:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                                readOnly:
+                                                  type: boolean
+                                                secretRef:
+                                                  type: object
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                targetPortal:
+                                                  type: string
+                                            name:
+                                              type: string
+                                            nfs:
+                                              type: object
+                                              required:
+                                              - path
+                                              - server
+                                              properties:
+                                                path:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                                server:
+                                                  type: string
+                                            persistentVolumeClaim:
+                                              type: object
+                                              required:
+                                              - claimName
+                                              properties:
+                                                claimName:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                            photonPersistentDisk:
+                                              type: object
+                                              required:
+                                              - pdID
+                                              properties:
+                                                fsType:
+                                                  type: string
+                                                pdID:
+                                                  type: string
+                                            portworxVolume:
+                                              type: object
+                                              required:
+                                              - volumeID
+                                              properties:
+                                                fsType:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                                volumeID:
+                                                  type: string
+                                            projected:
+                                              type: object
+                                              required:
+                                              - sources
+                                              properties:
+                                                defaultMode:
+                                                  type: integer
+                                                  format: int32
+                                                sources:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                    properties:
+                                                      configMap:
+                                                        type: object
+                                                        properties:
+                                                          items:
+                                                            type: array
+                                                            items:
+                                                              type: object
+                                                              required:
+                                                              - key
+                                                              - path
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                mode:
+                                                                  type: integer
+                                                                  format: int32
+                                                                path:
+                                                                  type: string
+                                                          name:
+                                                            type: string
+                                                          optional:
+                                                            type: boolean
+                                                      downwardAPI:
+                                                        type: object
+                                                        properties:
+                                                          items:
+                                                            type: array
+                                                            items:
+                                                              type: object
+                                                              required:
+                                                              - path
+                                                              properties:
+                                                                fieldRef:
+                                                                  type: object
+                                                                  required:
+                                                                  - fieldPath
+                                                                  properties:
+                                                                    apiVersion:
+                                                                      type: string
+                                                                    fieldPath:
+                                                                      type: string
+                                                                mode:
+                                                                  type: integer
+                                                                  format: int32
+                                                                path:
+                                                                  type: string
+                                                                resourceFieldRef:
+                                                                  type: object
+                                                                  required:
+                                                                  - resource
+                                                                  properties:
+                                                                    containerName:
+                                                                      type: string
+                                                                    divisor:
+                                                                      type: string
+                                                                    resource:
+                                                                      type: string
+                                                      secret:
+                                                        type: object
+                                                        properties:
+                                                          items:
+                                                            type: array
+                                                            items:
+                                                              type: object
+                                                              required:
+                                                              - key
+                                                              - path
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                mode:
+                                                                  type: integer
+                                                                  format: int32
+                                                                path:
+                                                                  type: string
+                                                          name:
+                                                            type: string
+                                                          optional:
+                                                            type: boolean
+                                                      serviceAccountToken:
+                                                        type: object
+                                                        required:
+                                                        - path
+                                                        properties:
+                                                          audience:
+                                                            type: string
+                                                          expirationSeconds:
+                                                            type: integer
+                                                            format: int64
+                                                          path:
+                                                            type: string
+                                            quobyte:
+                                              type: object
+                                              required:
+                                              - registry
+                                              - volume
+                                              properties:
+                                                group:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                                registry:
+                                                  type: string
+                                                tenant:
+                                                  type: string
+                                                user:
+                                                  type: string
+                                                volume:
+                                                  type: string
+                                            rbd:
+                                              type: object
+                                              required:
+                                              - image
+                                              - monitors
+                                              properties:
+                                                fsType:
+                                                  type: string
+                                                image:
+                                                  type: string
+                                                keyring:
+                                                  type: string
+                                                monitors:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                                pool:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                                secretRef:
+                                                  type: object
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                user:
+                                                  type: string
+                                            scaleIO:
+                                              type: object
+                                              required:
+                                              - gateway
+                                              - secretRef
+                                              - system
+                                              properties:
+                                                fsType:
+                                                  type: string
+                                                gateway:
+                                                  type: string
+                                                protectionDomain:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                                secretRef:
+                                                  type: object
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                sslEnabled:
+                                                  type: boolean
+                                                storageMode:
+                                                  type: string
+                                                storagePool:
+                                                  type: string
+                                                system:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                            secret:
+                                              type: object
+                                              properties:
+                                                defaultMode:
+                                                  type: integer
+                                                  format: int32
+                                                items:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                    required:
+                                                    - key
+                                                    - path
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      mode:
+                                                        type: integer
+                                                        format: int32
+                                                      path:
+                                                        type: string
+                                                optional:
+                                                  type: boolean
+                                                secretName:
+                                                  type: string
+                                            storageos:
+                                              type: object
+                                              properties:
+                                                fsType:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                                secretRef:
+                                                  type: object
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                volumeName:
+                                                  type: string
+                                                volumeNamespace:
+                                                  type: string
+                                            vsphereVolume:
+                                              type: object
+                                              required:
+                                              - volumePath
+                                              properties:
+                                                fsType:
+                                                  type: string
+                                                storagePolicyID:
+                                                  type: string
+                                                storagePolicyName:
+                                                  type: string
+                                                volumePath:
+                                                  type: string
+                              ttlSecondsAfterFinished:
+                                type: integer
+                                format: int32
+                      readinessGates:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            apiVersion:
+                              type: string
+                            conditionTypes:
+                              type: array
+                              items:
+                                type: string
+                            failureThreshold:
+                              type: integer
+                              format: int32
+                            initialDelaySeconds:
+                              type: integer
+                              format: int32
+                            kind:
+                              type: string
+                            name:
+                              type: string
+                            periodSeconds:
+                              type: integer
+                              format: int32
+                            selector:
+                              type: object
+                              properties:
+                                matchExpressions:
+                                  type: array
+                                  items:
+                                    type: object
+                                    required:
+                                    - key
+                                    - operator
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  type: object
+                                  additionalProperties:
+                                    type: string
+                      selector:
+                        type: object
+                        properties:
+                          matchExpressions:
+                            type: array
+                            items:
+                              type: object
+                              required:
+                              - key
+                              - operator
+                              properties:
+                                key:
+                                  type: string
+                                operator:
+                                  type: string
+                                values:
+                                  type: array
+                                  items:
+                                    type: string
+                          matchLabels:
+                            type: object
+                            additionalProperties:
+                              type: string
+                      setupDefaultClusterRole:
+                        type: string
+                      setupDefaultRules:
+                        type: array
+                        items:
+                          type: object
+                          required:
+                          - verbs
+                          properties:
+                            apiGroups:
+                              type: array
+                              items:
+                                type: string
+                            nonResourceURLs:
+                              type: array
+                              items:
+                                type: string
+                            resourceNames:
+                              type: array
+                              items:
+                                type: string
+                            resources:
+                              type: array
+                              items:
+                                type: string
+                            verbs:
+                              type: array
+                              items:
+                                type: string
+                      setupServiceAccountName:
+                        type: string
+                      setupTasks:
+                        type: array
+                        items:
+                          type: object
+                          required:
+                          - name
+                          properties:
+                            helmChart:
+                              type: string
+                            helmChartVersion:
+                              type: string
+                            helmValues:
+                              type: array
+                              items:
+                                type: object
+                                required:
+                                - name
+                                properties:
+                                  forceString:
+                                    type: boolean
+                                  name:
+                                    type: string
+                                  value:
+                                    anyOf:
+                                    - type: string
+                                    - type: integer
+                                  valueFrom:
+                                    type: object
+                                    properties:
+                                      parameterRef:
+                                        type: object
+                                        required:
+                                        - name
+                                        properties:
+                                          name:
+                                            type: string
+                            helmValuesFrom:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  configMap:
+                                    type: object
+                                    properties:
+                                      name:
+                                        type: string
+                            image:
+                              type: string
+                            name:
+                              type: string
+                            skipCreate:
+                              type: boolean
+                            skipDelete:
+                              type: boolean
+                            volumeMounts:
+                              type: array
+                              items:
+                                type: object
+                                required:
+                                - mountPath
+                                - name
+                                properties:
+                                  mountPath:
+                                    type: string
+                                  mountPropagation:
+                                    type: string
+                                  name:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  subPath:
+                                    type: string
+                                  subPathExpr:
+                                    type: string
+                      setupVolumes:
+                        type: array
+                        items:
+                          type: object
+                          required:
+                          - name
+                          properties:
+                            awsElasticBlockStore:
+                              type: object
+                              required:
+                              - volumeID
+                              properties:
+                                fsType:
+                                  type: string
+                                partition:
+                                  type: integer
+                                  format: int32
+                                readOnly:
+                                  type: boolean
+                                volumeID:
+                                  type: string
+                            azureDisk:
+                              type: object
+                              required:
+                              - diskName
+                              - diskURI
+                              properties:
+                                cachingMode:
+                                  type: string
+                                diskName:
+                                  type: string
+                                diskURI:
+                                  type: string
+                                fsType:
+                                  type: string
+                                kind:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                            azureFile:
+                              type: object
+                              required:
+                              - secretName
+                              - shareName
+                              properties:
+                                readOnly:
+                                  type: boolean
+                                secretName:
+                                  type: string
+                                shareName:
+                                  type: string
+                            cephfs:
+                              type: object
+                              required:
+                              - monitors
+                              properties:
+                                monitors:
+                                  type: array
+                                  items:
+                                    type: string
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretFile:
+                                  type: string
+                                secretRef:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                user:
+                                  type: string
+                            cinder:
+                              type: object
+                              required:
+                              - volumeID
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                volumeID:
+                                  type: string
+                            configMap:
+                              type: object
+                              properties:
+                                defaultMode:
+                                  type: integer
+                                  format: int32
+                                items:
+                                  type: array
+                                  items:
+                                    type: object
+                                    required:
+                                    - key
+                                    - path
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        type: integer
+                                        format: int32
+                                      path:
+                                        type: string
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+                            csi:
+                              type: object
+                              required:
+                              - driver
+                              properties:
+                                driver:
+                                  type: string
+                                fsType:
+                                  type: string
+                                nodePublishSecretRef:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                readOnly:
+                                  type: boolean
+                                volumeAttributes:
+                                  type: object
+                                  additionalProperties:
+                                    type: string
+                            downwardAPI:
+                              type: object
+                              properties:
+                                defaultMode:
+                                  type: integer
+                                  format: int32
+                                items:
+                                  type: array
+                                  items:
+                                    type: object
+                                    required:
+                                    - path
+                                    properties:
+                                      fieldRef:
+                                        type: object
+                                        required:
+                                        - fieldPath
+                                        properties:
+                                          apiVersion:
+                                            type: string
+                                          fieldPath:
+                                            type: string
+                                      mode:
+                                        type: integer
+                                        format: int32
+                                      path:
+                                        type: string
+                                      resourceFieldRef:
+                                        type: object
+                                        required:
+                                        - resource
+                                        properties:
+                                          containerName:
+                                            type: string
+                                          divisor:
+                                            type: string
+                                          resource:
+                                            type: string
+                            emptyDir:
+                              type: object
+                              properties:
+                                medium:
+                                  type: string
+                                sizeLimit:
+                                  type: string
+                            fc:
+                              type: object
+                              properties:
+                                fsType:
+                                  type: string
+                                lun:
+                                  type: integer
+                                  format: int32
+                                readOnly:
+                                  type: boolean
+                                targetWWNs:
+                                  type: array
+                                  items:
+                                    type: string
+                                wwids:
+                                  type: array
+                                  items:
+                                    type: string
+                            flexVolume:
+                              type: object
+                              required:
+                              - driver
+                              properties:
+                                driver:
+                                  type: string
+                                fsType:
+                                  type: string
+                                options:
+                                  type: object
+                                  additionalProperties:
+                                    type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                            flocker:
+                              type: object
+                              properties:
+                                datasetName:
+                                  type: string
+                                datasetUUID:
+                                  type: string
+                            gcePersistentDisk:
+                              type: object
+                              required:
+                              - pdName
+                              properties:
+                                fsType:
+                                  type: string
+                                partition:
+                                  type: integer
+                                  format: int32
+                                pdName:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                            gitRepo:
+                              type: object
+                              required:
+                              - repository
+                              properties:
+                                directory:
+                                  type: string
+                                repository:
+                                  type: string
+                                revision:
+                                  type: string
+                            glusterfs:
+                              type: object
+                              required:
+                              - endpoints
+                              - path
+                              properties:
+                                endpoints:
+                                  type: string
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                            hostPath:
+                              type: object
+                              required:
+                              - path
+                              properties:
+                                path:
+                                  type: string
+                                type:
+                                  type: string
+                            iscsi:
+                              type: object
+                              required:
+                              - iqn
+                              - lun
+                              - targetPortal
+                              properties:
+                                chapAuthDiscovery:
+                                  type: boolean
+                                chapAuthSession:
+                                  type: boolean
+                                fsType:
+                                  type: string
+                                initiatorName:
+                                  type: string
+                                iqn:
+                                  type: string
+                                iscsiInterface:
+                                  type: string
+                                lun:
+                                  type: integer
+                                  format: int32
+                                portals:
+                                  type: array
+                                  items:
+                                    type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                targetPortal:
+                                  type: string
+                            name:
+                              type: string
+                            nfs:
+                              type: object
+                              required:
+                              - path
+                              - server
+                              properties:
+                                path:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                server:
+                                  type: string
+                            persistentVolumeClaim:
+                              type: object
+                              required:
+                              - claimName
+                              properties:
+                                claimName:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                            photonPersistentDisk:
+                              type: object
+                              required:
+                              - pdID
+                              properties:
+                                fsType:
+                                  type: string
+                                pdID:
+                                  type: string
+                            portworxVolume:
+                              type: object
+                              required:
+                              - volumeID
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                volumeID:
+                                  type: string
+                            projected:
+                              type: object
+                              required:
+                              - sources
+                              properties:
+                                defaultMode:
+                                  type: integer
+                                  format: int32
+                                sources:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      configMap:
+                                        type: object
+                                        properties:
+                                          items:
+                                            type: array
+                                            items:
+                                              type: object
+                                              required:
+                                              - key
+                                              - path
+                                              properties:
+                                                key:
+                                                  type: string
+                                                mode:
+                                                  type: integer
+                                                  format: int32
+                                                path:
+                                                  type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                      downwardAPI:
+                                        type: object
+                                        properties:
+                                          items:
+                                            type: array
+                                            items:
+                                              type: object
+                                              required:
+                                              - path
+                                              properties:
+                                                fieldRef:
+                                                  type: object
+                                                  required:
+                                                  - fieldPath
+                                                  properties:
+                                                    apiVersion:
+                                                      type: string
+                                                    fieldPath:
+                                                      type: string
+                                                mode:
+                                                  type: integer
+                                                  format: int32
+                                                path:
+                                                  type: string
+                                                resourceFieldRef:
+                                                  type: object
+                                                  required:
+                                                  - resource
+                                                  properties:
+                                                    containerName:
+                                                      type: string
+                                                    divisor:
+                                                      type: string
+                                                    resource:
+                                                      type: string
+                                      secret:
+                                        type: object
+                                        properties:
+                                          items:
+                                            type: array
+                                            items:
+                                              type: object
+                                              required:
+                                              - key
+                                              - path
+                                              properties:
+                                                key:
+                                                  type: string
+                                                mode:
+                                                  type: integer
+                                                  format: int32
+                                                path:
+                                                  type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                      serviceAccountToken:
+                                        type: object
+                                        required:
+                                        - path
+                                        properties:
+                                          audience:
+                                            type: string
+                                          expirationSeconds:
+                                            type: integer
+                                            format: int64
+                                          path:
+                                            type: string
+                            quobyte:
+                              type: object
+                              required:
+                              - registry
+                              - volume
+                              properties:
+                                group:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                registry:
+                                  type: string
+                                tenant:
+                                  type: string
+                                user:
+                                  type: string
+                                volume:
+                                  type: string
+                            rbd:
+                              type: object
+                              required:
+                              - image
+                              - monitors
+                              properties:
+                                fsType:
+                                  type: string
+                                image:
+                                  type: string
+                                keyring:
+                                  type: string
+                                monitors:
+                                  type: array
+                                  items:
+                                    type: string
+                                pool:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                user:
+                                  type: string
+                            scaleIO:
+                              type: object
+                              required:
+                              - gateway
+                              - secretRef
+                              - system
+                              properties:
+                                fsType:
+                                  type: string
+                                gateway:
+                                  type: string
+                                protectionDomain:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                sslEnabled:
+                                  type: boolean
+                                storageMode:
+                                  type: string
+                                storagePool:
+                                  type: string
+                                system:
+                                  type: string
+                                volumeName:
+                                  type: string
+                            secret:
+                              type: object
+                              properties:
+                                defaultMode:
+                                  type: integer
+                                  format: int32
+                                items:
+                                  type: array
+                                  items:
+                                    type: object
+                                    required:
+                                    - key
+                                    - path
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        type: integer
+                                        format: int32
+                                      path:
+                                        type: string
+                                optional:
+                                  type: boolean
+                                secretName:
+                                  type: string
+                            storageos:
+                              type: object
+                              properties:
+                                fsType:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                secretRef:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                volumeName:
+                                  type: string
+                                volumeNamespace:
+                                  type: string
+                            vsphereVolume:
+                              type: object
+                              required:
+                              - volumePath
+                              properties:
+                                fsType:
+                                  type: string
+                                storagePolicyID:
+                                  type: string
+                                storagePolicyName:
+                                  type: string
+                                volumePath:
+                                  type: string
+                      startTimeOffset:
+                        type: string
+                      ttlSecondsAfterFailure:
+                        type: integer
+                        format: int32
+                      ttlSecondsAfterFinished:
+                        type: integer
+                        format: int32
+                      values:
+                        type: array
+                        items:
+                          type: object
+                          required:
+                          - name
+                          - value
+                          properties:
+                            attemptsRemaining:
+                              type: integer
+                            error:
+                              type: string
+                            name:
+                              type: string
+                            value:
+                              type: string
+          status:
+            type: object
+            required:
+            - activeTrials
+            - phase
+            properties:
+              activeTrials:
+                type: integer
+                format: int32
+              phase:
+                type: string
 status:
   acceptedNames:
     kind: ""

--- a/config/crd/bases/redskyops.dev_trials.yaml
+++ b/config/crd/bases/redskyops.dev_trials.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -34,9 +32,7221 @@ spec:
   - name: v1alpha1
     served: true
     storage: false
+    "schema":
+      "openAPIV3Schema":
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            properties:
+              approximateRuntime:
+                type: string
+              assignments:
+                type: array
+                items:
+                  type: object
+                  required:
+                  - name
+                  - value
+                  properties:
+                    name:
+                      type: string
+                    value:
+                      type: integer
+                      format: int64
+              experimentRef:
+                type: object
+                properties:
+                  apiVersion:
+                    type: string
+                  fieldPath:
+                    type: string
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                  resourceVersion:
+                    type: string
+                  uid:
+                    type: string
+              initialDelaySeconds:
+                type: integer
+                format: int32
+              patchOperations:
+                type: array
+                items:
+                  type: object
+                  required:
+                  - data
+                  - patchType
+                  - targetRef
+                  properties:
+                    attemptsRemaining:
+                      type: integer
+                    data:
+                      type: string
+                      format: byte
+                    patchType:
+                      type: string
+                    targetRef:
+                      type: object
+                      properties:
+                        apiVersion:
+                          type: string
+                        fieldPath:
+                          type: string
+                        kind:
+                          type: string
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                        resourceVersion:
+                          type: string
+                        uid:
+                          type: string
+              readinessChecks:
+                type: array
+                items:
+                  type: object
+                  required:
+                  - targetRef
+                  properties:
+                    attemptsRemaining:
+                      type: integer
+                      format: int32
+                    conditionTypes:
+                      type: array
+                      items:
+                        type: string
+                    initialDelaySeconds:
+                      type: integer
+                      format: int32
+                    lastCheckTime:
+                      type: string
+                      format: date-time
+                    periodSeconds:
+                      type: integer
+                      format: int32
+                    selector:
+                      type: object
+                      properties:
+                        matchExpressions:
+                          type: array
+                          items:
+                            type: object
+                            required:
+                            - key
+                            - operator
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                type: string
+                              values:
+                                type: array
+                                items:
+                                  type: string
+                        matchLabels:
+                          type: object
+                          additionalProperties:
+                            type: string
+                    targetRef:
+                      type: object
+                      properties:
+                        apiVersion:
+                          type: string
+                        fieldPath:
+                          type: string
+                        kind:
+                          type: string
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                        resourceVersion:
+                          type: string
+                        uid:
+                          type: string
+              readinessGates:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    apiVersion:
+                      type: string
+                    conditionTypes:
+                      type: array
+                      items:
+                        type: string
+                    failureThreshold:
+                      type: integer
+                      format: int32
+                    initialDelaySeconds:
+                      type: integer
+                      format: int32
+                    kind:
+                      type: string
+                    name:
+                      type: string
+                    periodSeconds:
+                      type: integer
+                      format: int32
+                    selector:
+                      type: object
+                      properties:
+                        matchExpressions:
+                          type: array
+                          items:
+                            type: object
+                            required:
+                            - key
+                            - operator
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                type: string
+                              values:
+                                type: array
+                                items:
+                                  type: string
+                        matchLabels:
+                          type: object
+                          additionalProperties:
+                            type: string
+              selector:
+                type: object
+                properties:
+                  matchExpressions:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                      - key
+                      - operator
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          type: string
+                        values:
+                          type: array
+                          items:
+                            type: string
+                  matchLabels:
+                    type: object
+                    additionalProperties:
+                      type: string
+              setupDefaultClusterRole:
+                type: string
+              setupDefaultRules:
+                type: array
+                items:
+                  type: object
+                  required:
+                  - verbs
+                  properties:
+                    apiGroups:
+                      type: array
+                      items:
+                        type: string
+                    nonResourceURLs:
+                      type: array
+                      items:
+                        type: string
+                    resourceNames:
+                      type: array
+                      items:
+                        type: string
+                    resources:
+                      type: array
+                      items:
+                        type: string
+                    verbs:
+                      type: array
+                      items:
+                        type: string
+              setupServiceAccountName:
+                type: string
+              setupTasks:
+                type: array
+                items:
+                  type: object
+                  required:
+                  - name
+                  properties:
+                    helmChart:
+                      type: string
+                    helmChartVersion:
+                      type: string
+                    helmValues:
+                      type: array
+                      items:
+                        type: object
+                        required:
+                        - name
+                        properties:
+                          forceString:
+                            type: boolean
+                          name:
+                            type: string
+                          value:
+                            anyOf:
+                            - type: string
+                            - type: integer
+                          valueFrom:
+                            type: object
+                            properties:
+                              parameterRef:
+                                type: object
+                                required:
+                                - name
+                                properties:
+                                  name:
+                                    type: string
+                    helmValuesFrom:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          configMap:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                    image:
+                      type: string
+                    name:
+                      type: string
+                    skipCreate:
+                      type: boolean
+                    skipDelete:
+                      type: boolean
+                    volumeMounts:
+                      type: array
+                      items:
+                        type: object
+                        required:
+                        - mountPath
+                        - name
+                        properties:
+                          mountPath:
+                            type: string
+                          mountPropagation:
+                            type: string
+                          name:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          subPath:
+                            type: string
+                          subPathExpr:
+                            type: string
+              setupVolumes:
+                type: array
+                items:
+                  type: object
+                  required:
+                  - name
+                  properties:
+                    awsElasticBlockStore:
+                      type: object
+                      required:
+                      - volumeID
+                      properties:
+                        fsType:
+                          type: string
+                        partition:
+                          type: integer
+                          format: int32
+                        readOnly:
+                          type: boolean
+                        volumeID:
+                          type: string
+                    azureDisk:
+                      type: object
+                      required:
+                      - diskName
+                      - diskURI
+                      properties:
+                        cachingMode:
+                          type: string
+                        diskName:
+                          type: string
+                        diskURI:
+                          type: string
+                        fsType:
+                          type: string
+                        kind:
+                          type: string
+                        readOnly:
+                          type: boolean
+                    azureFile:
+                      type: object
+                      required:
+                      - secretName
+                      - shareName
+                      properties:
+                        readOnly:
+                          type: boolean
+                        secretName:
+                          type: string
+                        shareName:
+                          type: string
+                    cephfs:
+                      type: object
+                      required:
+                      - monitors
+                      properties:
+                        monitors:
+                          type: array
+                          items:
+                            type: string
+                        path:
+                          type: string
+                        readOnly:
+                          type: boolean
+                        secretFile:
+                          type: string
+                        secretRef:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                        user:
+                          type: string
+                    cinder:
+                      type: object
+                      required:
+                      - volumeID
+                      properties:
+                        fsType:
+                          type: string
+                        readOnly:
+                          type: boolean
+                        secretRef:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                        volumeID:
+                          type: string
+                    configMap:
+                      type: object
+                      properties:
+                        defaultMode:
+                          type: integer
+                          format: int32
+                        items:
+                          type: array
+                          items:
+                            type: object
+                            required:
+                            - key
+                            - path
+                            properties:
+                              key:
+                                type: string
+                              mode:
+                                type: integer
+                                format: int32
+                              path:
+                                type: string
+                        name:
+                          type: string
+                        optional:
+                          type: boolean
+                    csi:
+                      type: object
+                      required:
+                      - driver
+                      properties:
+                        driver:
+                          type: string
+                        fsType:
+                          type: string
+                        nodePublishSecretRef:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                        readOnly:
+                          type: boolean
+                        volumeAttributes:
+                          type: object
+                          additionalProperties:
+                            type: string
+                    downwardAPI:
+                      type: object
+                      properties:
+                        defaultMode:
+                          type: integer
+                          format: int32
+                        items:
+                          type: array
+                          items:
+                            type: object
+                            required:
+                            - path
+                            properties:
+                              fieldRef:
+                                type: object
+                                required:
+                                - fieldPath
+                                properties:
+                                  apiVersion:
+                                    type: string
+                                  fieldPath:
+                                    type: string
+                              mode:
+                                type: integer
+                                format: int32
+                              path:
+                                type: string
+                              resourceFieldRef:
+                                type: object
+                                required:
+                                - resource
+                                properties:
+                                  containerName:
+                                    type: string
+                                  divisor:
+                                    type: string
+                                  resource:
+                                    type: string
+                    emptyDir:
+                      type: object
+                      properties:
+                        medium:
+                          type: string
+                        sizeLimit:
+                          type: string
+                    fc:
+                      type: object
+                      properties:
+                        fsType:
+                          type: string
+                        lun:
+                          type: integer
+                          format: int32
+                        readOnly:
+                          type: boolean
+                        targetWWNs:
+                          type: array
+                          items:
+                            type: string
+                        wwids:
+                          type: array
+                          items:
+                            type: string
+                    flexVolume:
+                      type: object
+                      required:
+                      - driver
+                      properties:
+                        driver:
+                          type: string
+                        fsType:
+                          type: string
+                        options:
+                          type: object
+                          additionalProperties:
+                            type: string
+                        readOnly:
+                          type: boolean
+                        secretRef:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                    flocker:
+                      type: object
+                      properties:
+                        datasetName:
+                          type: string
+                        datasetUUID:
+                          type: string
+                    gcePersistentDisk:
+                      type: object
+                      required:
+                      - pdName
+                      properties:
+                        fsType:
+                          type: string
+                        partition:
+                          type: integer
+                          format: int32
+                        pdName:
+                          type: string
+                        readOnly:
+                          type: boolean
+                    gitRepo:
+                      type: object
+                      required:
+                      - repository
+                      properties:
+                        directory:
+                          type: string
+                        repository:
+                          type: string
+                        revision:
+                          type: string
+                    glusterfs:
+                      type: object
+                      required:
+                      - endpoints
+                      - path
+                      properties:
+                        endpoints:
+                          type: string
+                        path:
+                          type: string
+                        readOnly:
+                          type: boolean
+                    hostPath:
+                      type: object
+                      required:
+                      - path
+                      properties:
+                        path:
+                          type: string
+                        type:
+                          type: string
+                    iscsi:
+                      type: object
+                      required:
+                      - iqn
+                      - lun
+                      - targetPortal
+                      properties:
+                        chapAuthDiscovery:
+                          type: boolean
+                        chapAuthSession:
+                          type: boolean
+                        fsType:
+                          type: string
+                        initiatorName:
+                          type: string
+                        iqn:
+                          type: string
+                        iscsiInterface:
+                          type: string
+                        lun:
+                          type: integer
+                          format: int32
+                        portals:
+                          type: array
+                          items:
+                            type: string
+                        readOnly:
+                          type: boolean
+                        secretRef:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                        targetPortal:
+                          type: string
+                    name:
+                      type: string
+                    nfs:
+                      type: object
+                      required:
+                      - path
+                      - server
+                      properties:
+                        path:
+                          type: string
+                        readOnly:
+                          type: boolean
+                        server:
+                          type: string
+                    persistentVolumeClaim:
+                      type: object
+                      required:
+                      - claimName
+                      properties:
+                        claimName:
+                          type: string
+                        readOnly:
+                          type: boolean
+                    photonPersistentDisk:
+                      type: object
+                      required:
+                      - pdID
+                      properties:
+                        fsType:
+                          type: string
+                        pdID:
+                          type: string
+                    portworxVolume:
+                      type: object
+                      required:
+                      - volumeID
+                      properties:
+                        fsType:
+                          type: string
+                        readOnly:
+                          type: boolean
+                        volumeID:
+                          type: string
+                    projected:
+                      type: object
+                      required:
+                      - sources
+                      properties:
+                        defaultMode:
+                          type: integer
+                          format: int32
+                        sources:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              configMap:
+                                type: object
+                                properties:
+                                  items:
+                                    type: array
+                                    items:
+                                      type: object
+                                      required:
+                                      - key
+                                      - path
+                                      properties:
+                                        key:
+                                          type: string
+                                        mode:
+                                          type: integer
+                                          format: int32
+                                        path:
+                                          type: string
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                              downwardAPI:
+                                type: object
+                                properties:
+                                  items:
+                                    type: array
+                                    items:
+                                      type: object
+                                      required:
+                                      - path
+                                      properties:
+                                        fieldRef:
+                                          type: object
+                                          required:
+                                          - fieldPath
+                                          properties:
+                                            apiVersion:
+                                              type: string
+                                            fieldPath:
+                                              type: string
+                                        mode:
+                                          type: integer
+                                          format: int32
+                                        path:
+                                          type: string
+                                        resourceFieldRef:
+                                          type: object
+                                          required:
+                                          - resource
+                                          properties:
+                                            containerName:
+                                              type: string
+                                            divisor:
+                                              type: string
+                                            resource:
+                                              type: string
+                              secret:
+                                type: object
+                                properties:
+                                  items:
+                                    type: array
+                                    items:
+                                      type: object
+                                      required:
+                                      - key
+                                      - path
+                                      properties:
+                                        key:
+                                          type: string
+                                        mode:
+                                          type: integer
+                                          format: int32
+                                        path:
+                                          type: string
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                              serviceAccountToken:
+                                type: object
+                                required:
+                                - path
+                                properties:
+                                  audience:
+                                    type: string
+                                  expirationSeconds:
+                                    type: integer
+                                    format: int64
+                                  path:
+                                    type: string
+                    quobyte:
+                      type: object
+                      required:
+                      - registry
+                      - volume
+                      properties:
+                        group:
+                          type: string
+                        readOnly:
+                          type: boolean
+                        registry:
+                          type: string
+                        tenant:
+                          type: string
+                        user:
+                          type: string
+                        volume:
+                          type: string
+                    rbd:
+                      type: object
+                      required:
+                      - image
+                      - monitors
+                      properties:
+                        fsType:
+                          type: string
+                        image:
+                          type: string
+                        keyring:
+                          type: string
+                        monitors:
+                          type: array
+                          items:
+                            type: string
+                        pool:
+                          type: string
+                        readOnly:
+                          type: boolean
+                        secretRef:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                        user:
+                          type: string
+                    scaleIO:
+                      type: object
+                      required:
+                      - gateway
+                      - secretRef
+                      - system
+                      properties:
+                        fsType:
+                          type: string
+                        gateway:
+                          type: string
+                        protectionDomain:
+                          type: string
+                        readOnly:
+                          type: boolean
+                        secretRef:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                        sslEnabled:
+                          type: boolean
+                        storageMode:
+                          type: string
+                        storagePool:
+                          type: string
+                        system:
+                          type: string
+                        volumeName:
+                          type: string
+                    secret:
+                      type: object
+                      properties:
+                        defaultMode:
+                          type: integer
+                          format: int32
+                        items:
+                          type: array
+                          items:
+                            type: object
+                            required:
+                            - key
+                            - path
+                            properties:
+                              key:
+                                type: string
+                              mode:
+                                type: integer
+                                format: int32
+                              path:
+                                type: string
+                        optional:
+                          type: boolean
+                        secretName:
+                          type: string
+                    storageos:
+                      type: object
+                      properties:
+                        fsType:
+                          type: string
+                        readOnly:
+                          type: boolean
+                        secretRef:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                        volumeName:
+                          type: string
+                        volumeNamespace:
+                          type: string
+                    vsphereVolume:
+                      type: object
+                      required:
+                      - volumePath
+                      properties:
+                        fsType:
+                          type: string
+                        storagePolicyID:
+                          type: string
+                        storagePolicyName:
+                          type: string
+                        volumePath:
+                          type: string
+              startTimeOffset:
+                type: string
+              template:
+                type: object
+                properties:
+                  metadata:
+                    type: object
+                  spec:
+                    type: object
+                    required:
+                    - template
+                    properties:
+                      activeDeadlineSeconds:
+                        type: integer
+                        format: int64
+                      backoffLimit:
+                        type: integer
+                        format: int32
+                      completions:
+                        type: integer
+                        format: int32
+                      manualSelector:
+                        type: boolean
+                      parallelism:
+                        type: integer
+                        format: int32
+                      selector:
+                        type: object
+                        properties:
+                          matchExpressions:
+                            type: array
+                            items:
+                              type: object
+                              required:
+                              - key
+                              - operator
+                              properties:
+                                key:
+                                  type: string
+                                operator:
+                                  type: string
+                                values:
+                                  type: array
+                                  items:
+                                    type: string
+                          matchLabels:
+                            type: object
+                            additionalProperties:
+                              type: string
+                      template:
+                        type: object
+                        properties:
+                          metadata:
+                            type: object
+                          spec:
+                            type: object
+                            required:
+                            - containers
+                            properties:
+                              activeDeadlineSeconds:
+                                type: integer
+                                format: int64
+                              affinity:
+                                type: object
+                                properties:
+                                  nodeAffinity:
+                                    type: object
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        type: array
+                                        items:
+                                          type: object
+                                          required:
+                                          - preference
+                                          - weight
+                                          properties:
+                                            preference:
+                                              type: object
+                                              properties:
+                                                matchExpressions:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        type: array
+                                                        items:
+                                                          type: string
+                                                matchFields:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        type: array
+                                                        items:
+                                                          type: string
+                                            weight:
+                                              type: integer
+                                              format: int32
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        type: object
+                                        required:
+                                        - nodeSelectorTerms
+                                        properties:
+                                          nodeSelectorTerms:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                matchExpressions:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        type: array
+                                                        items:
+                                                          type: string
+                                                matchFields:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        type: array
+                                                        items:
+                                                          type: string
+                                  podAffinity:
+                                    type: object
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        type: array
+                                        items:
+                                          type: object
+                                          required:
+                                          - podAffinityTerm
+                                          - weight
+                                          properties:
+                                            podAffinityTerm:
+                                              type: object
+                                              required:
+                                              - topologyKey
+                                              properties:
+                                                labelSelector:
+                                                  type: object
+                                                  properties:
+                                                    matchExpressions:
+                                                      type: array
+                                                      items:
+                                                        type: object
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            type: array
+                                                            items:
+                                                              type: string
+                                                    matchLabels:
+                                                      type: object
+                                                      additionalProperties:
+                                                        type: string
+                                                namespaces:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                                topologyKey:
+                                                  type: string
+                                            weight:
+                                              type: integer
+                                              format: int32
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        type: array
+                                        items:
+                                          type: object
+                                          required:
+                                          - topologyKey
+                                          properties:
+                                            labelSelector:
+                                              type: object
+                                              properties:
+                                                matchExpressions:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        type: array
+                                                        items:
+                                                          type: string
+                                                matchLabels:
+                                                  type: object
+                                                  additionalProperties:
+                                                    type: string
+                                            namespaces:
+                                              type: array
+                                              items:
+                                                type: string
+                                            topologyKey:
+                                              type: string
+                                  podAntiAffinity:
+                                    type: object
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        type: array
+                                        items:
+                                          type: object
+                                          required:
+                                          - podAffinityTerm
+                                          - weight
+                                          properties:
+                                            podAffinityTerm:
+                                              type: object
+                                              required:
+                                              - topologyKey
+                                              properties:
+                                                labelSelector:
+                                                  type: object
+                                                  properties:
+                                                    matchExpressions:
+                                                      type: array
+                                                      items:
+                                                        type: object
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            type: array
+                                                            items:
+                                                              type: string
+                                                    matchLabels:
+                                                      type: object
+                                                      additionalProperties:
+                                                        type: string
+                                                namespaces:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                                topologyKey:
+                                                  type: string
+                                            weight:
+                                              type: integer
+                                              format: int32
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        type: array
+                                        items:
+                                          type: object
+                                          required:
+                                          - topologyKey
+                                          properties:
+                                            labelSelector:
+                                              type: object
+                                              properties:
+                                                matchExpressions:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        type: array
+                                                        items:
+                                                          type: string
+                                                matchLabels:
+                                                  type: object
+                                                  additionalProperties:
+                                                    type: string
+                                            namespaces:
+                                              type: array
+                                              items:
+                                                type: string
+                                            topologyKey:
+                                              type: string
+                              automountServiceAccountToken:
+                                type: boolean
+                              containers:
+                                type: array
+                                items:
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    args:
+                                      type: array
+                                      items:
+                                        type: string
+                                    command:
+                                      type: array
+                                      items:
+                                        type: string
+                                    env:
+                                      type: array
+                                      items:
+                                        type: object
+                                        required:
+                                        - name
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                          valueFrom:
+                                            type: object
+                                            properties:
+                                              configMapKeyRef:
+                                                type: object
+                                                required:
+                                                - key
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                              fieldRef:
+                                                type: object
+                                                required:
+                                                - fieldPath
+                                                properties:
+                                                  apiVersion:
+                                                    type: string
+                                                  fieldPath:
+                                                    type: string
+                                              resourceFieldRef:
+                                                type: object
+                                                required:
+                                                - resource
+                                                properties:
+                                                  containerName:
+                                                    type: string
+                                                  divisor:
+                                                    type: string
+                                                  resource:
+                                                    type: string
+                                              secretKeyRef:
+                                                type: object
+                                                required:
+                                                - key
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                    envFrom:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          configMapRef:
+                                            type: object
+                                            properties:
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                          prefix:
+                                            type: string
+                                          secretRef:
+                                            type: object
+                                            properties:
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                    image:
+                                      type: string
+                                    imagePullPolicy:
+                                      type: string
+                                    lifecycle:
+                                      type: object
+                                      properties:
+                                        postStart:
+                                          type: object
+                                          properties:
+                                            exec:
+                                              type: object
+                                              properties:
+                                                command:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                            httpGet:
+                                              type: object
+                                              required:
+                                              - port
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: string
+                                                  - type: integer
+                                                scheme:
+                                                  type: string
+                                            tcpSocket:
+                                              type: object
+                                              required:
+                                              - port
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: string
+                                                  - type: integer
+                                        preStop:
+                                          type: object
+                                          properties:
+                                            exec:
+                                              type: object
+                                              properties:
+                                                command:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                            httpGet:
+                                              type: object
+                                              required:
+                                              - port
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: string
+                                                  - type: integer
+                                                scheme:
+                                                  type: string
+                                            tcpSocket:
+                                              type: object
+                                              required:
+                                              - port
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: string
+                                                  - type: integer
+                                    livenessProbe:
+                                      type: object
+                                      properties:
+                                        exec:
+                                          type: object
+                                          properties:
+                                            command:
+                                              type: array
+                                              items:
+                                                type: string
+                                        failureThreshold:
+                                          type: integer
+                                          format: int32
+                                        httpGet:
+                                          type: object
+                                          required:
+                                          - port
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              type: array
+                                              items:
+                                                type: object
+                                                required:
+                                                - name
+                                                - value
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                            scheme:
+                                              type: string
+                                        initialDelaySeconds:
+                                          type: integer
+                                          format: int32
+                                        periodSeconds:
+                                          type: integer
+                                          format: int32
+                                        successThreshold:
+                                          type: integer
+                                          format: int32
+                                        tcpSocket:
+                                          type: object
+                                          required:
+                                          - port
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                        timeoutSeconds:
+                                          type: integer
+                                          format: int32
+                                    name:
+                                      type: string
+                                    ports:
+                                      type: array
+                                      items:
+                                        type: object
+                                        required:
+                                        - containerPort
+                                        properties:
+                                          containerPort:
+                                            type: integer
+                                            format: int32
+                                          hostIP:
+                                            type: string
+                                          hostPort:
+                                            type: integer
+                                            format: int32
+                                          name:
+                                            type: string
+                                          protocol:
+                                            type: string
+                                    readinessProbe:
+                                      type: object
+                                      properties:
+                                        exec:
+                                          type: object
+                                          properties:
+                                            command:
+                                              type: array
+                                              items:
+                                                type: string
+                                        failureThreshold:
+                                          type: integer
+                                          format: int32
+                                        httpGet:
+                                          type: object
+                                          required:
+                                          - port
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              type: array
+                                              items:
+                                                type: object
+                                                required:
+                                                - name
+                                                - value
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                            scheme:
+                                              type: string
+                                        initialDelaySeconds:
+                                          type: integer
+                                          format: int32
+                                        periodSeconds:
+                                          type: integer
+                                          format: int32
+                                        successThreshold:
+                                          type: integer
+                                          format: int32
+                                        tcpSocket:
+                                          type: object
+                                          required:
+                                          - port
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                        timeoutSeconds:
+                                          type: integer
+                                          format: int32
+                                    resources:
+                                      type: object
+                                      properties:
+                                        limits:
+                                          type: object
+                                          additionalProperties:
+                                            type: string
+                                        requests:
+                                          type: object
+                                          additionalProperties:
+                                            type: string
+                                    securityContext:
+                                      type: object
+                                      properties:
+                                        allowPrivilegeEscalation:
+                                          type: boolean
+                                        capabilities:
+                                          type: object
+                                          properties:
+                                            add:
+                                              type: array
+                                              items:
+                                                type: string
+                                            drop:
+                                              type: array
+                                              items:
+                                                type: string
+                                        privileged:
+                                          type: boolean
+                                        procMount:
+                                          type: string
+                                        readOnlyRootFilesystem:
+                                          type: boolean
+                                        runAsGroup:
+                                          type: integer
+                                          format: int64
+                                        runAsNonRoot:
+                                          type: boolean
+                                        runAsUser:
+                                          type: integer
+                                          format: int64
+                                        seLinuxOptions:
+                                          type: object
+                                          properties:
+                                            level:
+                                              type: string
+                                            role:
+                                              type: string
+                                            type:
+                                              type: string
+                                            user:
+                                              type: string
+                                        windowsOptions:
+                                          type: object
+                                          properties:
+                                            gmsaCredentialSpec:
+                                              type: string
+                                            gmsaCredentialSpecName:
+                                              type: string
+                                            runAsUserName:
+                                              type: string
+                                    startupProbe:
+                                      type: object
+                                      properties:
+                                        exec:
+                                          type: object
+                                          properties:
+                                            command:
+                                              type: array
+                                              items:
+                                                type: string
+                                        failureThreshold:
+                                          type: integer
+                                          format: int32
+                                        httpGet:
+                                          type: object
+                                          required:
+                                          - port
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              type: array
+                                              items:
+                                                type: object
+                                                required:
+                                                - name
+                                                - value
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                            scheme:
+                                              type: string
+                                        initialDelaySeconds:
+                                          type: integer
+                                          format: int32
+                                        periodSeconds:
+                                          type: integer
+                                          format: int32
+                                        successThreshold:
+                                          type: integer
+                                          format: int32
+                                        tcpSocket:
+                                          type: object
+                                          required:
+                                          - port
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                        timeoutSeconds:
+                                          type: integer
+                                          format: int32
+                                    stdin:
+                                      type: boolean
+                                    stdinOnce:
+                                      type: boolean
+                                    terminationMessagePath:
+                                      type: string
+                                    terminationMessagePolicy:
+                                      type: string
+                                    tty:
+                                      type: boolean
+                                    volumeDevices:
+                                      type: array
+                                      items:
+                                        type: object
+                                        required:
+                                        - devicePath
+                                        - name
+                                        properties:
+                                          devicePath:
+                                            type: string
+                                          name:
+                                            type: string
+                                    volumeMounts:
+                                      type: array
+                                      items:
+                                        type: object
+                                        required:
+                                        - mountPath
+                                        - name
+                                        properties:
+                                          mountPath:
+                                            type: string
+                                          mountPropagation:
+                                            type: string
+                                          name:
+                                            type: string
+                                          readOnly:
+                                            type: boolean
+                                          subPath:
+                                            type: string
+                                          subPathExpr:
+                                            type: string
+                                    workingDir:
+                                      type: string
+                              dnsConfig:
+                                type: object
+                                properties:
+                                  nameservers:
+                                    type: array
+                                    items:
+                                      type: string
+                                  options:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                  searches:
+                                    type: array
+                                    items:
+                                      type: string
+                              dnsPolicy:
+                                type: string
+                              enableServiceLinks:
+                                type: boolean
+                              ephemeralContainers:
+                                type: array
+                                items:
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    args:
+                                      type: array
+                                      items:
+                                        type: string
+                                    command:
+                                      type: array
+                                      items:
+                                        type: string
+                                    env:
+                                      type: array
+                                      items:
+                                        type: object
+                                        required:
+                                        - name
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                          valueFrom:
+                                            type: object
+                                            properties:
+                                              configMapKeyRef:
+                                                type: object
+                                                required:
+                                                - key
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                              fieldRef:
+                                                type: object
+                                                required:
+                                                - fieldPath
+                                                properties:
+                                                  apiVersion:
+                                                    type: string
+                                                  fieldPath:
+                                                    type: string
+                                              resourceFieldRef:
+                                                type: object
+                                                required:
+                                                - resource
+                                                properties:
+                                                  containerName:
+                                                    type: string
+                                                  divisor:
+                                                    type: string
+                                                  resource:
+                                                    type: string
+                                              secretKeyRef:
+                                                type: object
+                                                required:
+                                                - key
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                    envFrom:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          configMapRef:
+                                            type: object
+                                            properties:
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                          prefix:
+                                            type: string
+                                          secretRef:
+                                            type: object
+                                            properties:
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                    image:
+                                      type: string
+                                    imagePullPolicy:
+                                      type: string
+                                    lifecycle:
+                                      type: object
+                                      properties:
+                                        postStart:
+                                          type: object
+                                          properties:
+                                            exec:
+                                              type: object
+                                              properties:
+                                                command:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                            httpGet:
+                                              type: object
+                                              required:
+                                              - port
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: string
+                                                  - type: integer
+                                                scheme:
+                                                  type: string
+                                            tcpSocket:
+                                              type: object
+                                              required:
+                                              - port
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: string
+                                                  - type: integer
+                                        preStop:
+                                          type: object
+                                          properties:
+                                            exec:
+                                              type: object
+                                              properties:
+                                                command:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                            httpGet:
+                                              type: object
+                                              required:
+                                              - port
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: string
+                                                  - type: integer
+                                                scheme:
+                                                  type: string
+                                            tcpSocket:
+                                              type: object
+                                              required:
+                                              - port
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: string
+                                                  - type: integer
+                                    livenessProbe:
+                                      type: object
+                                      properties:
+                                        exec:
+                                          type: object
+                                          properties:
+                                            command:
+                                              type: array
+                                              items:
+                                                type: string
+                                        failureThreshold:
+                                          type: integer
+                                          format: int32
+                                        httpGet:
+                                          type: object
+                                          required:
+                                          - port
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              type: array
+                                              items:
+                                                type: object
+                                                required:
+                                                - name
+                                                - value
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                            scheme:
+                                              type: string
+                                        initialDelaySeconds:
+                                          type: integer
+                                          format: int32
+                                        periodSeconds:
+                                          type: integer
+                                          format: int32
+                                        successThreshold:
+                                          type: integer
+                                          format: int32
+                                        tcpSocket:
+                                          type: object
+                                          required:
+                                          - port
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                        timeoutSeconds:
+                                          type: integer
+                                          format: int32
+                                    name:
+                                      type: string
+                                    ports:
+                                      type: array
+                                      items:
+                                        type: object
+                                        required:
+                                        - containerPort
+                                        properties:
+                                          containerPort:
+                                            type: integer
+                                            format: int32
+                                          hostIP:
+                                            type: string
+                                          hostPort:
+                                            type: integer
+                                            format: int32
+                                          name:
+                                            type: string
+                                          protocol:
+                                            type: string
+                                    readinessProbe:
+                                      type: object
+                                      properties:
+                                        exec:
+                                          type: object
+                                          properties:
+                                            command:
+                                              type: array
+                                              items:
+                                                type: string
+                                        failureThreshold:
+                                          type: integer
+                                          format: int32
+                                        httpGet:
+                                          type: object
+                                          required:
+                                          - port
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              type: array
+                                              items:
+                                                type: object
+                                                required:
+                                                - name
+                                                - value
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                            scheme:
+                                              type: string
+                                        initialDelaySeconds:
+                                          type: integer
+                                          format: int32
+                                        periodSeconds:
+                                          type: integer
+                                          format: int32
+                                        successThreshold:
+                                          type: integer
+                                          format: int32
+                                        tcpSocket:
+                                          type: object
+                                          required:
+                                          - port
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                        timeoutSeconds:
+                                          type: integer
+                                          format: int32
+                                    resources:
+                                      type: object
+                                      properties:
+                                        limits:
+                                          type: object
+                                          additionalProperties:
+                                            type: string
+                                        requests:
+                                          type: object
+                                          additionalProperties:
+                                            type: string
+                                    securityContext:
+                                      type: object
+                                      properties:
+                                        allowPrivilegeEscalation:
+                                          type: boolean
+                                        capabilities:
+                                          type: object
+                                          properties:
+                                            add:
+                                              type: array
+                                              items:
+                                                type: string
+                                            drop:
+                                              type: array
+                                              items:
+                                                type: string
+                                        privileged:
+                                          type: boolean
+                                        procMount:
+                                          type: string
+                                        readOnlyRootFilesystem:
+                                          type: boolean
+                                        runAsGroup:
+                                          type: integer
+                                          format: int64
+                                        runAsNonRoot:
+                                          type: boolean
+                                        runAsUser:
+                                          type: integer
+                                          format: int64
+                                        seLinuxOptions:
+                                          type: object
+                                          properties:
+                                            level:
+                                              type: string
+                                            role:
+                                              type: string
+                                            type:
+                                              type: string
+                                            user:
+                                              type: string
+                                        windowsOptions:
+                                          type: object
+                                          properties:
+                                            gmsaCredentialSpec:
+                                              type: string
+                                            gmsaCredentialSpecName:
+                                              type: string
+                                            runAsUserName:
+                                              type: string
+                                    startupProbe:
+                                      type: object
+                                      properties:
+                                        exec:
+                                          type: object
+                                          properties:
+                                            command:
+                                              type: array
+                                              items:
+                                                type: string
+                                        failureThreshold:
+                                          type: integer
+                                          format: int32
+                                        httpGet:
+                                          type: object
+                                          required:
+                                          - port
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              type: array
+                                              items:
+                                                type: object
+                                                required:
+                                                - name
+                                                - value
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                            scheme:
+                                              type: string
+                                        initialDelaySeconds:
+                                          type: integer
+                                          format: int32
+                                        periodSeconds:
+                                          type: integer
+                                          format: int32
+                                        successThreshold:
+                                          type: integer
+                                          format: int32
+                                        tcpSocket:
+                                          type: object
+                                          required:
+                                          - port
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                        timeoutSeconds:
+                                          type: integer
+                                          format: int32
+                                    stdin:
+                                      type: boolean
+                                    stdinOnce:
+                                      type: boolean
+                                    targetContainerName:
+                                      type: string
+                                    terminationMessagePath:
+                                      type: string
+                                    terminationMessagePolicy:
+                                      type: string
+                                    tty:
+                                      type: boolean
+                                    volumeDevices:
+                                      type: array
+                                      items:
+                                        type: object
+                                        required:
+                                        - devicePath
+                                        - name
+                                        properties:
+                                          devicePath:
+                                            type: string
+                                          name:
+                                            type: string
+                                    volumeMounts:
+                                      type: array
+                                      items:
+                                        type: object
+                                        required:
+                                        - mountPath
+                                        - name
+                                        properties:
+                                          mountPath:
+                                            type: string
+                                          mountPropagation:
+                                            type: string
+                                          name:
+                                            type: string
+                                          readOnly:
+                                            type: boolean
+                                          subPath:
+                                            type: string
+                                          subPathExpr:
+                                            type: string
+                                    workingDir:
+                                      type: string
+                              hostAliases:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    hostnames:
+                                      type: array
+                                      items:
+                                        type: string
+                                    ip:
+                                      type: string
+                              hostIPC:
+                                type: boolean
+                              hostNetwork:
+                                type: boolean
+                              hostPID:
+                                type: boolean
+                              hostname:
+                                type: string
+                              imagePullSecrets:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                              initContainers:
+                                type: array
+                                items:
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    args:
+                                      type: array
+                                      items:
+                                        type: string
+                                    command:
+                                      type: array
+                                      items:
+                                        type: string
+                                    env:
+                                      type: array
+                                      items:
+                                        type: object
+                                        required:
+                                        - name
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                          valueFrom:
+                                            type: object
+                                            properties:
+                                              configMapKeyRef:
+                                                type: object
+                                                required:
+                                                - key
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                              fieldRef:
+                                                type: object
+                                                required:
+                                                - fieldPath
+                                                properties:
+                                                  apiVersion:
+                                                    type: string
+                                                  fieldPath:
+                                                    type: string
+                                              resourceFieldRef:
+                                                type: object
+                                                required:
+                                                - resource
+                                                properties:
+                                                  containerName:
+                                                    type: string
+                                                  divisor:
+                                                    type: string
+                                                  resource:
+                                                    type: string
+                                              secretKeyRef:
+                                                type: object
+                                                required:
+                                                - key
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                    envFrom:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          configMapRef:
+                                            type: object
+                                            properties:
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                          prefix:
+                                            type: string
+                                          secretRef:
+                                            type: object
+                                            properties:
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                    image:
+                                      type: string
+                                    imagePullPolicy:
+                                      type: string
+                                    lifecycle:
+                                      type: object
+                                      properties:
+                                        postStart:
+                                          type: object
+                                          properties:
+                                            exec:
+                                              type: object
+                                              properties:
+                                                command:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                            httpGet:
+                                              type: object
+                                              required:
+                                              - port
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: string
+                                                  - type: integer
+                                                scheme:
+                                                  type: string
+                                            tcpSocket:
+                                              type: object
+                                              required:
+                                              - port
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: string
+                                                  - type: integer
+                                        preStop:
+                                          type: object
+                                          properties:
+                                            exec:
+                                              type: object
+                                              properties:
+                                                command:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                            httpGet:
+                                              type: object
+                                              required:
+                                              - port
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: string
+                                                  - type: integer
+                                                scheme:
+                                                  type: string
+                                            tcpSocket:
+                                              type: object
+                                              required:
+                                              - port
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: string
+                                                  - type: integer
+                                    livenessProbe:
+                                      type: object
+                                      properties:
+                                        exec:
+                                          type: object
+                                          properties:
+                                            command:
+                                              type: array
+                                              items:
+                                                type: string
+                                        failureThreshold:
+                                          type: integer
+                                          format: int32
+                                        httpGet:
+                                          type: object
+                                          required:
+                                          - port
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              type: array
+                                              items:
+                                                type: object
+                                                required:
+                                                - name
+                                                - value
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                            scheme:
+                                              type: string
+                                        initialDelaySeconds:
+                                          type: integer
+                                          format: int32
+                                        periodSeconds:
+                                          type: integer
+                                          format: int32
+                                        successThreshold:
+                                          type: integer
+                                          format: int32
+                                        tcpSocket:
+                                          type: object
+                                          required:
+                                          - port
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                        timeoutSeconds:
+                                          type: integer
+                                          format: int32
+                                    name:
+                                      type: string
+                                    ports:
+                                      type: array
+                                      items:
+                                        type: object
+                                        required:
+                                        - containerPort
+                                        properties:
+                                          containerPort:
+                                            type: integer
+                                            format: int32
+                                          hostIP:
+                                            type: string
+                                          hostPort:
+                                            type: integer
+                                            format: int32
+                                          name:
+                                            type: string
+                                          protocol:
+                                            type: string
+                                    readinessProbe:
+                                      type: object
+                                      properties:
+                                        exec:
+                                          type: object
+                                          properties:
+                                            command:
+                                              type: array
+                                              items:
+                                                type: string
+                                        failureThreshold:
+                                          type: integer
+                                          format: int32
+                                        httpGet:
+                                          type: object
+                                          required:
+                                          - port
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              type: array
+                                              items:
+                                                type: object
+                                                required:
+                                                - name
+                                                - value
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                            scheme:
+                                              type: string
+                                        initialDelaySeconds:
+                                          type: integer
+                                          format: int32
+                                        periodSeconds:
+                                          type: integer
+                                          format: int32
+                                        successThreshold:
+                                          type: integer
+                                          format: int32
+                                        tcpSocket:
+                                          type: object
+                                          required:
+                                          - port
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                        timeoutSeconds:
+                                          type: integer
+                                          format: int32
+                                    resources:
+                                      type: object
+                                      properties:
+                                        limits:
+                                          type: object
+                                          additionalProperties:
+                                            type: string
+                                        requests:
+                                          type: object
+                                          additionalProperties:
+                                            type: string
+                                    securityContext:
+                                      type: object
+                                      properties:
+                                        allowPrivilegeEscalation:
+                                          type: boolean
+                                        capabilities:
+                                          type: object
+                                          properties:
+                                            add:
+                                              type: array
+                                              items:
+                                                type: string
+                                            drop:
+                                              type: array
+                                              items:
+                                                type: string
+                                        privileged:
+                                          type: boolean
+                                        procMount:
+                                          type: string
+                                        readOnlyRootFilesystem:
+                                          type: boolean
+                                        runAsGroup:
+                                          type: integer
+                                          format: int64
+                                        runAsNonRoot:
+                                          type: boolean
+                                        runAsUser:
+                                          type: integer
+                                          format: int64
+                                        seLinuxOptions:
+                                          type: object
+                                          properties:
+                                            level:
+                                              type: string
+                                            role:
+                                              type: string
+                                            type:
+                                              type: string
+                                            user:
+                                              type: string
+                                        windowsOptions:
+                                          type: object
+                                          properties:
+                                            gmsaCredentialSpec:
+                                              type: string
+                                            gmsaCredentialSpecName:
+                                              type: string
+                                            runAsUserName:
+                                              type: string
+                                    startupProbe:
+                                      type: object
+                                      properties:
+                                        exec:
+                                          type: object
+                                          properties:
+                                            command:
+                                              type: array
+                                              items:
+                                                type: string
+                                        failureThreshold:
+                                          type: integer
+                                          format: int32
+                                        httpGet:
+                                          type: object
+                                          required:
+                                          - port
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              type: array
+                                              items:
+                                                type: object
+                                                required:
+                                                - name
+                                                - value
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                            scheme:
+                                              type: string
+                                        initialDelaySeconds:
+                                          type: integer
+                                          format: int32
+                                        periodSeconds:
+                                          type: integer
+                                          format: int32
+                                        successThreshold:
+                                          type: integer
+                                          format: int32
+                                        tcpSocket:
+                                          type: object
+                                          required:
+                                          - port
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                        timeoutSeconds:
+                                          type: integer
+                                          format: int32
+                                    stdin:
+                                      type: boolean
+                                    stdinOnce:
+                                      type: boolean
+                                    terminationMessagePath:
+                                      type: string
+                                    terminationMessagePolicy:
+                                      type: string
+                                    tty:
+                                      type: boolean
+                                    volumeDevices:
+                                      type: array
+                                      items:
+                                        type: object
+                                        required:
+                                        - devicePath
+                                        - name
+                                        properties:
+                                          devicePath:
+                                            type: string
+                                          name:
+                                            type: string
+                                    volumeMounts:
+                                      type: array
+                                      items:
+                                        type: object
+                                        required:
+                                        - mountPath
+                                        - name
+                                        properties:
+                                          mountPath:
+                                            type: string
+                                          mountPropagation:
+                                            type: string
+                                          name:
+                                            type: string
+                                          readOnly:
+                                            type: boolean
+                                          subPath:
+                                            type: string
+                                          subPathExpr:
+                                            type: string
+                                    workingDir:
+                                      type: string
+                              nodeName:
+                                type: string
+                              nodeSelector:
+                                type: object
+                                additionalProperties:
+                                  type: string
+                              overhead:
+                                type: object
+                                additionalProperties:
+                                  type: string
+                              preemptionPolicy:
+                                type: string
+                              priority:
+                                type: integer
+                                format: int32
+                              priorityClassName:
+                                type: string
+                              readinessGates:
+                                type: array
+                                items:
+                                  type: object
+                                  required:
+                                  - conditionType
+                                  properties:
+                                    conditionType:
+                                      type: string
+                              restartPolicy:
+                                type: string
+                              runtimeClassName:
+                                type: string
+                              schedulerName:
+                                type: string
+                              securityContext:
+                                type: object
+                                properties:
+                                  fsGroup:
+                                    type: integer
+                                    format: int64
+                                  runAsGroup:
+                                    type: integer
+                                    format: int64
+                                  runAsNonRoot:
+                                    type: boolean
+                                  runAsUser:
+                                    type: integer
+                                    format: int64
+                                  seLinuxOptions:
+                                    type: object
+                                    properties:
+                                      level:
+                                        type: string
+                                      role:
+                                        type: string
+                                      type:
+                                        type: string
+                                      user:
+                                        type: string
+                                  supplementalGroups:
+                                    type: array
+                                    items:
+                                      type: integer
+                                      format: int64
+                                  sysctls:
+                                    type: array
+                                    items:
+                                      type: object
+                                      required:
+                                      - name
+                                      - value
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                  windowsOptions:
+                                    type: object
+                                    properties:
+                                      gmsaCredentialSpec:
+                                        type: string
+                                      gmsaCredentialSpecName:
+                                        type: string
+                                      runAsUserName:
+                                        type: string
+                              serviceAccount:
+                                type: string
+                              serviceAccountName:
+                                type: string
+                              shareProcessNamespace:
+                                type: boolean
+                              subdomain:
+                                type: string
+                              terminationGracePeriodSeconds:
+                                type: integer
+                                format: int64
+                              tolerations:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    effect:
+                                      type: string
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    tolerationSeconds:
+                                      type: integer
+                                      format: int64
+                                    value:
+                                      type: string
+                              topologySpreadConstraints:
+                                type: array
+                                items:
+                                  type: object
+                                  required:
+                                  - maxSkew
+                                  - topologyKey
+                                  - whenUnsatisfiable
+                                  properties:
+                                    labelSelector:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            required:
+                                            - key
+                                            - operator
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                        matchLabels:
+                                          type: object
+                                          additionalProperties:
+                                            type: string
+                                    maxSkew:
+                                      type: integer
+                                      format: int32
+                                    topologyKey:
+                                      type: string
+                                    whenUnsatisfiable:
+                                      type: string
+                              volumes:
+                                type: array
+                                items:
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    awsElasticBlockStore:
+                                      type: object
+                                      required:
+                                      - volumeID
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        partition:
+                                          type: integer
+                                          format: int32
+                                        readOnly:
+                                          type: boolean
+                                        volumeID:
+                                          type: string
+                                    azureDisk:
+                                      type: object
+                                      required:
+                                      - diskName
+                                      - diskURI
+                                      properties:
+                                        cachingMode:
+                                          type: string
+                                        diskName:
+                                          type: string
+                                        diskURI:
+                                          type: string
+                                        fsType:
+                                          type: string
+                                        kind:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                    azureFile:
+                                      type: object
+                                      required:
+                                      - secretName
+                                      - shareName
+                                      properties:
+                                        readOnly:
+                                          type: boolean
+                                        secretName:
+                                          type: string
+                                        shareName:
+                                          type: string
+                                    cephfs:
+                                      type: object
+                                      required:
+                                      - monitors
+                                      properties:
+                                        monitors:
+                                          type: array
+                                          items:
+                                            type: string
+                                        path:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        secretFile:
+                                          type: string
+                                        secretRef:
+                                          type: object
+                                          properties:
+                                            name:
+                                              type: string
+                                        user:
+                                          type: string
+                                    cinder:
+                                      type: object
+                                      required:
+                                      - volumeID
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        secretRef:
+                                          type: object
+                                          properties:
+                                            name:
+                                              type: string
+                                        volumeID:
+                                          type: string
+                                    configMap:
+                                      type: object
+                                      properties:
+                                        defaultMode:
+                                          type: integer
+                                          format: int32
+                                        items:
+                                          type: array
+                                          items:
+                                            type: object
+                                            required:
+                                            - key
+                                            - path
+                                            properties:
+                                              key:
+                                                type: string
+                                              mode:
+                                                type: integer
+                                                format: int32
+                                              path:
+                                                type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                    csi:
+                                      type: object
+                                      required:
+                                      - driver
+                                      properties:
+                                        driver:
+                                          type: string
+                                        fsType:
+                                          type: string
+                                        nodePublishSecretRef:
+                                          type: object
+                                          properties:
+                                            name:
+                                              type: string
+                                        readOnly:
+                                          type: boolean
+                                        volumeAttributes:
+                                          type: object
+                                          additionalProperties:
+                                            type: string
+                                    downwardAPI:
+                                      type: object
+                                      properties:
+                                        defaultMode:
+                                          type: integer
+                                          format: int32
+                                        items:
+                                          type: array
+                                          items:
+                                            type: object
+                                            required:
+                                            - path
+                                            properties:
+                                              fieldRef:
+                                                type: object
+                                                required:
+                                                - fieldPath
+                                                properties:
+                                                  apiVersion:
+                                                    type: string
+                                                  fieldPath:
+                                                    type: string
+                                              mode:
+                                                type: integer
+                                                format: int32
+                                              path:
+                                                type: string
+                                              resourceFieldRef:
+                                                type: object
+                                                required:
+                                                - resource
+                                                properties:
+                                                  containerName:
+                                                    type: string
+                                                  divisor:
+                                                    type: string
+                                                  resource:
+                                                    type: string
+                                    emptyDir:
+                                      type: object
+                                      properties:
+                                        medium:
+                                          type: string
+                                        sizeLimit:
+                                          type: string
+                                    fc:
+                                      type: object
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        lun:
+                                          type: integer
+                                          format: int32
+                                        readOnly:
+                                          type: boolean
+                                        targetWWNs:
+                                          type: array
+                                          items:
+                                            type: string
+                                        wwids:
+                                          type: array
+                                          items:
+                                            type: string
+                                    flexVolume:
+                                      type: object
+                                      required:
+                                      - driver
+                                      properties:
+                                        driver:
+                                          type: string
+                                        fsType:
+                                          type: string
+                                        options:
+                                          type: object
+                                          additionalProperties:
+                                            type: string
+                                        readOnly:
+                                          type: boolean
+                                        secretRef:
+                                          type: object
+                                          properties:
+                                            name:
+                                              type: string
+                                    flocker:
+                                      type: object
+                                      properties:
+                                        datasetName:
+                                          type: string
+                                        datasetUUID:
+                                          type: string
+                                    gcePersistentDisk:
+                                      type: object
+                                      required:
+                                      - pdName
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        partition:
+                                          type: integer
+                                          format: int32
+                                        pdName:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                    gitRepo:
+                                      type: object
+                                      required:
+                                      - repository
+                                      properties:
+                                        directory:
+                                          type: string
+                                        repository:
+                                          type: string
+                                        revision:
+                                          type: string
+                                    glusterfs:
+                                      type: object
+                                      required:
+                                      - endpoints
+                                      - path
+                                      properties:
+                                        endpoints:
+                                          type: string
+                                        path:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                    hostPath:
+                                      type: object
+                                      required:
+                                      - path
+                                      properties:
+                                        path:
+                                          type: string
+                                        type:
+                                          type: string
+                                    iscsi:
+                                      type: object
+                                      required:
+                                      - iqn
+                                      - lun
+                                      - targetPortal
+                                      properties:
+                                        chapAuthDiscovery:
+                                          type: boolean
+                                        chapAuthSession:
+                                          type: boolean
+                                        fsType:
+                                          type: string
+                                        initiatorName:
+                                          type: string
+                                        iqn:
+                                          type: string
+                                        iscsiInterface:
+                                          type: string
+                                        lun:
+                                          type: integer
+                                          format: int32
+                                        portals:
+                                          type: array
+                                          items:
+                                            type: string
+                                        readOnly:
+                                          type: boolean
+                                        secretRef:
+                                          type: object
+                                          properties:
+                                            name:
+                                              type: string
+                                        targetPortal:
+                                          type: string
+                                    name:
+                                      type: string
+                                    nfs:
+                                      type: object
+                                      required:
+                                      - path
+                                      - server
+                                      properties:
+                                        path:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        server:
+                                          type: string
+                                    persistentVolumeClaim:
+                                      type: object
+                                      required:
+                                      - claimName
+                                      properties:
+                                        claimName:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                    photonPersistentDisk:
+                                      type: object
+                                      required:
+                                      - pdID
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        pdID:
+                                          type: string
+                                    portworxVolume:
+                                      type: object
+                                      required:
+                                      - volumeID
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        volumeID:
+                                          type: string
+                                    projected:
+                                      type: object
+                                      required:
+                                      - sources
+                                      properties:
+                                        defaultMode:
+                                          type: integer
+                                          format: int32
+                                        sources:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              configMap:
+                                                type: object
+                                                properties:
+                                                  items:
+                                                    type: array
+                                                    items:
+                                                      type: object
+                                                      required:
+                                                      - key
+                                                      - path
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        mode:
+                                                          type: integer
+                                                          format: int32
+                                                        path:
+                                                          type: string
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                              downwardAPI:
+                                                type: object
+                                                properties:
+                                                  items:
+                                                    type: array
+                                                    items:
+                                                      type: object
+                                                      required:
+                                                      - path
+                                                      properties:
+                                                        fieldRef:
+                                                          type: object
+                                                          required:
+                                                          - fieldPath
+                                                          properties:
+                                                            apiVersion:
+                                                              type: string
+                                                            fieldPath:
+                                                              type: string
+                                                        mode:
+                                                          type: integer
+                                                          format: int32
+                                                        path:
+                                                          type: string
+                                                        resourceFieldRef:
+                                                          type: object
+                                                          required:
+                                                          - resource
+                                                          properties:
+                                                            containerName:
+                                                              type: string
+                                                            divisor:
+                                                              type: string
+                                                            resource:
+                                                              type: string
+                                              secret:
+                                                type: object
+                                                properties:
+                                                  items:
+                                                    type: array
+                                                    items:
+                                                      type: object
+                                                      required:
+                                                      - key
+                                                      - path
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        mode:
+                                                          type: integer
+                                                          format: int32
+                                                        path:
+                                                          type: string
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                              serviceAccountToken:
+                                                type: object
+                                                required:
+                                                - path
+                                                properties:
+                                                  audience:
+                                                    type: string
+                                                  expirationSeconds:
+                                                    type: integer
+                                                    format: int64
+                                                  path:
+                                                    type: string
+                                    quobyte:
+                                      type: object
+                                      required:
+                                      - registry
+                                      - volume
+                                      properties:
+                                        group:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        registry:
+                                          type: string
+                                        tenant:
+                                          type: string
+                                        user:
+                                          type: string
+                                        volume:
+                                          type: string
+                                    rbd:
+                                      type: object
+                                      required:
+                                      - image
+                                      - monitors
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        image:
+                                          type: string
+                                        keyring:
+                                          type: string
+                                        monitors:
+                                          type: array
+                                          items:
+                                            type: string
+                                        pool:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        secretRef:
+                                          type: object
+                                          properties:
+                                            name:
+                                              type: string
+                                        user:
+                                          type: string
+                                    scaleIO:
+                                      type: object
+                                      required:
+                                      - gateway
+                                      - secretRef
+                                      - system
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        gateway:
+                                          type: string
+                                        protectionDomain:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        secretRef:
+                                          type: object
+                                          properties:
+                                            name:
+                                              type: string
+                                        sslEnabled:
+                                          type: boolean
+                                        storageMode:
+                                          type: string
+                                        storagePool:
+                                          type: string
+                                        system:
+                                          type: string
+                                        volumeName:
+                                          type: string
+                                    secret:
+                                      type: object
+                                      properties:
+                                        defaultMode:
+                                          type: integer
+                                          format: int32
+                                        items:
+                                          type: array
+                                          items:
+                                            type: object
+                                            required:
+                                            - key
+                                            - path
+                                            properties:
+                                              key:
+                                                type: string
+                                              mode:
+                                                type: integer
+                                                format: int32
+                                              path:
+                                                type: string
+                                        optional:
+                                          type: boolean
+                                        secretName:
+                                          type: string
+                                    storageos:
+                                      type: object
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        secretRef:
+                                          type: object
+                                          properties:
+                                            name:
+                                              type: string
+                                        volumeName:
+                                          type: string
+                                        volumeNamespace:
+                                          type: string
+                                    vsphereVolume:
+                                      type: object
+                                      required:
+                                      - volumePath
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        storagePolicyID:
+                                          type: string
+                                        storagePolicyName:
+                                          type: string
+                                        volumePath:
+                                          type: string
+                      ttlSecondsAfterFinished:
+                        type: integer
+                        format: int32
+              ttlSecondsAfterFailure:
+                type: integer
+                format: int32
+              ttlSecondsAfterFinished:
+                type: integer
+                format: int32
+              values:
+                type: array
+                items:
+                  type: object
+                  required:
+                  - name
+                  - value
+                  properties:
+                    attemptsRemaining:
+                      type: integer
+                    error:
+                      type: string
+                    name:
+                      type: string
+                    value:
+                      type: string
+          status:
+            type: object
+            required:
+            - assignments
+            - phase
+            - values
+            properties:
+              assignments:
+                type: string
+              completionTime:
+                type: string
+                format: date-time
+              conditions:
+                type: array
+                items:
+                  type: object
+                  required:
+                  - lastProbeTime
+                  - lastTransitionTime
+                  - status
+                  - type
+                  properties:
+                    lastProbeTime:
+                      type: string
+                      format: date-time
+                    lastTransitionTime:
+                      type: string
+                      format: date-time
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+              phase:
+                type: string
+              startTime:
+                type: string
+                format: date-time
+              values:
+                type: string
   - name: v1beta1
     served: true
     storage: true
+    "schema":
+      "openAPIV3Schema":
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            properties:
+              approximateRuntime:
+                type: string
+              assignments:
+                type: array
+                items:
+                  type: object
+                  required:
+                  - name
+                  - value
+                  properties:
+                    name:
+                      type: string
+                    value:
+                      type: integer
+                      format: int64
+              experimentRef:
+                type: object
+                properties:
+                  apiVersion:
+                    type: string
+                  fieldPath:
+                    type: string
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                  resourceVersion:
+                    type: string
+                  uid:
+                    type: string
+              initialDelaySeconds:
+                type: integer
+                format: int32
+              jobTemplate:
+                type: object
+                properties:
+                  metadata:
+                    type: object
+                  spec:
+                    type: object
+                    required:
+                    - template
+                    properties:
+                      activeDeadlineSeconds:
+                        type: integer
+                        format: int64
+                      backoffLimit:
+                        type: integer
+                        format: int32
+                      completions:
+                        type: integer
+                        format: int32
+                      manualSelector:
+                        type: boolean
+                      parallelism:
+                        type: integer
+                        format: int32
+                      selector:
+                        type: object
+                        properties:
+                          matchExpressions:
+                            type: array
+                            items:
+                              type: object
+                              required:
+                              - key
+                              - operator
+                              properties:
+                                key:
+                                  type: string
+                                operator:
+                                  type: string
+                                values:
+                                  type: array
+                                  items:
+                                    type: string
+                          matchLabels:
+                            type: object
+                            additionalProperties:
+                              type: string
+                      template:
+                        type: object
+                        properties:
+                          metadata:
+                            type: object
+                          spec:
+                            type: object
+                            required:
+                            - containers
+                            properties:
+                              activeDeadlineSeconds:
+                                type: integer
+                                format: int64
+                              affinity:
+                                type: object
+                                properties:
+                                  nodeAffinity:
+                                    type: object
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        type: array
+                                        items:
+                                          type: object
+                                          required:
+                                          - preference
+                                          - weight
+                                          properties:
+                                            preference:
+                                              type: object
+                                              properties:
+                                                matchExpressions:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        type: array
+                                                        items:
+                                                          type: string
+                                                matchFields:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        type: array
+                                                        items:
+                                                          type: string
+                                            weight:
+                                              type: integer
+                                              format: int32
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        type: object
+                                        required:
+                                        - nodeSelectorTerms
+                                        properties:
+                                          nodeSelectorTerms:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                matchExpressions:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        type: array
+                                                        items:
+                                                          type: string
+                                                matchFields:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        type: array
+                                                        items:
+                                                          type: string
+                                  podAffinity:
+                                    type: object
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        type: array
+                                        items:
+                                          type: object
+                                          required:
+                                          - podAffinityTerm
+                                          - weight
+                                          properties:
+                                            podAffinityTerm:
+                                              type: object
+                                              required:
+                                              - topologyKey
+                                              properties:
+                                                labelSelector:
+                                                  type: object
+                                                  properties:
+                                                    matchExpressions:
+                                                      type: array
+                                                      items:
+                                                        type: object
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            type: array
+                                                            items:
+                                                              type: string
+                                                    matchLabels:
+                                                      type: object
+                                                      additionalProperties:
+                                                        type: string
+                                                namespaces:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                                topologyKey:
+                                                  type: string
+                                            weight:
+                                              type: integer
+                                              format: int32
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        type: array
+                                        items:
+                                          type: object
+                                          required:
+                                          - topologyKey
+                                          properties:
+                                            labelSelector:
+                                              type: object
+                                              properties:
+                                                matchExpressions:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        type: array
+                                                        items:
+                                                          type: string
+                                                matchLabels:
+                                                  type: object
+                                                  additionalProperties:
+                                                    type: string
+                                            namespaces:
+                                              type: array
+                                              items:
+                                                type: string
+                                            topologyKey:
+                                              type: string
+                                  podAntiAffinity:
+                                    type: object
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        type: array
+                                        items:
+                                          type: object
+                                          required:
+                                          - podAffinityTerm
+                                          - weight
+                                          properties:
+                                            podAffinityTerm:
+                                              type: object
+                                              required:
+                                              - topologyKey
+                                              properties:
+                                                labelSelector:
+                                                  type: object
+                                                  properties:
+                                                    matchExpressions:
+                                                      type: array
+                                                      items:
+                                                        type: object
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            type: array
+                                                            items:
+                                                              type: string
+                                                    matchLabels:
+                                                      type: object
+                                                      additionalProperties:
+                                                        type: string
+                                                namespaces:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                                topologyKey:
+                                                  type: string
+                                            weight:
+                                              type: integer
+                                              format: int32
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        type: array
+                                        items:
+                                          type: object
+                                          required:
+                                          - topologyKey
+                                          properties:
+                                            labelSelector:
+                                              type: object
+                                              properties:
+                                                matchExpressions:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        type: array
+                                                        items:
+                                                          type: string
+                                                matchLabels:
+                                                  type: object
+                                                  additionalProperties:
+                                                    type: string
+                                            namespaces:
+                                              type: array
+                                              items:
+                                                type: string
+                                            topologyKey:
+                                              type: string
+                              automountServiceAccountToken:
+                                type: boolean
+                              containers:
+                                type: array
+                                items:
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    args:
+                                      type: array
+                                      items:
+                                        type: string
+                                    command:
+                                      type: array
+                                      items:
+                                        type: string
+                                    env:
+                                      type: array
+                                      items:
+                                        type: object
+                                        required:
+                                        - name
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                          valueFrom:
+                                            type: object
+                                            properties:
+                                              configMapKeyRef:
+                                                type: object
+                                                required:
+                                                - key
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                              fieldRef:
+                                                type: object
+                                                required:
+                                                - fieldPath
+                                                properties:
+                                                  apiVersion:
+                                                    type: string
+                                                  fieldPath:
+                                                    type: string
+                                              resourceFieldRef:
+                                                type: object
+                                                required:
+                                                - resource
+                                                properties:
+                                                  containerName:
+                                                    type: string
+                                                  divisor:
+                                                    type: string
+                                                  resource:
+                                                    type: string
+                                              secretKeyRef:
+                                                type: object
+                                                required:
+                                                - key
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                    envFrom:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          configMapRef:
+                                            type: object
+                                            properties:
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                          prefix:
+                                            type: string
+                                          secretRef:
+                                            type: object
+                                            properties:
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                    image:
+                                      type: string
+                                    imagePullPolicy:
+                                      type: string
+                                    lifecycle:
+                                      type: object
+                                      properties:
+                                        postStart:
+                                          type: object
+                                          properties:
+                                            exec:
+                                              type: object
+                                              properties:
+                                                command:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                            httpGet:
+                                              type: object
+                                              required:
+                                              - port
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: string
+                                                  - type: integer
+                                                scheme:
+                                                  type: string
+                                            tcpSocket:
+                                              type: object
+                                              required:
+                                              - port
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: string
+                                                  - type: integer
+                                        preStop:
+                                          type: object
+                                          properties:
+                                            exec:
+                                              type: object
+                                              properties:
+                                                command:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                            httpGet:
+                                              type: object
+                                              required:
+                                              - port
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: string
+                                                  - type: integer
+                                                scheme:
+                                                  type: string
+                                            tcpSocket:
+                                              type: object
+                                              required:
+                                              - port
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: string
+                                                  - type: integer
+                                    livenessProbe:
+                                      type: object
+                                      properties:
+                                        exec:
+                                          type: object
+                                          properties:
+                                            command:
+                                              type: array
+                                              items:
+                                                type: string
+                                        failureThreshold:
+                                          type: integer
+                                          format: int32
+                                        httpGet:
+                                          type: object
+                                          required:
+                                          - port
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              type: array
+                                              items:
+                                                type: object
+                                                required:
+                                                - name
+                                                - value
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                            scheme:
+                                              type: string
+                                        initialDelaySeconds:
+                                          type: integer
+                                          format: int32
+                                        periodSeconds:
+                                          type: integer
+                                          format: int32
+                                        successThreshold:
+                                          type: integer
+                                          format: int32
+                                        tcpSocket:
+                                          type: object
+                                          required:
+                                          - port
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                        timeoutSeconds:
+                                          type: integer
+                                          format: int32
+                                    name:
+                                      type: string
+                                    ports:
+                                      type: array
+                                      items:
+                                        type: object
+                                        required:
+                                        - containerPort
+                                        properties:
+                                          containerPort:
+                                            type: integer
+                                            format: int32
+                                          hostIP:
+                                            type: string
+                                          hostPort:
+                                            type: integer
+                                            format: int32
+                                          name:
+                                            type: string
+                                          protocol:
+                                            type: string
+                                    readinessProbe:
+                                      type: object
+                                      properties:
+                                        exec:
+                                          type: object
+                                          properties:
+                                            command:
+                                              type: array
+                                              items:
+                                                type: string
+                                        failureThreshold:
+                                          type: integer
+                                          format: int32
+                                        httpGet:
+                                          type: object
+                                          required:
+                                          - port
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              type: array
+                                              items:
+                                                type: object
+                                                required:
+                                                - name
+                                                - value
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                            scheme:
+                                              type: string
+                                        initialDelaySeconds:
+                                          type: integer
+                                          format: int32
+                                        periodSeconds:
+                                          type: integer
+                                          format: int32
+                                        successThreshold:
+                                          type: integer
+                                          format: int32
+                                        tcpSocket:
+                                          type: object
+                                          required:
+                                          - port
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                        timeoutSeconds:
+                                          type: integer
+                                          format: int32
+                                    resources:
+                                      type: object
+                                      properties:
+                                        limits:
+                                          type: object
+                                          additionalProperties:
+                                            type: string
+                                        requests:
+                                          type: object
+                                          additionalProperties:
+                                            type: string
+                                    securityContext:
+                                      type: object
+                                      properties:
+                                        allowPrivilegeEscalation:
+                                          type: boolean
+                                        capabilities:
+                                          type: object
+                                          properties:
+                                            add:
+                                              type: array
+                                              items:
+                                                type: string
+                                            drop:
+                                              type: array
+                                              items:
+                                                type: string
+                                        privileged:
+                                          type: boolean
+                                        procMount:
+                                          type: string
+                                        readOnlyRootFilesystem:
+                                          type: boolean
+                                        runAsGroup:
+                                          type: integer
+                                          format: int64
+                                        runAsNonRoot:
+                                          type: boolean
+                                        runAsUser:
+                                          type: integer
+                                          format: int64
+                                        seLinuxOptions:
+                                          type: object
+                                          properties:
+                                            level:
+                                              type: string
+                                            role:
+                                              type: string
+                                            type:
+                                              type: string
+                                            user:
+                                              type: string
+                                        windowsOptions:
+                                          type: object
+                                          properties:
+                                            gmsaCredentialSpec:
+                                              type: string
+                                            gmsaCredentialSpecName:
+                                              type: string
+                                            runAsUserName:
+                                              type: string
+                                    startupProbe:
+                                      type: object
+                                      properties:
+                                        exec:
+                                          type: object
+                                          properties:
+                                            command:
+                                              type: array
+                                              items:
+                                                type: string
+                                        failureThreshold:
+                                          type: integer
+                                          format: int32
+                                        httpGet:
+                                          type: object
+                                          required:
+                                          - port
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              type: array
+                                              items:
+                                                type: object
+                                                required:
+                                                - name
+                                                - value
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                            scheme:
+                                              type: string
+                                        initialDelaySeconds:
+                                          type: integer
+                                          format: int32
+                                        periodSeconds:
+                                          type: integer
+                                          format: int32
+                                        successThreshold:
+                                          type: integer
+                                          format: int32
+                                        tcpSocket:
+                                          type: object
+                                          required:
+                                          - port
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                        timeoutSeconds:
+                                          type: integer
+                                          format: int32
+                                    stdin:
+                                      type: boolean
+                                    stdinOnce:
+                                      type: boolean
+                                    terminationMessagePath:
+                                      type: string
+                                    terminationMessagePolicy:
+                                      type: string
+                                    tty:
+                                      type: boolean
+                                    volumeDevices:
+                                      type: array
+                                      items:
+                                        type: object
+                                        required:
+                                        - devicePath
+                                        - name
+                                        properties:
+                                          devicePath:
+                                            type: string
+                                          name:
+                                            type: string
+                                    volumeMounts:
+                                      type: array
+                                      items:
+                                        type: object
+                                        required:
+                                        - mountPath
+                                        - name
+                                        properties:
+                                          mountPath:
+                                            type: string
+                                          mountPropagation:
+                                            type: string
+                                          name:
+                                            type: string
+                                          readOnly:
+                                            type: boolean
+                                          subPath:
+                                            type: string
+                                          subPathExpr:
+                                            type: string
+                                    workingDir:
+                                      type: string
+                              dnsConfig:
+                                type: object
+                                properties:
+                                  nameservers:
+                                    type: array
+                                    items:
+                                      type: string
+                                  options:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                  searches:
+                                    type: array
+                                    items:
+                                      type: string
+                              dnsPolicy:
+                                type: string
+                              enableServiceLinks:
+                                type: boolean
+                              ephemeralContainers:
+                                type: array
+                                items:
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    args:
+                                      type: array
+                                      items:
+                                        type: string
+                                    command:
+                                      type: array
+                                      items:
+                                        type: string
+                                    env:
+                                      type: array
+                                      items:
+                                        type: object
+                                        required:
+                                        - name
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                          valueFrom:
+                                            type: object
+                                            properties:
+                                              configMapKeyRef:
+                                                type: object
+                                                required:
+                                                - key
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                              fieldRef:
+                                                type: object
+                                                required:
+                                                - fieldPath
+                                                properties:
+                                                  apiVersion:
+                                                    type: string
+                                                  fieldPath:
+                                                    type: string
+                                              resourceFieldRef:
+                                                type: object
+                                                required:
+                                                - resource
+                                                properties:
+                                                  containerName:
+                                                    type: string
+                                                  divisor:
+                                                    type: string
+                                                  resource:
+                                                    type: string
+                                              secretKeyRef:
+                                                type: object
+                                                required:
+                                                - key
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                    envFrom:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          configMapRef:
+                                            type: object
+                                            properties:
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                          prefix:
+                                            type: string
+                                          secretRef:
+                                            type: object
+                                            properties:
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                    image:
+                                      type: string
+                                    imagePullPolicy:
+                                      type: string
+                                    lifecycle:
+                                      type: object
+                                      properties:
+                                        postStart:
+                                          type: object
+                                          properties:
+                                            exec:
+                                              type: object
+                                              properties:
+                                                command:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                            httpGet:
+                                              type: object
+                                              required:
+                                              - port
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: string
+                                                  - type: integer
+                                                scheme:
+                                                  type: string
+                                            tcpSocket:
+                                              type: object
+                                              required:
+                                              - port
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: string
+                                                  - type: integer
+                                        preStop:
+                                          type: object
+                                          properties:
+                                            exec:
+                                              type: object
+                                              properties:
+                                                command:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                            httpGet:
+                                              type: object
+                                              required:
+                                              - port
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: string
+                                                  - type: integer
+                                                scheme:
+                                                  type: string
+                                            tcpSocket:
+                                              type: object
+                                              required:
+                                              - port
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: string
+                                                  - type: integer
+                                    livenessProbe:
+                                      type: object
+                                      properties:
+                                        exec:
+                                          type: object
+                                          properties:
+                                            command:
+                                              type: array
+                                              items:
+                                                type: string
+                                        failureThreshold:
+                                          type: integer
+                                          format: int32
+                                        httpGet:
+                                          type: object
+                                          required:
+                                          - port
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              type: array
+                                              items:
+                                                type: object
+                                                required:
+                                                - name
+                                                - value
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                            scheme:
+                                              type: string
+                                        initialDelaySeconds:
+                                          type: integer
+                                          format: int32
+                                        periodSeconds:
+                                          type: integer
+                                          format: int32
+                                        successThreshold:
+                                          type: integer
+                                          format: int32
+                                        tcpSocket:
+                                          type: object
+                                          required:
+                                          - port
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                        timeoutSeconds:
+                                          type: integer
+                                          format: int32
+                                    name:
+                                      type: string
+                                    ports:
+                                      type: array
+                                      items:
+                                        type: object
+                                        required:
+                                        - containerPort
+                                        properties:
+                                          containerPort:
+                                            type: integer
+                                            format: int32
+                                          hostIP:
+                                            type: string
+                                          hostPort:
+                                            type: integer
+                                            format: int32
+                                          name:
+                                            type: string
+                                          protocol:
+                                            type: string
+                                    readinessProbe:
+                                      type: object
+                                      properties:
+                                        exec:
+                                          type: object
+                                          properties:
+                                            command:
+                                              type: array
+                                              items:
+                                                type: string
+                                        failureThreshold:
+                                          type: integer
+                                          format: int32
+                                        httpGet:
+                                          type: object
+                                          required:
+                                          - port
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              type: array
+                                              items:
+                                                type: object
+                                                required:
+                                                - name
+                                                - value
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                            scheme:
+                                              type: string
+                                        initialDelaySeconds:
+                                          type: integer
+                                          format: int32
+                                        periodSeconds:
+                                          type: integer
+                                          format: int32
+                                        successThreshold:
+                                          type: integer
+                                          format: int32
+                                        tcpSocket:
+                                          type: object
+                                          required:
+                                          - port
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                        timeoutSeconds:
+                                          type: integer
+                                          format: int32
+                                    resources:
+                                      type: object
+                                      properties:
+                                        limits:
+                                          type: object
+                                          additionalProperties:
+                                            type: string
+                                        requests:
+                                          type: object
+                                          additionalProperties:
+                                            type: string
+                                    securityContext:
+                                      type: object
+                                      properties:
+                                        allowPrivilegeEscalation:
+                                          type: boolean
+                                        capabilities:
+                                          type: object
+                                          properties:
+                                            add:
+                                              type: array
+                                              items:
+                                                type: string
+                                            drop:
+                                              type: array
+                                              items:
+                                                type: string
+                                        privileged:
+                                          type: boolean
+                                        procMount:
+                                          type: string
+                                        readOnlyRootFilesystem:
+                                          type: boolean
+                                        runAsGroup:
+                                          type: integer
+                                          format: int64
+                                        runAsNonRoot:
+                                          type: boolean
+                                        runAsUser:
+                                          type: integer
+                                          format: int64
+                                        seLinuxOptions:
+                                          type: object
+                                          properties:
+                                            level:
+                                              type: string
+                                            role:
+                                              type: string
+                                            type:
+                                              type: string
+                                            user:
+                                              type: string
+                                        windowsOptions:
+                                          type: object
+                                          properties:
+                                            gmsaCredentialSpec:
+                                              type: string
+                                            gmsaCredentialSpecName:
+                                              type: string
+                                            runAsUserName:
+                                              type: string
+                                    startupProbe:
+                                      type: object
+                                      properties:
+                                        exec:
+                                          type: object
+                                          properties:
+                                            command:
+                                              type: array
+                                              items:
+                                                type: string
+                                        failureThreshold:
+                                          type: integer
+                                          format: int32
+                                        httpGet:
+                                          type: object
+                                          required:
+                                          - port
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              type: array
+                                              items:
+                                                type: object
+                                                required:
+                                                - name
+                                                - value
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                            scheme:
+                                              type: string
+                                        initialDelaySeconds:
+                                          type: integer
+                                          format: int32
+                                        periodSeconds:
+                                          type: integer
+                                          format: int32
+                                        successThreshold:
+                                          type: integer
+                                          format: int32
+                                        tcpSocket:
+                                          type: object
+                                          required:
+                                          - port
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                        timeoutSeconds:
+                                          type: integer
+                                          format: int32
+                                    stdin:
+                                      type: boolean
+                                    stdinOnce:
+                                      type: boolean
+                                    targetContainerName:
+                                      type: string
+                                    terminationMessagePath:
+                                      type: string
+                                    terminationMessagePolicy:
+                                      type: string
+                                    tty:
+                                      type: boolean
+                                    volumeDevices:
+                                      type: array
+                                      items:
+                                        type: object
+                                        required:
+                                        - devicePath
+                                        - name
+                                        properties:
+                                          devicePath:
+                                            type: string
+                                          name:
+                                            type: string
+                                    volumeMounts:
+                                      type: array
+                                      items:
+                                        type: object
+                                        required:
+                                        - mountPath
+                                        - name
+                                        properties:
+                                          mountPath:
+                                            type: string
+                                          mountPropagation:
+                                            type: string
+                                          name:
+                                            type: string
+                                          readOnly:
+                                            type: boolean
+                                          subPath:
+                                            type: string
+                                          subPathExpr:
+                                            type: string
+                                    workingDir:
+                                      type: string
+                              hostAliases:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    hostnames:
+                                      type: array
+                                      items:
+                                        type: string
+                                    ip:
+                                      type: string
+                              hostIPC:
+                                type: boolean
+                              hostNetwork:
+                                type: boolean
+                              hostPID:
+                                type: boolean
+                              hostname:
+                                type: string
+                              imagePullSecrets:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                              initContainers:
+                                type: array
+                                items:
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    args:
+                                      type: array
+                                      items:
+                                        type: string
+                                    command:
+                                      type: array
+                                      items:
+                                        type: string
+                                    env:
+                                      type: array
+                                      items:
+                                        type: object
+                                        required:
+                                        - name
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                          valueFrom:
+                                            type: object
+                                            properties:
+                                              configMapKeyRef:
+                                                type: object
+                                                required:
+                                                - key
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                              fieldRef:
+                                                type: object
+                                                required:
+                                                - fieldPath
+                                                properties:
+                                                  apiVersion:
+                                                    type: string
+                                                  fieldPath:
+                                                    type: string
+                                              resourceFieldRef:
+                                                type: object
+                                                required:
+                                                - resource
+                                                properties:
+                                                  containerName:
+                                                    type: string
+                                                  divisor:
+                                                    type: string
+                                                  resource:
+                                                    type: string
+                                              secretKeyRef:
+                                                type: object
+                                                required:
+                                                - key
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                    envFrom:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          configMapRef:
+                                            type: object
+                                            properties:
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                          prefix:
+                                            type: string
+                                          secretRef:
+                                            type: object
+                                            properties:
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                    image:
+                                      type: string
+                                    imagePullPolicy:
+                                      type: string
+                                    lifecycle:
+                                      type: object
+                                      properties:
+                                        postStart:
+                                          type: object
+                                          properties:
+                                            exec:
+                                              type: object
+                                              properties:
+                                                command:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                            httpGet:
+                                              type: object
+                                              required:
+                                              - port
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: string
+                                                  - type: integer
+                                                scheme:
+                                                  type: string
+                                            tcpSocket:
+                                              type: object
+                                              required:
+                                              - port
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: string
+                                                  - type: integer
+                                        preStop:
+                                          type: object
+                                          properties:
+                                            exec:
+                                              type: object
+                                              properties:
+                                                command:
+                                                  type: array
+                                                  items:
+                                                    type: string
+                                            httpGet:
+                                              type: object
+                                              required:
+                                              - port
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: string
+                                                  - type: integer
+                                                scheme:
+                                                  type: string
+                                            tcpSocket:
+                                              type: object
+                                              required:
+                                              - port
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: string
+                                                  - type: integer
+                                    livenessProbe:
+                                      type: object
+                                      properties:
+                                        exec:
+                                          type: object
+                                          properties:
+                                            command:
+                                              type: array
+                                              items:
+                                                type: string
+                                        failureThreshold:
+                                          type: integer
+                                          format: int32
+                                        httpGet:
+                                          type: object
+                                          required:
+                                          - port
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              type: array
+                                              items:
+                                                type: object
+                                                required:
+                                                - name
+                                                - value
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                            scheme:
+                                              type: string
+                                        initialDelaySeconds:
+                                          type: integer
+                                          format: int32
+                                        periodSeconds:
+                                          type: integer
+                                          format: int32
+                                        successThreshold:
+                                          type: integer
+                                          format: int32
+                                        tcpSocket:
+                                          type: object
+                                          required:
+                                          - port
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                        timeoutSeconds:
+                                          type: integer
+                                          format: int32
+                                    name:
+                                      type: string
+                                    ports:
+                                      type: array
+                                      items:
+                                        type: object
+                                        required:
+                                        - containerPort
+                                        properties:
+                                          containerPort:
+                                            type: integer
+                                            format: int32
+                                          hostIP:
+                                            type: string
+                                          hostPort:
+                                            type: integer
+                                            format: int32
+                                          name:
+                                            type: string
+                                          protocol:
+                                            type: string
+                                    readinessProbe:
+                                      type: object
+                                      properties:
+                                        exec:
+                                          type: object
+                                          properties:
+                                            command:
+                                              type: array
+                                              items:
+                                                type: string
+                                        failureThreshold:
+                                          type: integer
+                                          format: int32
+                                        httpGet:
+                                          type: object
+                                          required:
+                                          - port
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              type: array
+                                              items:
+                                                type: object
+                                                required:
+                                                - name
+                                                - value
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                            scheme:
+                                              type: string
+                                        initialDelaySeconds:
+                                          type: integer
+                                          format: int32
+                                        periodSeconds:
+                                          type: integer
+                                          format: int32
+                                        successThreshold:
+                                          type: integer
+                                          format: int32
+                                        tcpSocket:
+                                          type: object
+                                          required:
+                                          - port
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                        timeoutSeconds:
+                                          type: integer
+                                          format: int32
+                                    resources:
+                                      type: object
+                                      properties:
+                                        limits:
+                                          type: object
+                                          additionalProperties:
+                                            type: string
+                                        requests:
+                                          type: object
+                                          additionalProperties:
+                                            type: string
+                                    securityContext:
+                                      type: object
+                                      properties:
+                                        allowPrivilegeEscalation:
+                                          type: boolean
+                                        capabilities:
+                                          type: object
+                                          properties:
+                                            add:
+                                              type: array
+                                              items:
+                                                type: string
+                                            drop:
+                                              type: array
+                                              items:
+                                                type: string
+                                        privileged:
+                                          type: boolean
+                                        procMount:
+                                          type: string
+                                        readOnlyRootFilesystem:
+                                          type: boolean
+                                        runAsGroup:
+                                          type: integer
+                                          format: int64
+                                        runAsNonRoot:
+                                          type: boolean
+                                        runAsUser:
+                                          type: integer
+                                          format: int64
+                                        seLinuxOptions:
+                                          type: object
+                                          properties:
+                                            level:
+                                              type: string
+                                            role:
+                                              type: string
+                                            type:
+                                              type: string
+                                            user:
+                                              type: string
+                                        windowsOptions:
+                                          type: object
+                                          properties:
+                                            gmsaCredentialSpec:
+                                              type: string
+                                            gmsaCredentialSpecName:
+                                              type: string
+                                            runAsUserName:
+                                              type: string
+                                    startupProbe:
+                                      type: object
+                                      properties:
+                                        exec:
+                                          type: object
+                                          properties:
+                                            command:
+                                              type: array
+                                              items:
+                                                type: string
+                                        failureThreshold:
+                                          type: integer
+                                          format: int32
+                                        httpGet:
+                                          type: object
+                                          required:
+                                          - port
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              type: array
+                                              items:
+                                                type: object
+                                                required:
+                                                - name
+                                                - value
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                            scheme:
+                                              type: string
+                                        initialDelaySeconds:
+                                          type: integer
+                                          format: int32
+                                        periodSeconds:
+                                          type: integer
+                                          format: int32
+                                        successThreshold:
+                                          type: integer
+                                          format: int32
+                                        tcpSocket:
+                                          type: object
+                                          required:
+                                          - port
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: string
+                                              - type: integer
+                                        timeoutSeconds:
+                                          type: integer
+                                          format: int32
+                                    stdin:
+                                      type: boolean
+                                    stdinOnce:
+                                      type: boolean
+                                    terminationMessagePath:
+                                      type: string
+                                    terminationMessagePolicy:
+                                      type: string
+                                    tty:
+                                      type: boolean
+                                    volumeDevices:
+                                      type: array
+                                      items:
+                                        type: object
+                                        required:
+                                        - devicePath
+                                        - name
+                                        properties:
+                                          devicePath:
+                                            type: string
+                                          name:
+                                            type: string
+                                    volumeMounts:
+                                      type: array
+                                      items:
+                                        type: object
+                                        required:
+                                        - mountPath
+                                        - name
+                                        properties:
+                                          mountPath:
+                                            type: string
+                                          mountPropagation:
+                                            type: string
+                                          name:
+                                            type: string
+                                          readOnly:
+                                            type: boolean
+                                          subPath:
+                                            type: string
+                                          subPathExpr:
+                                            type: string
+                                    workingDir:
+                                      type: string
+                              nodeName:
+                                type: string
+                              nodeSelector:
+                                type: object
+                                additionalProperties:
+                                  type: string
+                              overhead:
+                                type: object
+                                additionalProperties:
+                                  type: string
+                              preemptionPolicy:
+                                type: string
+                              priority:
+                                type: integer
+                                format: int32
+                              priorityClassName:
+                                type: string
+                              readinessGates:
+                                type: array
+                                items:
+                                  type: object
+                                  required:
+                                  - conditionType
+                                  properties:
+                                    conditionType:
+                                      type: string
+                              restartPolicy:
+                                type: string
+                              runtimeClassName:
+                                type: string
+                              schedulerName:
+                                type: string
+                              securityContext:
+                                type: object
+                                properties:
+                                  fsGroup:
+                                    type: integer
+                                    format: int64
+                                  runAsGroup:
+                                    type: integer
+                                    format: int64
+                                  runAsNonRoot:
+                                    type: boolean
+                                  runAsUser:
+                                    type: integer
+                                    format: int64
+                                  seLinuxOptions:
+                                    type: object
+                                    properties:
+                                      level:
+                                        type: string
+                                      role:
+                                        type: string
+                                      type:
+                                        type: string
+                                      user:
+                                        type: string
+                                  supplementalGroups:
+                                    type: array
+                                    items:
+                                      type: integer
+                                      format: int64
+                                  sysctls:
+                                    type: array
+                                    items:
+                                      type: object
+                                      required:
+                                      - name
+                                      - value
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                  windowsOptions:
+                                    type: object
+                                    properties:
+                                      gmsaCredentialSpec:
+                                        type: string
+                                      gmsaCredentialSpecName:
+                                        type: string
+                                      runAsUserName:
+                                        type: string
+                              serviceAccount:
+                                type: string
+                              serviceAccountName:
+                                type: string
+                              shareProcessNamespace:
+                                type: boolean
+                              subdomain:
+                                type: string
+                              terminationGracePeriodSeconds:
+                                type: integer
+                                format: int64
+                              tolerations:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    effect:
+                                      type: string
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    tolerationSeconds:
+                                      type: integer
+                                      format: int64
+                                    value:
+                                      type: string
+                              topologySpreadConstraints:
+                                type: array
+                                items:
+                                  type: object
+                                  required:
+                                  - maxSkew
+                                  - topologyKey
+                                  - whenUnsatisfiable
+                                  properties:
+                                    labelSelector:
+                                      type: object
+                                      properties:
+                                        matchExpressions:
+                                          type: array
+                                          items:
+                                            type: object
+                                            required:
+                                            - key
+                                            - operator
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                type: array
+                                                items:
+                                                  type: string
+                                        matchLabels:
+                                          type: object
+                                          additionalProperties:
+                                            type: string
+                                    maxSkew:
+                                      type: integer
+                                      format: int32
+                                    topologyKey:
+                                      type: string
+                                    whenUnsatisfiable:
+                                      type: string
+                              volumes:
+                                type: array
+                                items:
+                                  type: object
+                                  required:
+                                  - name
+                                  properties:
+                                    awsElasticBlockStore:
+                                      type: object
+                                      required:
+                                      - volumeID
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        partition:
+                                          type: integer
+                                          format: int32
+                                        readOnly:
+                                          type: boolean
+                                        volumeID:
+                                          type: string
+                                    azureDisk:
+                                      type: object
+                                      required:
+                                      - diskName
+                                      - diskURI
+                                      properties:
+                                        cachingMode:
+                                          type: string
+                                        diskName:
+                                          type: string
+                                        diskURI:
+                                          type: string
+                                        fsType:
+                                          type: string
+                                        kind:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                    azureFile:
+                                      type: object
+                                      required:
+                                      - secretName
+                                      - shareName
+                                      properties:
+                                        readOnly:
+                                          type: boolean
+                                        secretName:
+                                          type: string
+                                        shareName:
+                                          type: string
+                                    cephfs:
+                                      type: object
+                                      required:
+                                      - monitors
+                                      properties:
+                                        monitors:
+                                          type: array
+                                          items:
+                                            type: string
+                                        path:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        secretFile:
+                                          type: string
+                                        secretRef:
+                                          type: object
+                                          properties:
+                                            name:
+                                              type: string
+                                        user:
+                                          type: string
+                                    cinder:
+                                      type: object
+                                      required:
+                                      - volumeID
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        secretRef:
+                                          type: object
+                                          properties:
+                                            name:
+                                              type: string
+                                        volumeID:
+                                          type: string
+                                    configMap:
+                                      type: object
+                                      properties:
+                                        defaultMode:
+                                          type: integer
+                                          format: int32
+                                        items:
+                                          type: array
+                                          items:
+                                            type: object
+                                            required:
+                                            - key
+                                            - path
+                                            properties:
+                                              key:
+                                                type: string
+                                              mode:
+                                                type: integer
+                                                format: int32
+                                              path:
+                                                type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                    csi:
+                                      type: object
+                                      required:
+                                      - driver
+                                      properties:
+                                        driver:
+                                          type: string
+                                        fsType:
+                                          type: string
+                                        nodePublishSecretRef:
+                                          type: object
+                                          properties:
+                                            name:
+                                              type: string
+                                        readOnly:
+                                          type: boolean
+                                        volumeAttributes:
+                                          type: object
+                                          additionalProperties:
+                                            type: string
+                                    downwardAPI:
+                                      type: object
+                                      properties:
+                                        defaultMode:
+                                          type: integer
+                                          format: int32
+                                        items:
+                                          type: array
+                                          items:
+                                            type: object
+                                            required:
+                                            - path
+                                            properties:
+                                              fieldRef:
+                                                type: object
+                                                required:
+                                                - fieldPath
+                                                properties:
+                                                  apiVersion:
+                                                    type: string
+                                                  fieldPath:
+                                                    type: string
+                                              mode:
+                                                type: integer
+                                                format: int32
+                                              path:
+                                                type: string
+                                              resourceFieldRef:
+                                                type: object
+                                                required:
+                                                - resource
+                                                properties:
+                                                  containerName:
+                                                    type: string
+                                                  divisor:
+                                                    type: string
+                                                  resource:
+                                                    type: string
+                                    emptyDir:
+                                      type: object
+                                      properties:
+                                        medium:
+                                          type: string
+                                        sizeLimit:
+                                          type: string
+                                    fc:
+                                      type: object
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        lun:
+                                          type: integer
+                                          format: int32
+                                        readOnly:
+                                          type: boolean
+                                        targetWWNs:
+                                          type: array
+                                          items:
+                                            type: string
+                                        wwids:
+                                          type: array
+                                          items:
+                                            type: string
+                                    flexVolume:
+                                      type: object
+                                      required:
+                                      - driver
+                                      properties:
+                                        driver:
+                                          type: string
+                                        fsType:
+                                          type: string
+                                        options:
+                                          type: object
+                                          additionalProperties:
+                                            type: string
+                                        readOnly:
+                                          type: boolean
+                                        secretRef:
+                                          type: object
+                                          properties:
+                                            name:
+                                              type: string
+                                    flocker:
+                                      type: object
+                                      properties:
+                                        datasetName:
+                                          type: string
+                                        datasetUUID:
+                                          type: string
+                                    gcePersistentDisk:
+                                      type: object
+                                      required:
+                                      - pdName
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        partition:
+                                          type: integer
+                                          format: int32
+                                        pdName:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                    gitRepo:
+                                      type: object
+                                      required:
+                                      - repository
+                                      properties:
+                                        directory:
+                                          type: string
+                                        repository:
+                                          type: string
+                                        revision:
+                                          type: string
+                                    glusterfs:
+                                      type: object
+                                      required:
+                                      - endpoints
+                                      - path
+                                      properties:
+                                        endpoints:
+                                          type: string
+                                        path:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                    hostPath:
+                                      type: object
+                                      required:
+                                      - path
+                                      properties:
+                                        path:
+                                          type: string
+                                        type:
+                                          type: string
+                                    iscsi:
+                                      type: object
+                                      required:
+                                      - iqn
+                                      - lun
+                                      - targetPortal
+                                      properties:
+                                        chapAuthDiscovery:
+                                          type: boolean
+                                        chapAuthSession:
+                                          type: boolean
+                                        fsType:
+                                          type: string
+                                        initiatorName:
+                                          type: string
+                                        iqn:
+                                          type: string
+                                        iscsiInterface:
+                                          type: string
+                                        lun:
+                                          type: integer
+                                          format: int32
+                                        portals:
+                                          type: array
+                                          items:
+                                            type: string
+                                        readOnly:
+                                          type: boolean
+                                        secretRef:
+                                          type: object
+                                          properties:
+                                            name:
+                                              type: string
+                                        targetPortal:
+                                          type: string
+                                    name:
+                                      type: string
+                                    nfs:
+                                      type: object
+                                      required:
+                                      - path
+                                      - server
+                                      properties:
+                                        path:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        server:
+                                          type: string
+                                    persistentVolumeClaim:
+                                      type: object
+                                      required:
+                                      - claimName
+                                      properties:
+                                        claimName:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                    photonPersistentDisk:
+                                      type: object
+                                      required:
+                                      - pdID
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        pdID:
+                                          type: string
+                                    portworxVolume:
+                                      type: object
+                                      required:
+                                      - volumeID
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        volumeID:
+                                          type: string
+                                    projected:
+                                      type: object
+                                      required:
+                                      - sources
+                                      properties:
+                                        defaultMode:
+                                          type: integer
+                                          format: int32
+                                        sources:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              configMap:
+                                                type: object
+                                                properties:
+                                                  items:
+                                                    type: array
+                                                    items:
+                                                      type: object
+                                                      required:
+                                                      - key
+                                                      - path
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        mode:
+                                                          type: integer
+                                                          format: int32
+                                                        path:
+                                                          type: string
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                              downwardAPI:
+                                                type: object
+                                                properties:
+                                                  items:
+                                                    type: array
+                                                    items:
+                                                      type: object
+                                                      required:
+                                                      - path
+                                                      properties:
+                                                        fieldRef:
+                                                          type: object
+                                                          required:
+                                                          - fieldPath
+                                                          properties:
+                                                            apiVersion:
+                                                              type: string
+                                                            fieldPath:
+                                                              type: string
+                                                        mode:
+                                                          type: integer
+                                                          format: int32
+                                                        path:
+                                                          type: string
+                                                        resourceFieldRef:
+                                                          type: object
+                                                          required:
+                                                          - resource
+                                                          properties:
+                                                            containerName:
+                                                              type: string
+                                                            divisor:
+                                                              type: string
+                                                            resource:
+                                                              type: string
+                                              secret:
+                                                type: object
+                                                properties:
+                                                  items:
+                                                    type: array
+                                                    items:
+                                                      type: object
+                                                      required:
+                                                      - key
+                                                      - path
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        mode:
+                                                          type: integer
+                                                          format: int32
+                                                        path:
+                                                          type: string
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                              serviceAccountToken:
+                                                type: object
+                                                required:
+                                                - path
+                                                properties:
+                                                  audience:
+                                                    type: string
+                                                  expirationSeconds:
+                                                    type: integer
+                                                    format: int64
+                                                  path:
+                                                    type: string
+                                    quobyte:
+                                      type: object
+                                      required:
+                                      - registry
+                                      - volume
+                                      properties:
+                                        group:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        registry:
+                                          type: string
+                                        tenant:
+                                          type: string
+                                        user:
+                                          type: string
+                                        volume:
+                                          type: string
+                                    rbd:
+                                      type: object
+                                      required:
+                                      - image
+                                      - monitors
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        image:
+                                          type: string
+                                        keyring:
+                                          type: string
+                                        monitors:
+                                          type: array
+                                          items:
+                                            type: string
+                                        pool:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        secretRef:
+                                          type: object
+                                          properties:
+                                            name:
+                                              type: string
+                                        user:
+                                          type: string
+                                    scaleIO:
+                                      type: object
+                                      required:
+                                      - gateway
+                                      - secretRef
+                                      - system
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        gateway:
+                                          type: string
+                                        protectionDomain:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        secretRef:
+                                          type: object
+                                          properties:
+                                            name:
+                                              type: string
+                                        sslEnabled:
+                                          type: boolean
+                                        storageMode:
+                                          type: string
+                                        storagePool:
+                                          type: string
+                                        system:
+                                          type: string
+                                        volumeName:
+                                          type: string
+                                    secret:
+                                      type: object
+                                      properties:
+                                        defaultMode:
+                                          type: integer
+                                          format: int32
+                                        items:
+                                          type: array
+                                          items:
+                                            type: object
+                                            required:
+                                            - key
+                                            - path
+                                            properties:
+                                              key:
+                                                type: string
+                                              mode:
+                                                type: integer
+                                                format: int32
+                                              path:
+                                                type: string
+                                        optional:
+                                          type: boolean
+                                        secretName:
+                                          type: string
+                                    storageos:
+                                      type: object
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        secretRef:
+                                          type: object
+                                          properties:
+                                            name:
+                                              type: string
+                                        volumeName:
+                                          type: string
+                                        volumeNamespace:
+                                          type: string
+                                    vsphereVolume:
+                                      type: object
+                                      required:
+                                      - volumePath
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        storagePolicyID:
+                                          type: string
+                                        storagePolicyName:
+                                          type: string
+                                        volumePath:
+                                          type: string
+                      ttlSecondsAfterFinished:
+                        type: integer
+                        format: int32
+              readinessGates:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    apiVersion:
+                      type: string
+                    conditionTypes:
+                      type: array
+                      items:
+                        type: string
+                    failureThreshold:
+                      type: integer
+                      format: int32
+                    initialDelaySeconds:
+                      type: integer
+                      format: int32
+                    kind:
+                      type: string
+                    name:
+                      type: string
+                    periodSeconds:
+                      type: integer
+                      format: int32
+                    selector:
+                      type: object
+                      properties:
+                        matchExpressions:
+                          type: array
+                          items:
+                            type: object
+                            required:
+                            - key
+                            - operator
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                type: string
+                              values:
+                                type: array
+                                items:
+                                  type: string
+                        matchLabels:
+                          type: object
+                          additionalProperties:
+                            type: string
+              selector:
+                type: object
+                properties:
+                  matchExpressions:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                      - key
+                      - operator
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          type: string
+                        values:
+                          type: array
+                          items:
+                            type: string
+                  matchLabels:
+                    type: object
+                    additionalProperties:
+                      type: string
+              setupDefaultClusterRole:
+                type: string
+              setupDefaultRules:
+                type: array
+                items:
+                  type: object
+                  required:
+                  - verbs
+                  properties:
+                    apiGroups:
+                      type: array
+                      items:
+                        type: string
+                    nonResourceURLs:
+                      type: array
+                      items:
+                        type: string
+                    resourceNames:
+                      type: array
+                      items:
+                        type: string
+                    resources:
+                      type: array
+                      items:
+                        type: string
+                    verbs:
+                      type: array
+                      items:
+                        type: string
+              setupServiceAccountName:
+                type: string
+              setupTasks:
+                type: array
+                items:
+                  type: object
+                  required:
+                  - name
+                  properties:
+                    helmChart:
+                      type: string
+                    helmChartVersion:
+                      type: string
+                    helmValues:
+                      type: array
+                      items:
+                        type: object
+                        required:
+                        - name
+                        properties:
+                          forceString:
+                            type: boolean
+                          name:
+                            type: string
+                          value:
+                            anyOf:
+                            - type: string
+                            - type: integer
+                          valueFrom:
+                            type: object
+                            properties:
+                              parameterRef:
+                                type: object
+                                required:
+                                - name
+                                properties:
+                                  name:
+                                    type: string
+                    helmValuesFrom:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          configMap:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                    image:
+                      type: string
+                    name:
+                      type: string
+                    skipCreate:
+                      type: boolean
+                    skipDelete:
+                      type: boolean
+                    volumeMounts:
+                      type: array
+                      items:
+                        type: object
+                        required:
+                        - mountPath
+                        - name
+                        properties:
+                          mountPath:
+                            type: string
+                          mountPropagation:
+                            type: string
+                          name:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          subPath:
+                            type: string
+                          subPathExpr:
+                            type: string
+              setupVolumes:
+                type: array
+                items:
+                  type: object
+                  required:
+                  - name
+                  properties:
+                    awsElasticBlockStore:
+                      type: object
+                      required:
+                      - volumeID
+                      properties:
+                        fsType:
+                          type: string
+                        partition:
+                          type: integer
+                          format: int32
+                        readOnly:
+                          type: boolean
+                        volumeID:
+                          type: string
+                    azureDisk:
+                      type: object
+                      required:
+                      - diskName
+                      - diskURI
+                      properties:
+                        cachingMode:
+                          type: string
+                        diskName:
+                          type: string
+                        diskURI:
+                          type: string
+                        fsType:
+                          type: string
+                        kind:
+                          type: string
+                        readOnly:
+                          type: boolean
+                    azureFile:
+                      type: object
+                      required:
+                      - secretName
+                      - shareName
+                      properties:
+                        readOnly:
+                          type: boolean
+                        secretName:
+                          type: string
+                        shareName:
+                          type: string
+                    cephfs:
+                      type: object
+                      required:
+                      - monitors
+                      properties:
+                        monitors:
+                          type: array
+                          items:
+                            type: string
+                        path:
+                          type: string
+                        readOnly:
+                          type: boolean
+                        secretFile:
+                          type: string
+                        secretRef:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                        user:
+                          type: string
+                    cinder:
+                      type: object
+                      required:
+                      - volumeID
+                      properties:
+                        fsType:
+                          type: string
+                        readOnly:
+                          type: boolean
+                        secretRef:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                        volumeID:
+                          type: string
+                    configMap:
+                      type: object
+                      properties:
+                        defaultMode:
+                          type: integer
+                          format: int32
+                        items:
+                          type: array
+                          items:
+                            type: object
+                            required:
+                            - key
+                            - path
+                            properties:
+                              key:
+                                type: string
+                              mode:
+                                type: integer
+                                format: int32
+                              path:
+                                type: string
+                        name:
+                          type: string
+                        optional:
+                          type: boolean
+                    csi:
+                      type: object
+                      required:
+                      - driver
+                      properties:
+                        driver:
+                          type: string
+                        fsType:
+                          type: string
+                        nodePublishSecretRef:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                        readOnly:
+                          type: boolean
+                        volumeAttributes:
+                          type: object
+                          additionalProperties:
+                            type: string
+                    downwardAPI:
+                      type: object
+                      properties:
+                        defaultMode:
+                          type: integer
+                          format: int32
+                        items:
+                          type: array
+                          items:
+                            type: object
+                            required:
+                            - path
+                            properties:
+                              fieldRef:
+                                type: object
+                                required:
+                                - fieldPath
+                                properties:
+                                  apiVersion:
+                                    type: string
+                                  fieldPath:
+                                    type: string
+                              mode:
+                                type: integer
+                                format: int32
+                              path:
+                                type: string
+                              resourceFieldRef:
+                                type: object
+                                required:
+                                - resource
+                                properties:
+                                  containerName:
+                                    type: string
+                                  divisor:
+                                    type: string
+                                  resource:
+                                    type: string
+                    emptyDir:
+                      type: object
+                      properties:
+                        medium:
+                          type: string
+                        sizeLimit:
+                          type: string
+                    fc:
+                      type: object
+                      properties:
+                        fsType:
+                          type: string
+                        lun:
+                          type: integer
+                          format: int32
+                        readOnly:
+                          type: boolean
+                        targetWWNs:
+                          type: array
+                          items:
+                            type: string
+                        wwids:
+                          type: array
+                          items:
+                            type: string
+                    flexVolume:
+                      type: object
+                      required:
+                      - driver
+                      properties:
+                        driver:
+                          type: string
+                        fsType:
+                          type: string
+                        options:
+                          type: object
+                          additionalProperties:
+                            type: string
+                        readOnly:
+                          type: boolean
+                        secretRef:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                    flocker:
+                      type: object
+                      properties:
+                        datasetName:
+                          type: string
+                        datasetUUID:
+                          type: string
+                    gcePersistentDisk:
+                      type: object
+                      required:
+                      - pdName
+                      properties:
+                        fsType:
+                          type: string
+                        partition:
+                          type: integer
+                          format: int32
+                        pdName:
+                          type: string
+                        readOnly:
+                          type: boolean
+                    gitRepo:
+                      type: object
+                      required:
+                      - repository
+                      properties:
+                        directory:
+                          type: string
+                        repository:
+                          type: string
+                        revision:
+                          type: string
+                    glusterfs:
+                      type: object
+                      required:
+                      - endpoints
+                      - path
+                      properties:
+                        endpoints:
+                          type: string
+                        path:
+                          type: string
+                        readOnly:
+                          type: boolean
+                    hostPath:
+                      type: object
+                      required:
+                      - path
+                      properties:
+                        path:
+                          type: string
+                        type:
+                          type: string
+                    iscsi:
+                      type: object
+                      required:
+                      - iqn
+                      - lun
+                      - targetPortal
+                      properties:
+                        chapAuthDiscovery:
+                          type: boolean
+                        chapAuthSession:
+                          type: boolean
+                        fsType:
+                          type: string
+                        initiatorName:
+                          type: string
+                        iqn:
+                          type: string
+                        iscsiInterface:
+                          type: string
+                        lun:
+                          type: integer
+                          format: int32
+                        portals:
+                          type: array
+                          items:
+                            type: string
+                        readOnly:
+                          type: boolean
+                        secretRef:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                        targetPortal:
+                          type: string
+                    name:
+                      type: string
+                    nfs:
+                      type: object
+                      required:
+                      - path
+                      - server
+                      properties:
+                        path:
+                          type: string
+                        readOnly:
+                          type: boolean
+                        server:
+                          type: string
+                    persistentVolumeClaim:
+                      type: object
+                      required:
+                      - claimName
+                      properties:
+                        claimName:
+                          type: string
+                        readOnly:
+                          type: boolean
+                    photonPersistentDisk:
+                      type: object
+                      required:
+                      - pdID
+                      properties:
+                        fsType:
+                          type: string
+                        pdID:
+                          type: string
+                    portworxVolume:
+                      type: object
+                      required:
+                      - volumeID
+                      properties:
+                        fsType:
+                          type: string
+                        readOnly:
+                          type: boolean
+                        volumeID:
+                          type: string
+                    projected:
+                      type: object
+                      required:
+                      - sources
+                      properties:
+                        defaultMode:
+                          type: integer
+                          format: int32
+                        sources:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              configMap:
+                                type: object
+                                properties:
+                                  items:
+                                    type: array
+                                    items:
+                                      type: object
+                                      required:
+                                      - key
+                                      - path
+                                      properties:
+                                        key:
+                                          type: string
+                                        mode:
+                                          type: integer
+                                          format: int32
+                                        path:
+                                          type: string
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                              downwardAPI:
+                                type: object
+                                properties:
+                                  items:
+                                    type: array
+                                    items:
+                                      type: object
+                                      required:
+                                      - path
+                                      properties:
+                                        fieldRef:
+                                          type: object
+                                          required:
+                                          - fieldPath
+                                          properties:
+                                            apiVersion:
+                                              type: string
+                                            fieldPath:
+                                              type: string
+                                        mode:
+                                          type: integer
+                                          format: int32
+                                        path:
+                                          type: string
+                                        resourceFieldRef:
+                                          type: object
+                                          required:
+                                          - resource
+                                          properties:
+                                            containerName:
+                                              type: string
+                                            divisor:
+                                              type: string
+                                            resource:
+                                              type: string
+                              secret:
+                                type: object
+                                properties:
+                                  items:
+                                    type: array
+                                    items:
+                                      type: object
+                                      required:
+                                      - key
+                                      - path
+                                      properties:
+                                        key:
+                                          type: string
+                                        mode:
+                                          type: integer
+                                          format: int32
+                                        path:
+                                          type: string
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                              serviceAccountToken:
+                                type: object
+                                required:
+                                - path
+                                properties:
+                                  audience:
+                                    type: string
+                                  expirationSeconds:
+                                    type: integer
+                                    format: int64
+                                  path:
+                                    type: string
+                    quobyte:
+                      type: object
+                      required:
+                      - registry
+                      - volume
+                      properties:
+                        group:
+                          type: string
+                        readOnly:
+                          type: boolean
+                        registry:
+                          type: string
+                        tenant:
+                          type: string
+                        user:
+                          type: string
+                        volume:
+                          type: string
+                    rbd:
+                      type: object
+                      required:
+                      - image
+                      - monitors
+                      properties:
+                        fsType:
+                          type: string
+                        image:
+                          type: string
+                        keyring:
+                          type: string
+                        monitors:
+                          type: array
+                          items:
+                            type: string
+                        pool:
+                          type: string
+                        readOnly:
+                          type: boolean
+                        secretRef:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                        user:
+                          type: string
+                    scaleIO:
+                      type: object
+                      required:
+                      - gateway
+                      - secretRef
+                      - system
+                      properties:
+                        fsType:
+                          type: string
+                        gateway:
+                          type: string
+                        protectionDomain:
+                          type: string
+                        readOnly:
+                          type: boolean
+                        secretRef:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                        sslEnabled:
+                          type: boolean
+                        storageMode:
+                          type: string
+                        storagePool:
+                          type: string
+                        system:
+                          type: string
+                        volumeName:
+                          type: string
+                    secret:
+                      type: object
+                      properties:
+                        defaultMode:
+                          type: integer
+                          format: int32
+                        items:
+                          type: array
+                          items:
+                            type: object
+                            required:
+                            - key
+                            - path
+                            properties:
+                              key:
+                                type: string
+                              mode:
+                                type: integer
+                                format: int32
+                              path:
+                                type: string
+                        optional:
+                          type: boolean
+                        secretName:
+                          type: string
+                    storageos:
+                      type: object
+                      properties:
+                        fsType:
+                          type: string
+                        readOnly:
+                          type: boolean
+                        secretRef:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                        volumeName:
+                          type: string
+                        volumeNamespace:
+                          type: string
+                    vsphereVolume:
+                      type: object
+                      required:
+                      - volumePath
+                      properties:
+                        fsType:
+                          type: string
+                        storagePolicyID:
+                          type: string
+                        storagePolicyName:
+                          type: string
+                        volumePath:
+                          type: string
+              startTimeOffset:
+                type: string
+              ttlSecondsAfterFailure:
+                type: integer
+                format: int32
+              ttlSecondsAfterFinished:
+                type: integer
+                format: int32
+              values:
+                type: array
+                items:
+                  type: object
+                  required:
+                  - name
+                  - value
+                  properties:
+                    attemptsRemaining:
+                      type: integer
+                    error:
+                      type: string
+                    name:
+                      type: string
+                    value:
+                      type: string
+          status:
+            type: object
+            required:
+            - assignments
+            - phase
+            - values
+            properties:
+              assignments:
+                type: string
+              completionTime:
+                type: string
+                format: date-time
+              conditions:
+                type: array
+                items:
+                  type: object
+                  required:
+                  - lastProbeTime
+                  - lastTransitionTime
+                  - status
+                  - type
+                  properties:
+                    lastProbeTime:
+                      type: string
+                      format: date-time
+                    lastTransitionTime:
+                      type: string
+                      format: date-time
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+              patchOperations:
+                type: array
+                items:
+                  type: object
+                  required:
+                  - data
+                  - patchType
+                  - targetRef
+                  properties:
+                    attemptsRemaining:
+                      type: integer
+                    data:
+                      type: string
+                      format: byte
+                    patchType:
+                      type: string
+                    targetRef:
+                      type: object
+                      properties:
+                        apiVersion:
+                          type: string
+                        fieldPath:
+                          type: string
+                        kind:
+                          type: string
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                        resourceVersion:
+                          type: string
+                        uid:
+                          type: string
+              phase:
+                type: string
+              readinessChecks:
+                type: array
+                items:
+                  type: object
+                  required:
+                  - targetRef
+                  properties:
+                    attemptsRemaining:
+                      type: integer
+                      format: int32
+                    conditionTypes:
+                      type: array
+                      items:
+                        type: string
+                    initialDelaySeconds:
+                      type: integer
+                      format: int32
+                    lastCheckTime:
+                      type: string
+                      format: date-time
+                    periodSeconds:
+                      type: integer
+                      format: int32
+                    selector:
+                      type: object
+                      properties:
+                        matchExpressions:
+                          type: array
+                          items:
+                            type: object
+                            required:
+                            - key
+                            - operator
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                type: string
+                              values:
+                                type: array
+                                items:
+                                  type: string
+                        matchLabels:
+                          type: object
+                          additionalProperties:
+                            type: string
+                    targetRef:
+                      type: object
+                      properties:
+                        apiVersion:
+                          type: string
+                        fieldPath:
+                          type: string
+                        kind:
+                          type: string
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                        resourceVersion:
+                          type: string
+                        uid:
+                          type: string
+              startTime:
+                type: string
+                format: date-time
+              values:
+                type: string
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
Apparently you can generate the schema for multi-version, legacy CRDs.