### PR TITLE
Make delete better at deleting

### DIFF
--- a/redskyctl/internal/commands/experiments/delete.go
+++ b/redskyctl/internal/commands/experiments/delete.go
@@ -76,7 +76,7 @@ func (o *DeleteOptions) delete(ctx context.Context) error {
 	return nil
 }
 
-// ignoreDelete error is helper for ignoring errors that occur during deletion
+// ignoreDeleteError is a helper for ignoring errors that occur during deletion
 func (o *DeleteOptions) ignoreDeleteError(err error) error {
 	if o.IgnoreNotFound && controller.IgnoreNotFound(err) == nil {
 		return nil
@@ -84,9 +84,11 @@ func (o *DeleteOptions) ignoreDeleteError(err error) error {
 	return err
 }
 
+// deleteExperiment deletes an individual experiment by name
+//noinspection GoNilness
 func (o *DeleteOptions) deleteExperiment(ctx context.Context, name experimentsv1alpha1.ExperimentName) error {
 	exp, err := o.ExperimentsAPI.GetExperimentByName(ctx, name)
-	if err != nil {
+	if err != nil && exp.SelfURL == "" {
 		return err
 	}
 


### PR DESCRIPTION
When we do a delete, we first fetch the object. If there are schema incompatibilities this fetch fails. However, we are deleting the thing, it doesn't matter if it is bad. All that matters is we can get the `SelfURL` off of it. Since metadata is deserialized before the JSON body, it is possible that we already have the `SelfURL` at the time most JSON incompatibilities occur, so we can safely ignore the error if we already have the URL.