### PR TITLE
refactor: Create patch package

### DIFF
--- a/internal/patch/patch.go
+++ b/internal/patch/patch.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2020 GramLabs, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package patch
+
+import (
+	"encoding/json"
+	"fmt"
+
+	redsky "github.com/redskyops/redskyops-controller/api/v1beta1"
+	"github.com/redskyops/redskyops-controller/internal/template"
+	"github.com/redskyops/redskyops-controller/internal/trial"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const defaultAttemptsRemaining = 3
+
+// RenderTemplate determines the patch target and renders the patch template
+func RenderTemplate(te *template.Engine, t *redsky.Trial, p *redsky.PatchTemplate) (*corev1.ObjectReference, []byte, error) {
+	// Render the actual patch data
+	data, err := te.RenderPatch(p, t)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Determine the reference, possibly extracting it from the rendered data
+	ref := &corev1.ObjectReference{}
+	if p.TargetRef != nil {
+		p.TargetRef.DeepCopyInto(ref)
+	} else if p.Type == redsky.PatchStrategic || p.Type == "" {
+		m := &metav1.PartialObjectMetadata{}
+		if err := json.Unmarshal(data, m); err != nil {
+			return nil, nil, err
+		}
+		ref.APIVersion = m.APIVersion
+		ref.Kind = m.Kind
+		ref.Name = m.Name
+		ref.Namespace = m.Namespace
+	}
+
+	// Default the namespace to the trial namespace
+	if ref.Namespace == "" {
+		ref.Namespace = t.Namespace
+	}
+
+	// Validate the reference
+	if ref.Name == "" || ref.Kind == "" {
+		return nil, nil, fmt.Errorf("invalid patch reference")
+	}
+
+	return ref, data, nil
+}
+
+// createPatchOperation creates a new patch operation from a patch template and it's (fully rendered) patch data
+func CreatePatchOperation(t *redsky.Trial, p *redsky.PatchTemplate, ref *corev1.ObjectReference, data []byte) (*redsky.PatchOperation, error) {
+	// If the patch is effectively null, we do not need to evaluate it
+	if len(data) == 0 || string(data) == "null" {
+		return nil, nil
+	}
+
+	po := &redsky.PatchOperation{
+		TargetRef:         *ref,
+		Data:              data,
+		AttemptsRemaining: defaultAttemptsRemaining,
+	}
+
+	// Determine the patch type
+	switch p.Type {
+	case redsky.PatchStrategic, "":
+		po.PatchType = types.StrategicMergePatchType
+	case redsky.PatchMerge:
+		po.PatchType = types.MergePatchType
+	case redsky.PatchJSON:
+		po.PatchType = types.JSONPatchType
+	default:
+		return nil, fmt.Errorf("unknown patch type: %s", p.Type)
+	}
+
+	// If the patch is for the trial job itself, it cannot be applied (since the job won't exist until well after patches are applied)
+	if trial.IsTrialJobReference(t, &po.TargetRef) {
+		po.AttemptsRemaining = 0
+		if po.PatchType != types.StrategicMergePatchType {
+			return nil, fmt.Errorf("trial job patch must be a strategic merge patch")
+		}
+	}
+
+	return po, nil
+}

--- a/internal/patch/patch_test.go
+++ b/internal/patch/patch_test.go
@@ -1,0 +1,215 @@
+/*
+Copyright 2020 GramLabs, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package patch
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	redsky "github.com/redskyops/redskyops-controller/api/v1beta1"
+	"github.com/redskyops/redskyops-controller/internal/template"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestPatch(t *testing.T) {
+	te := template.New()
+
+	trial := &redsky.Trial{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mytrial",
+			Namespace: "default",
+		},
+	}
+
+	patchMeta := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myapp
+  namespace: default`
+
+	patchSpec := `spec:
+        template:
+          spec:
+            containers:
+            - name: postgres
+              imagePullPolicy: Always`
+
+	fullPatch := patchMeta + "\n" + patchSpec
+
+	jsonPatch := `[
+    {
+     "op": "replace",
+     "path": "/spec/template/spec/containers/0/imagePullPolicy",
+		 "value": "Always"
+    },
+  ]`
+
+	testCases := []struct {
+		desc                string
+		trial               *redsky.Trial
+		patchTemplate       *redsky.PatchTemplate
+		attemptsRemaining   int
+		expectedError       bool
+		expectedRenderError bool
+		expectedPOError     bool
+	}{
+		{
+			desc:  "default",
+			trial: trial,
+			patchTemplate: &redsky.PatchTemplate{
+				// Note: defining an empty string ("") results
+				// in a `null` being returned. Think this is valid
+				// but makes testing a little more complicated.
+				Patch: fullPatch,
+				TargetRef: &corev1.ObjectReference{
+					Kind:       "Deployment",
+					APIVersion: "apps/v1",
+					Name:       "myapp",
+					Namespace:  "default",
+				},
+			},
+			attemptsRemaining: defaultAttemptsRemaining,
+		},
+		{
+			desc:  "strategic w/o targetref",
+			trial: trial,
+			patchTemplate: &redsky.PatchTemplate{
+				Type:      redsky.PatchStrategic,
+				Patch:     fullPatch,
+				TargetRef: nil,
+			},
+			attemptsRemaining: defaultAttemptsRemaining,
+		},
+		{
+			desc:  "strategic w/o targetref w/o full",
+			trial: trial,
+			patchTemplate: &redsky.PatchTemplate{
+				Type:      redsky.PatchStrategic,
+				Patch:     patchSpec,
+				TargetRef: nil,
+			},
+			expectedRenderError: true,
+		},
+		{
+			desc:  "patchmerge",
+			trial: trial,
+			patchTemplate: &redsky.PatchTemplate{
+				Type:  redsky.PatchMerge,
+				Patch: fullPatch,
+				TargetRef: &corev1.ObjectReference{
+					Kind:       "Deployment",
+					APIVersion: "apps/v1",
+					Name:       "myapp",
+					Namespace:  "default",
+				},
+			},
+			attemptsRemaining: defaultAttemptsRemaining,
+		},
+		{
+			desc:  "patchjson",
+			trial: trial,
+			patchTemplate: &redsky.PatchTemplate{
+				Type:  redsky.PatchJSON,
+				Patch: jsonPatch,
+				TargetRef: &corev1.ObjectReference{
+					Kind:       "Deployment",
+					APIVersion: "apps/v1",
+					Name:       "myapp",
+					Namespace:  "default",
+				},
+			},
+			attemptsRemaining: defaultAttemptsRemaining,
+		},
+		{
+			desc:  "patchTrial - json",
+			trial: trial,
+			patchTemplate: &redsky.PatchTemplate{
+				Type:  redsky.PatchJSON,
+				Patch: patchSpec,
+				TargetRef: &corev1.ObjectReference{
+					Kind:       "Job",
+					APIVersion: "batch/v1",
+					Name:       trial.Name,
+					Namespace:  trial.Namespace,
+				},
+			},
+			expectedPOError: true,
+		},
+		{
+			desc:  "patchTrial - strategic merge",
+			trial: trial,
+			patchTemplate: &redsky.PatchTemplate{
+				Type:  redsky.PatchStrategic,
+				Patch: patchSpec,
+				TargetRef: &corev1.ObjectReference{
+					Kind:       "Job",
+					APIVersion: "batch/v1",
+					Name:       trial.Name,
+					Namespace:  trial.Namespace,
+				},
+			},
+			attemptsRemaining: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%q", tc.desc), func(t *testing.T) {
+			// Test RenderTemplate
+			ref, data, err := RenderTemplate(te, tc.trial, tc.patchTemplate)
+			if tc.expectedRenderError {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.NotNil(t, ref)
+			assert.NotEmpty(t, data)
+
+			if tc.patchTemplate.TargetRef != nil {
+				assert.Equal(t, tc.patchTemplate.TargetRef, ref)
+			}
+
+			switch tc.patchTemplate.Type {
+			case redsky.PatchStrategic, redsky.PatchMerge:
+				if !strings.Contains(tc.desc, "patchTrial") {
+					assert.Equal(t, tc.patchTemplate.Patch, fullPatch)
+				}
+			case redsky.PatchJSON:
+				if !strings.Contains(tc.desc, "patchTrial") {
+					assert.Equal(t, tc.patchTemplate.Patch, jsonPatch)
+				}
+			}
+
+			// Test CreatePatchOperation
+			po, err := CreatePatchOperation(tc.trial, tc.patchTemplate, ref, data)
+			if tc.expectedPOError {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.NotNil(t, po)
+
+			assert.Equal(t, tc.attemptsRemaining, po.AttemptsRemaining)
+			if tc.patchTemplate.TargetRef != nil {
+				assert.Equal(t, tc.patchTemplate.TargetRef, &po.TargetRef)
+			}
+			assert.Equal(t, data, po.Data)
+		})
+	}
+}

--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -101,9 +101,8 @@ type Engine struct {
 
 // New creates a new template engine
 func New() *Engine {
-	f := FuncMap()
 	return &Engine{
-		FuncMap: f,
+		FuncMap: FuncMap(),
 	}
 }
 


### PR DESCRIPTION
This moves the functionality of RenderTemplate and CreatePatchOperation to
a separate pacakge to facilitate reuse.

Signed-off-by: Brad Beam <brad.beam@carbonrelay.com>