### PR TITLE
refactor: Allow kustomize to be more composable

### DIFF
--- a/redskyctl/internal/commands/initialize/generator.go
+++ b/redskyctl/internal/commands/initialize/generator.go
@@ -77,6 +77,7 @@ func (o *GeneratorOptions) generate(ctx context.Context) error {
 	}
 
 	yamls, err := kustomize.Yamls(
+		kustomize.WithInstall(),
 		kustomize.WithImage(o.Image),
 		kustomize.WithNamespace(ctrl.Namespace),
 		kustomize.WithAPI(apiEnabled),

--- a/redskyctl/internal/commands/initialize/initialize.go
+++ b/redskyctl/internal/commands/initialize/initialize.go
@@ -145,6 +145,7 @@ func (o *Options) generateInstall(ctx context.Context) (io.Reader, error) {
 	}
 
 	yamls, err := kustomize.Yamls(
+		kustomize.WithInstall(),
 		kustomize.WithNamespace(ctrl.Namespace),
 		kustomize.WithImage(o.Image),
 		kustomize.WithLabels(map[string]string{

--- a/redskyctl/internal/kustomize/assets.go
+++ b/redskyctl/internal/kustomize/assets.go
@@ -35,8 +35,8 @@ type Asset struct {
 	bytes []byte
 }
 
-var Assets = map[string]Asset{
-	"stock": kustomizeBase,
+var Assets = map[string]*Asset{
+	"stock": &kustomizeBase,
 }
 
 // Reader is a convenience function to provide an io.Reader interface for the
@@ -88,4 +88,10 @@ func (a *Asset) decode() (err error) {
 	a.bytes = output.Bytes()
 
 	return nil
+}
+
+func NewAssetFromBytes(b []byte) *Asset {
+	return &Asset{
+		bytes: b,
+	}
 }

--- a/redskyctl/internal/kustomize/kustomize.go
+++ b/redskyctl/internal/kustomize/kustomize.go
@@ -42,20 +42,6 @@ type Kustomize struct {
 func NewKustomization(setters ...Option) (k *Kustomize, err error) {
 	k = defaultOptions()
 
-	// Write out all assets to in memory filesystem
-	for name, asset := range Assets {
-		k.kustomize.Resources = append(k.kustomize.Resources, name)
-
-		var assetBytes []byte
-		if assetBytes, err = asset.Bytes(); err != nil {
-			return k, err
-		}
-
-		if err = k.fs.WriteFile(filepath.Join(k.Base, name), assetBytes); err != nil {
-			return k, err
-		}
-	}
-
 	// Update settings for kustomization
 	for _, setter := range setters {
 		if err = setter(k); err != nil {

--- a/redskyctl/internal/kustomize/kustomize_test.go
+++ b/redskyctl/internal/kustomize/kustomize_test.go
@@ -35,7 +35,8 @@ func Test(t *testing.T) {
 		}
 	}{
 		{
-			desc: "default",
+			desc:    "default",
+			options: []Option{WithInstall()},
 			expected: struct {
 				Namespace string
 				Image     string
@@ -46,7 +47,7 @@ func Test(t *testing.T) {
 		},
 		{
 			desc:    "custom namespace",
-			options: []Option{WithNamespace("trololololo")},
+			options: []Option{WithInstall(), WithNamespace("trololololo")},
 			expected: struct {
 				Namespace string
 				Image     string
@@ -57,7 +58,7 @@ func Test(t *testing.T) {
 		},
 		{
 			desc:    "custom image",
-			options: []Option{WithImage("mycoolregistry.com/image:tag")},
+			options: []Option{WithInstall(), WithImage("mycoolregistry.com/image:tag")},
 			expected: struct {
 				Namespace string
 				Image     string


### PR DESCRIPTION
This removes the hardcoded restriction on using embedded assets only and
exposes WithAssets and WithPatches to allow our kustomize wrapper to be
more reusable.

Signed-off-by: Brad Beam <brad.beam@carbonrelay.com>
