### PR TITLE
fix: Reference correct workflow when downloading artifacts

### DIFF
--- a/.github/workflows/kubematrix.yaml
+++ b/.github/workflows/kubematrix.yaml
@@ -51,8 +51,7 @@ jobs:
         uses: dawidd6/action-download-artifact@v2
         with:
           github_token: ${{secrets.GITHUB_TOKEN}}
-          #workflow: master.yaml
-          workflow: push.yaml
+          workflow: master.yaml
           name: redskyctl_linux_amd64
           path: dist/redskyctl_linux_amd64
           commit: ${{ github.event.pull_request.head.sha || github.sha }}


### PR DESCRIPTION
Hopefully this fixes the recent failure. 

Signed-off-by: Brad Beam <brad.beam@carbonrelay.com>