### PR TITLE
Fix redskyctl Docker image not getting pushed

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -60,7 +60,6 @@ jobs:
       - name: Build controller
         run: |
           make docker-build-ci
-          make docker-push
       - name: Build tool
         uses: goreleaser/goreleaser-action@v1
         with:
@@ -68,13 +67,14 @@ jobs:
           key: ${{ secrets.BMASTERS_PRIVATE_KEY }}
         env:
           GITHUB_TOKEN: ${{ secrets.BMASTERS_TOKEN }}
-      - name: Tag Docker images
+      - name: Push Docker images
         run: |
           docker tag "${IMG}" "${IMG%%:*}:${DOCKER_TAG}"
-          docker push "${IMG%%:*}:${DOCKER_TAG}"
           docker tag "${REDSKYCTL_IMG}" "${REDSKYCTL_IMG%%:*}:${DOCKER_TAG}"
-          docker push "${REDSKYCTL_IMG%%:*}:${DOCKER_TAG}"
           docker tag "${SETUPTOOLS_IMG}" "${SETUPTOOLS_IMG%%:*}:${DOCKER_TAG}"
+          make docker-push
+          docker push "${IMG%%:*}:${DOCKER_TAG}"
+          docker push "${REDSKYCTL_IMG%%:*}:${DOCKER_TAG}"
           docker push "${SETUPTOOLS_IMG%%:*}:${DOCKER_TAG}"
       - name: Upload macOS binary
         uses: actions/upload-artifact@v1

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -80,11 +80,13 @@ jobs:
       - name: Build controller
         run: |
           make docker-build-ci
-          make docker-push
       - name: Build tool
         uses: goreleaser/goreleaser-action@v1
         with:
           args: release --skip-sign --rm-dist
+      - name: Push Docker images
+        run: |
+          make docker-push
       - name: Upload macOS binary
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -57,7 +57,7 @@ jobs:
           project_id: ${{ secrets.GOOGLE_PROJECT_ID }}
       - name: Bootstrap
         run: |
-          TAG=${GITHUB_SHA:0:8}.${GITHUB_RUN_ID}
+          TAG=${GITHUB_SHA:0:8}.${GITHUB_RUN_NUMBER}
           echo "::set-env name=IMG::gcr.io/${{ secrets.GOOGLE_PROJECT_ID }}/redskyops-controller:${TAG}"
           echo "::set-env name=REDSKYCTL_IMG::gcr.io/${{ secrets.GOOGLE_PROJECT_ID }}/redskyctl:${TAG}"
           echo "::set-env name=SETUPTOOLS_IMG::gcr.io/${{ secrets.GOOGLE_PROJECT_ID }}/setuptools:${TAG}"

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,7 @@ docker-build-ci:
 docker-push:
 	docker push ${IMG}
 	docker push ${SETUPTOOLS_IMG}
+	docker push ${REDSKYCTL_IMG}
 
 # find or download controller-gen
 # download controller-gen if necessary


### PR DESCRIPTION
The GoReleaser plugin will not push if publishing is globally skipped (i.e. all non`refs/tags` builds) OR if the release has `draft: true` (which is always the case to allow for the changelog to be updated by a human).