### PR TITLE
Build improvements

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -76,6 +76,9 @@ jobs:
           args: release --rm-dist --release-notes hack/changelog.md.txt
         env:
           GITHUB_TOKEN: ${{ secrets.BMASTERS_TOKEN }}
+          AC_USERNAME: ${{ secrets.AC_USERNAME }}
+          AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
+          AC_IDENTITY_P12: ${{ secrets.AC_IDENTITY_P12 }}
       - name: Push Docker images
         run: |
           docker tag "${IMG}" "${IMG%%:*}:${DOCKER_TAG}"

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -47,21 +47,26 @@ jobs:
         env:
           GPG_PRIVATE_KEY: ${{ secrets.BMASTERS_PRIVATE_KEY }}
       - name: Bootstrap
+        env:
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         run: |
           if [ -z "${GITHUB_REF/refs\/tags\/*/}" ]; then
-            echo "::set-env name=VERSION::${GITHUB_REF##*/}"
             TAG=${GITHUB_REF##*/v}
-            DOCKER_TAG=latest
+            echo "::set-env name=DOCKER_TAG::latest"
+            echo "::set-env name=VERSION::v${TAG}"
+            echo "::set-env name=IMG::redskyops/redskyops-controller:${TAG}"
+            echo "::set-env name=REDSKYCTL_IMG::redskyops/redskyctl:${TAG}"
+            echo "::set-env name=SETUPTOOLS_IMG::redskyops/setuptools:${TAG}"
+            printenv DOCKER_PASSWORD | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
           else
-            TAG=${GITHUB_SHA:0:8}.${GITHUB_RUN_NUMBER}
-            DOCKER_TAG=canary
+            TAG="sha-$(git rev-parse --short HEAD)"
+            echo "::set-env name=DOCKER_TAG::canary" # TODO This should change to "latest" after the 1.6.0 release
+            echo "::set-env name=IMG::gcr.io/${{ secrets.GOOGLE_PROJECT_ID }}/redskyops-controller:${TAG}"
+            echo "::set-env name=REDSKYCTL_IMG::gcr.io/${{ secrets.GOOGLE_PROJECT_ID }}/redskyctl:${TAG}"
+            echo "::set-env name=SETUPTOOLS_IMG::gcr.io/${{ secrets.GOOGLE_PROJECT_ID }}/setuptools:${TAG}"
+            gcloud --quiet auth configure-docker
           fi
-          echo "::set-env name=IMG::gcr.io/${{ secrets.GOOGLE_PROJECT_ID }}/redskyops-controller:${TAG}"
-          echo "::set-env name=REDSKYCTL_IMG::gcr.io/${{ secrets.GOOGLE_PROJECT_ID }}/redskyctl:${TAG}"
-          echo "::set-env name=SETUPTOOLS_IMG::gcr.io/${{ secrets.GOOGLE_PROJECT_ID }}/setuptools:${TAG}"
           echo "::set-env name=PULL_POLICY::Always"
-          echo "::set-env name=DOCKER_TAG::${DOCKER_TAG}"
-          gcloud --quiet auth configure-docker
       - name: Build controller
         run: |
           make docker-build-ci

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -57,6 +57,7 @@ jobs:
             echo "::set-env name=IMG::redskyops/redskyops-controller:${TAG}"
             echo "::set-env name=REDSKYCTL_IMG::redskyops/redskyctl:${TAG}"
             echo "::set-env name=SETUPTOOLS_IMG::redskyops/setuptools:${TAG}"
+            echo "::set-env name=AC_USERNAME::${{ secrets.AC_USERNAME }}"
             printenv DOCKER_PASSWORD | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
           else
             TAG="sha-$(git rev-parse --short HEAD)"
@@ -76,7 +77,6 @@ jobs:
           args: release --rm-dist --release-notes hack/changelog.md.txt
         env:
           GITHUB_TOKEN: ${{ secrets.BMASTERS_TOKEN }}
-          AC_USERNAME: ${{ secrets.AC_USERNAME }}
           AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
           AC_IDENTITY_P12: ${{ secrets.AC_IDENTITY_P12 }}
       - name: Push Docker images

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -41,6 +41,11 @@ jobs:
           service_account_email: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
           service_account_key: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY }}
           project_id: ${{ secrets.GOOGLE_PROJECT_ID }}
+      - name: Import GPG key
+        id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@v2
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.BMASTERS_PRIVATE_KEY }}
       - name: Bootstrap
         run: |
           if [ -z "${GITHUB_REF/refs\/tags\/*/}" ]; then
@@ -61,10 +66,9 @@ jobs:
         run: |
           make docker-build-ci
       - name: Build tool
-        uses: goreleaser/goreleaser-action@v1
+        uses: goreleaser/goreleaser-action@v2
         with:
           args: release --rm-dist --release-notes hack/changelog.md.txt
-          key: ${{ secrets.BMASTERS_PRIVATE_KEY }}
         env:
           GITHUB_TOKEN: ${{ secrets.BMASTERS_TOKEN }}
       - name: Push Docker images

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Build and Deploy
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     env:
       BUILD_METADATA: build.${{ github.run_number }}
       GIT_COMMIT: ${{ github.sha }}

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -81,7 +81,7 @@ jobs:
         run: |
           make docker-build-ci
       - name: Build tool
-        uses: goreleaser/goreleaser-action@v1
+        uses: goreleaser/goreleaser-action@v2
         with:
           args: release --skip-sign --rm-dist
       - name: Push Docker images

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -57,11 +57,12 @@ jobs:
           project_id: ${{ secrets.GOOGLE_PROJECT_ID }}
       - name: Bootstrap
         run: |
-          TAG=${GITHUB_SHA:0:8}.${GITHUB_RUN_NUMBER}
+          TAG="sha-$(git rev-parse --short HEAD)"
           echo "::set-env name=IMG::gcr.io/${{ secrets.GOOGLE_PROJECT_ID }}/redskyops-controller:${TAG}"
           echo "::set-env name=REDSKYCTL_IMG::gcr.io/${{ secrets.GOOGLE_PROJECT_ID }}/redskyctl:${TAG}"
           echo "::set-env name=SETUPTOOLS_IMG::gcr.io/${{ secrets.GOOGLE_PROJECT_ID }}/setuptools:${TAG}"
           echo "::set-env name=PULL_POLICY::Always"
+          echo "::set-env name=DOCKER_TAG::pr-${{ github.event.number }}"
           gcloud --quiet auth configure-docker
       - name: Cache Go Modules
         uses: actions/cache@v1
@@ -86,7 +87,13 @@ jobs:
           args: release --skip-sign --rm-dist
       - name: Push Docker images
         run: |
+          docker tag "${IMG}" "${IMG%%:*}:${DOCKER_TAG}"
+          docker tag "${REDSKYCTL_IMG}" "${REDSKYCTL_IMG%%:*}:${DOCKER_TAG}"
+          docker tag "${SETUPTOOLS_IMG}" "${SETUPTOOLS_IMG%%:*}:${DOCKER_TAG}"
           make docker-push
+          docker push "${IMG%%:*}:${DOCKER_TAG}"
+          docker push "${REDSKYCTL_IMG%%:*}:${DOCKER_TAG}"
+          docker push "${SETUPTOOLS_IMG%%:*}:${DOCKER_TAG}"
       - name: Upload macOS binary
         uses: actions/upload-artifact@v2
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,6 +15,9 @@ builds:
       - '-X github.com/redskyops/redskyops-controller/internal/version.BuildMetadata={{ .Env.BUILD_METADATA }}'
       - '-X github.com/redskyops/redskyops-controller/internal/setup.Image={{ .Env.SETUPTOOLS_IMG }}'
       - '-X github.com/redskyops/redskyops-controller/internal/setup.ImagePullPolicy={{ .Env.PULL_POLICY }}'
+    hooks:
+      post:
+        - hack/codesign.sh "{{ .Path }}"
 checksum:
   name_template: "checksums.txt"
 snapshot:
@@ -41,3 +44,7 @@ brews:
     description: Kubernetes Exploration
 signs:
   - artifacts: checksum
+  - id: notarization
+    cmd: hack/notarize.sh
+    args: ["${artifact}"]
+    artifacts: all

--- a/hack/codesign.sh
+++ b/hack/codesign.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -eu
+
+# Code Signing
+# ============
+# This script facilitates code signing of binaries for macOS. This script conditionally signs a binary
+# under the following conditions:
+# 1. The binary path contains "darwin" (this prevents duplicating GoReleaser build configurations)
+# 2. The `security` and `codesign` programs are available (this allows the script to be run on Linux)
+# 3. The P12 key pair used as the signing identity is available (allows the script to be run on non-release builds)
+
+# Verify, but exit normally to ensure the conditional nature of the checks
+FILE="${1:?missing file argument}"
+[ "$(basename "$(dirname "$FILE")")" == "redskyctl_darwin_amd64" ] || { echo >&2 "skipping code signing on file '$1'"; exit; }
+command -v security >/dev/null 2>&1 || { echo >&2 "skipping code signing, security not present"; exit; }
+command -v codesign >/dev/null 2>&1 || { echo >&2 "skipping code signing, codesign not present"; exit; }
+[ -n "${AC_IDENTITY_P12:-}" ] || { echo >&2 "skipping code signing, no signing identity"; exit; }
+
+# Create a temporary location for the keychain
+AC_IDENTITY_PASSPHRASE="${AC_IDENTITY_PASSPHRASE:-$AC_PASSWORD}"
+KEYCHAIN_PASSWORD="$(openssl rand -base64 30)"
+KEYCHAIN="$(mktemp -d)/codesigning.keychain-db"
+removeKeychain() {
+  rm -rf "$(dirname "$KEYCHAIN")"
+}
+trap removeKeychain EXIT
+
+# Create an unlocked keychain for signing
+security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+security set-keychain-settings "$KEYCHAIN" # Unset keychain settings (disable lock)
+security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+
+# Import the signing identity to the temporary keychain
+security import <(printenv AC_IDENTITY_P12 | base64 -D) -f pkcs12 -k "$KEYCHAIN" -P "$AC_IDENTITY_PASSPHRASE" -T "$(command -v codesign)" >/dev/null
+IDENTITY="$(security find-identity -v -p "codesigning" "$KEYCHAIN" | grep "1)" | awk '{print $2}')"
+
+# Update the keychain search list so codesign can use it
+security list-keychains -d user -s "$KEYCHAIN"
+restoreKeychain() {
+  security list-keychains -d user -s login.keychain
+}
+trap restoreKeychain EXIT
+
+# Actually sign the supplied file
+codesign --keychain "$KEYCHAIN" --sign "$IDENTITY" --force --verbose --timestamp --options "runtime" "$FILE"

--- a/hack/notarize.sh
+++ b/hack/notarize.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -eu
+
+# Notarization
+# ============
+# This script uploads binaries to Apple to get the code signatures trusted. Like the codesign script,
+# it only makes sense to do this conditionally.
+
+FILE="${1:?missing file argument}"
+NAME="$(basename "$FILE" ".tar.gz")"
+[ "$NAME" == "redskyctl-darwin-amd64" ] || { echo >&2 "skipping notarization for file=[$1]"; exit; }
+command -v ditto >/dev/null 2>&1 || { echo >&2 "skipping notarization, ditto not present"; exit; }
+command -v xcrun >/dev/null 2>&1 || { echo >&2 "skipping notarization, xcrun not present"; exit; }
+command -v jq >/dev/null 2>&1 || { echo >&2 "skipping notarization, jq not present"; exit; }
+[ -n "${AC_USERNAME:-}" ] || { echo >&2 "skipping notarization, no credentials"; exit; }
+[ -n "${AC_PASSWORD:-}" ] || { echo >&2 "skipping notarization, no credentials"; exit; }
+
+# Create a temporary location to perform notarization
+WORKDIR="$(mktemp -d)"
+function removeWorkdir()
+{
+  rm -rf "$WORKDIR"
+}
+trap removeWorkdir EXIT
+
+# Re-archive as a Zip
+mkdir "$WORKDIR/$NAME"
+tar -xf "$FILE" -C "$WORKDIR/$NAME"
+ditto -c -k "$WORKDIR/$NAME" "$WORKDIR/$NAME.zip"
+
+# Helper functions
+doNotarizeApp() {
+  xcrun altool --notarize-app --file "$1" --primary-bundle-id "dev.redskyops.redskyctl" \
+    -u "$AC_USERNAME" -p "@env:AC_PASSWORD" --output-format json | jq '."notarization-upload"'
+}
+doNotarizeInfo() {
+  xcrun altool --notarization-info "$1" \
+    -u "$AC_USERNAME" -p "@env:AC_PASSWORD" --output-format json | jq '."notarization-info"'
+}
+
+# Submit the Zip file for notarization, retain the request identifier
+REQUEST_UUID="$(doNotarizeApp "$WORKDIR/$NAME.zip" | jq -r '.RequestUUID')"
+echo >&2 "notarization request submitted id=$REQUEST_UUID"
+
+# Wait for a result
+SLEEP_TIME=10
+while true; do
+  sleep $SLEEP_TIME
+  INFO=$(doNotarizeInfo "$REQUEST_UUID")
+  case "$(echo "$INFO" | jq -r '.Status')" in
+    "in progress")
+      SLEEP_TIME=5
+      ;;
+    "success")
+      exit
+      ;;
+    "invalid")
+      LOG_FILE_URL="$(echo "$INFO" | jq -r '.LogFileURL')"
+      LOG="$(curl --silent "$LOG_FILE_URL")"
+      echo >&2 "notarization failed: $(echo "$LOG" | jq -r '.statusSummary')"
+      echo >&2 "more details: $LOG_FILE_URL"
+      exit 1
+      ;;
+  esac
+done


### PR DESCRIPTION
This is really a combination of build improvements for release builds:
1. GoReleaser Action update
2. Release images now go to Docker Hub (CI images continue to go to GCR)
3. Code signing and notarization for macOS

For the code signing, I originally wanted to use gon, however between the inconsistent examples and the pain of having to mass duplicate a bulk of the GoReleaser configuration, I opted instead to add two scripts. Both scripts are basically no-ops if we are not running on macOS or if the binary (or archive) in question is not targeted for macOS. The code signing script runs against every single "master" build (we do not sign PRs), however just because the binaries are signed, it does not mean GateKeeper will let them through. The benefit of this approach is that the rest of our build pipeline remains in-tact (e.g. we do not need to switch to `.zip` archives), once the binary itself is signed it doesn't matter how it gets packaged. Notarization is the process of submitting the signed binary to Apple: they do not accept tarballs so we re-package to a Zip file before sending it off. Notarization is configured as a "signing" step in GoReleaser which means it is essentially skipped everywhere but on release builds.