### PR TITLE
fix: Restrict kube matrix workflows to master pushes

### DIFF
--- a/.github/workflows/kubematrix.yaml
+++ b/.github/workflows/kubematrix.yaml
@@ -1,7 +1,6 @@
 name: Matrix workflow
 on:
-  #push:
-  pull_request:
+  push:
     branches:
       - master
 jobs:


### PR DESCRIPTION
Signed-off-by: Brad Beam <brad.beam@carbonrelay.com>