### PR TITLE
Auth changes

### DIFF
--- a/docs/redskyctl/redskyctl_config_view.md
+++ b/docs/redskyctl/redskyctl_config_view.md
@@ -13,9 +13,10 @@ redskyctl config view [flags]
 ### Options
 
 ```
-  -h, --help     help for view
-      --minify   Reduce information to effective values.
-      --raw      Display the raw configuration file without merging.
+  -h, --help            help for view
+      --minify          Reduce information to effective values.
+  -o, --output format   Output format. One of: yaml|json (default "yaml")
+      --raw             Display the raw configuration file without merging.
 ```
 
 ### Options inherited from parent commands

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -94,9 +94,9 @@ func defaultServerEndpoints(srv *Server) error {
 
 	// Special case for the registration service which is actually part of the accounts API
 	if u, err := url.Parse(srv.RedSky.AccountsEndpoint); err != nil {
-		defaultString(&srv.Authorization.RegistrationEndpoint, api+"/accounts/clients/register")
+		defaultString(&srv.Authorization.RegistrationEndpoint, api+"/accounts/clients")
 	} else {
-		u.Path = strings.TrimRight(u.Path, "/") + "/clients/register"
+		u.Path = strings.TrimRight(u.Path, "/") + "/clients"
 		defaultString(&srv.Authorization.RegistrationEndpoint, u.String())
 	}
 


### PR DESCRIPTION
The new registration endpoint is deployed in prod so we don't need `/register` on the end of the path anymore.

Also, I really just wanted to pipe my config into jq while testing.