### PR TITLE
Generation commands should handle v1alpha1 experiments as input

### DIFF
--- a/internal/controller/negotiation.go
+++ b/internal/controller/negotiation.go
@@ -42,13 +42,17 @@ import (
 // objects occurs during client-go reads into the cache. This ensures the controller never actually sees old
 // representations of the objects (and we lazily migrate storage to the latest representation).
 func WithConversion(config *rest.Config, scheme *runtime.Scheme) *rest.Config {
-	config.NegotiatedSerializer = &ConversionSerializer{
-		NegotiatedSerializer: serializer.WithoutConversionCodecFactory{
-			CodecFactory: serializer.NewCodecFactory(scheme),
-		},
-		scheme: scheme,
-	}
+	config.NegotiatedSerializer = NewConversionSerializer(scheme)
 	return config
+}
+
+// NewConversionSerializer creates a new negotiated serializer that handles detection/conversion between versions
+// of redskyops.dev objects.
+func NewConversionSerializer(scheme *runtime.Scheme) runtime.NegotiatedSerializer {
+	return &ConversionSerializer{
+		NegotiatedSerializer: serializer.NewCodecFactory(scheme).WithoutConversion(),
+		scheme:               scheme,
+	}
 }
 
 // ConversionSerializer is a negotiated serializer that also handles the representation migration hack.

--- a/redskyctl/internal/commands/generate/generate.go
+++ b/redskyctl/internal/commands/generate/generate.go
@@ -59,8 +59,8 @@ func NewCommand(o *Options) *cobra.Command {
 	return cmd
 }
 
-// readExperiment unmarshals experiment data
-func readExperiment(filename string, defaultReader io.Reader, list *redskyv1beta1.ExperimentList) error {
+// readExperiments unmarshals experiment data
+func readExperiments(filename string, defaultReader io.Reader, list *redskyv1beta1.ExperimentList) error {
 	if filename == "" {
 		return nil
 	}

--- a/redskyctl/internal/commands/generate/rbac.go
+++ b/redskyctl/internal/commands/generate/rbac.go
@@ -97,10 +97,8 @@ func (o *RBACOptions) Complete() {
 
 func (o *RBACOptions) generate() error {
 	// Read the experiments
-	// TODO For now just pretend like `readExperiment` could return multiple results
 	experimentList := &redskyv1beta1.ExperimentList{}
-	experimentList.Items = make([]redskyv1beta1.Experiment, 1)
-	if err := readExperiment(o.Filename, o.In, &experimentList.Items[0]); err != nil {
+	if err := readExperiment(o.Filename, o.In, experimentList); err != nil {
 		return err
 	}
 

--- a/redskyctl/internal/commands/generate/rbac.go
+++ b/redskyctl/internal/commands/generate/rbac.go
@@ -98,7 +98,7 @@ func (o *RBACOptions) Complete() {
 func (o *RBACOptions) generate() error {
 	// Read the experiments
 	experimentList := &redskyv1beta1.ExperimentList{}
-	if err := readExperiment(o.Filename, o.In, experimentList); err != nil {
+	if err := readExperiments(o.Filename, o.In, experimentList); err != nil {
 		return err
 	}
 

--- a/redskyctl/internal/commands/generate/trial.go
+++ b/redskyctl/internal/commands/generate/trial.go
@@ -64,12 +64,16 @@ func NewTrialCommand(o *TrialOptions) *cobra.Command {
 }
 
 func (o *TrialOptions) generate() error {
-	// TODO When "readExperiment" returns multiple experiments, this whole thing runs in a loop...
-	exp := &redskyv1beta1.Experiment{}
-	if err := readExperiment(o.Filename, o.In, exp); err != nil {
+	// Read the experiments
+	experimentList := &redskyv1beta1.ExperimentList{}
+	if err := readExperiment(o.Filename, o.In, experimentList); err != nil {
 		return err
 	}
+	if len(experimentList.Items) != 1 {
+		return fmt.Errorf("trial generation requires a single experiment as input")
+	}
 
+	exp := &experimentList.Items[0]
 	if len(exp.Spec.Parameters) == 0 {
 		return fmt.Errorf("experiment must contain at least one parameter")
 	}

--- a/redskyctl/internal/commands/generate/trial.go
+++ b/redskyctl/internal/commands/generate/trial.go
@@ -66,7 +66,7 @@ func NewTrialCommand(o *TrialOptions) *cobra.Command {
 func (o *TrialOptions) generate() error {
 	// Read the experiments
 	experimentList := &redskyv1beta1.ExperimentList{}
-	if err := readExperiment(o.Filename, o.In, experimentList); err != nil {
+	if err := readExperiments(o.Filename, o.In, experimentList); err != nil {
 		return err
 	}
 	if len(experimentList.Items) != 1 {


### PR DESCRIPTION
The `readExperiment` (which is now `readExperiments`) was just doing a raw YAML decode into an `Experiment`. Now we are using the same decoder we used to trick `client-go` into thinking that we always read in `v1beta1` objects.

There is an extra conversion necessary for two reasons. First: the goal of this function is read a list of experiments, not necessarily a single experiment; when a single experiment is provided we need to make it into a list of experiments (for which there is shocking no generic code that I could find). Second: unlike when reading from the API server (which will "convert" by simply overwriting the `apiVersion` to `v1beta1`), when reading from disk the `apiVersion` should actually match the representation; this means we may end up getting a `*redskyv1alpha1.Experiment` out of decode.