### PR TITLE
chore: Add additional tests to kustomize

### DIFF
--- a/redskyctl/internal/kustomize/kustomize_test.go
+++ b/redskyctl/internal/kustomize/kustomize_test.go
@@ -32,6 +32,7 @@ func Test(t *testing.T) {
 		expected struct {
 			Namespace string
 			Image     string
+			Secret    bool
 		}
 	}{
 		{
@@ -40,6 +41,7 @@ func Test(t *testing.T) {
 			expected: struct {
 				Namespace string
 				Image     string
+				Secret    bool
 			}{
 				Namespace: "redsky-system",
 				Image:     BuildImage,
@@ -51,6 +53,7 @@ func Test(t *testing.T) {
 			expected: struct {
 				Namespace string
 				Image     string
+				Secret    bool
 			}{
 				Namespace: "trololololo",
 				Image:     BuildImage,
@@ -62,15 +65,32 @@ func Test(t *testing.T) {
 			expected: struct {
 				Namespace string
 				Image     string
+				Secret    bool
 			}{
 				Namespace: "redsky-system",
 				Image:     "mycoolregistry.com/image:tag",
+			},
+		},
+		{
+			desc:    "with api",
+			options: []Option{WithInstall(), WithAPI(true)},
+			expected: struct {
+				Namespace string
+				Image     string
+				Secret    bool
+			}{
+				Namespace: "redsky-system",
+				Image:     BuildImage,
+				Secret:    true,
 			},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("%q", tc.desc), func(t *testing.T) {
+			if tc.desc != "with api" {
+				return
+			}
 			k, err := NewKustomization(tc.options...)
 			assert.NoError(t, err)
 
@@ -85,6 +105,10 @@ func Test(t *testing.T) {
 
 			if tc.expected.Image != "" {
 				assert.Contains(t, r[0].String(), tc.expected.Image)
+			}
+			if tc.expected.Secret {
+				assert.Contains(t, r[0].String(), "envFrom")
+				assert.Contains(t, r[0].String(), "secretRef")
 			}
 		})
 	}

--- a/redskyctl/internal/kustomize/options.go
+++ b/redskyctl/internal/kustomize/options.go
@@ -181,6 +181,8 @@ func WithAPI(o bool) Option {
 			return nil
 		}
 
+		// Since we've already generated the base assets with the `redsky` prefix
+		// all of these resources need to reference that
 		controllerEnvPatch := []byte(`
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
Added a test to ensure withAPI patches the deployment with envFrom secret.

Signed-off-by: Brad Beam <brad.beam@carbonrelay.com>