### PR TITLE
Make UA string match repository name for the controller

### DIFF
--- a/controllers/server_controller.go
+++ b/controllers/server_controller.go
@@ -146,7 +146,7 @@ func (r *ServerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			}
 		}
 
-		c, err := redskyapi.NewClient(ctx, cfg, version.UserAgent("RedSkyController", comment, nil))
+		c, err := redskyapi.NewClient(ctx, cfg, version.UserAgent("redskyops-controller", comment, nil))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Following through with a suggestion I made in another PR.

In looking through a lot of other UA strings, I still think the original might be more conventional (UpperCamelCase); however there is no programmatic translation of `redskyops-controller` to `RedSkyOpsController` (or the current `RedSkyController`) without hardcoding special cases (e.g. you could get to `RedskyopsController` but...). For now I'll just assume it is better to use the GitHub repo name.