### PR TITLE
Set GCP Setup Action to a fixed version

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -54,7 +54,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gobuildcache-
       - name: Set up Google Cloud Platform
-        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        uses: GoogleCloudPlatform/github-actions/setup-gcloud@0.1.3
         with:
           service_account_email: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
           service_account_key: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY }}

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -53,7 +53,7 @@ jobs:
           wait: 0s
       - name: Set up Google Cloud Platform
         if: github.event.pull_request.head.repo.fork == false
-        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        uses: GoogleCloudPlatform/github-actions/setup-gcloud@0.1.3
         with:
           service_account_email: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
           service_account_key: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY }}


### PR DESCRIPTION
Looks like they finally released the version that lets you set the project ID without a warning.