### PR TITLE
fix: Fix datadog application key

### DIFF
--- a/internal/metric/datadog.go
+++ b/internal/metric/datadog.go
@@ -33,7 +33,7 @@ func captureDatadogMetric(aggregator, query string, startTime, completionTime ti
 
 	applicationKey := os.Getenv("DATADOG_APP_KEY")
 	if applicationKey == "" {
-		apiKey = os.Getenv("DD_APP_KEY")
+		applicationKey = os.Getenv("DD_APP_KEY")
 	}
 
 	client := datadog.NewClient(apiKey, applicationKey)


### PR DESCRIPTION
We were erroneously setting apikey to the value of the environment
variable for application key.

Signed-off-by: Brad Beam <brad.beam@carbonrelay.com>