### PR TITLE
Add an execution environment to the configuration

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -133,6 +133,14 @@ func (rsc *RedSkyConfig) Reader() Reader {
 	return &overrideReader{overrides: &rsc.Overrides, delegate: &defaultReader{cfg: &rsc.data}}
 }
 
+// Environment returns the name of the execution environment
+func (rsc *RedSkyConfig) Environment() string {
+	if env := rsc.data.Environment; env != "" {
+		return env
+	}
+	return "production"
+}
+
 // SystemNamespace returns the namespace where the Red Sky controller is/should be installed
 func (rsc *RedSkyConfig) SystemNamespace() (string, error) {
 	ctrl, err := CurrentController(rsc.Reader())

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -135,6 +135,9 @@ func (rsc *RedSkyConfig) Reader() Reader {
 
 // Environment returns the name of the execution environment
 func (rsc *RedSkyConfig) Environment() string {
+	if env := rsc.Overrides.Environment; env != "" {
+		return env
+	}
 	if env := rsc.data.Environment; env != "" {
 		return env
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -39,9 +39,9 @@ func TestRedSkyConfig_Endpoints(t *testing.T) {
 	rss := &cfg.data.Servers[0].Server.RedSky
 	ep, err := cfg.Endpoints()
 	g.Expect(err).ShouldNot(HaveOccurred())
-	g.Expect(ep.Resolve(exp).String()).To(Equal(DefaultServerIdentifier + "experiments/"))
-	g.Expect(ep.Resolve(expFooBar).String()).To(Equal(DefaultServerIdentifier + "experiments/foo_bar"))
-	g.Expect(ep.Resolve(expFooBarTrials).String()).To(Equal(DefaultServerIdentifier + "experiments/foo_bar/trials/"))
+	g.Expect(ep.Resolve(exp).String()).To(Equal("https://api.carbonrelay.io/v1/experiments/"))
+	g.Expect(ep.Resolve(expFooBar).String()).To(Equal("https://api.carbonrelay.io/v1/experiments/foo_bar"))
+	g.Expect(ep.Resolve(expFooBarTrials).String()).To(Equal("https://api.carbonrelay.io/v1/experiments/foo_bar/trials/"))
 
 	// Change inside the path
 	rss.ExperimentsEndpoint = "http://example.com/api/experiments/"

--- a/internal/config/data.go
+++ b/internal/config/data.go
@@ -33,6 +33,8 @@ var (
 
 // Config is the top level configuration structure for Red Sky
 type Config struct {
+	// Environment identifies the service environment to prefer
+	Environment string `json:"env,omitempty"`
 	// Servers is a named list of server configurations
 	Servers []NamedServer `json:"servers,omitempty"`
 	// Authorizations is a named list of authorizations configurations

--- a/internal/config/data.go
+++ b/internal/config/data.go
@@ -33,8 +33,6 @@ var (
 
 // Config is the top level configuration structure for Red Sky
 type Config struct {
-	// Environment identifies the service environment to prefer
-	Environment string `json:"env,omitempty"`
 	// Servers is a named list of server configurations
 	Servers []NamedServer `json:"servers,omitempty"`
 	// Authorizations is a named list of authorizations configurations
@@ -47,6 +45,8 @@ type Config struct {
 	Contexts []NamedContext `json:"contexts,omitempty"`
 	// CurrentContext is the name of the default context
 	CurrentContext string `json:"current-context,omitempty"`
+	// Environment identifies the current execution environment
+	Environment string `json:"env,omitempty"`
 }
 
 // Server contains information about how to communicate with a Red Sky API Server

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -20,6 +20,7 @@ import "os"
 
 // envLoader adds environment variable overrides to the configuration
 func envLoader(cfg *RedSkyConfig) error {
+	defaultString(&cfg.Overrides.Environment, os.Getenv("REDSKY_ENV"))
 	defaultString(&cfg.Overrides.ServerIdentifier, os.Getenv("REDSKY_SERVER_IDENTIFIER"))
 	defaultString(&cfg.Overrides.ServerIssuer, os.Getenv("REDSKY_SERVER_ISSUER"))
 	defaultString(&cfg.Overrides.Credential.ClientID, os.Getenv("REDSKY_AUTHORIZATION_CLIENT_ID"))

--- a/internal/config/overrides.go
+++ b/internal/config/overrides.go
@@ -18,6 +18,8 @@ package config
 
 // Overrides represent information which can be overridden in the configuration
 type Overrides struct {
+	// Environment overrides the execution environment name
+	Environment string
 	// Context overrides the current Red Sky context name (_not_ the KubeConfig context)
 	Context string
 	// SystemNamespace overrides the current controller namespace (_not_ the Kube namespace)

--- a/internal/config/update.go
+++ b/internal/config/update.go
@@ -31,9 +31,8 @@ func SaveServer(name string, srv *Server) Change {
 		mergeServers(cfg, []NamedServer{{Name: name, Server: *srv}})
 		mergeAuthorizations(cfg, []NamedAuthorization{{Name: name}})
 
-		// Make sure we capture the current value of the default server identifier
-		defaultString(&findServer(cfg.Servers, name).Identifier, DefaultServerIdentifier)
-		return nil
+		// Make sure we capture the current value of the default server roots
+		return defaultServerRoots(cfg, findServer(cfg.Servers, name))
 	}
 }
 

--- a/internal/config/update.go
+++ b/internal/config/update.go
@@ -96,6 +96,9 @@ func SetProperty(name, value string) Change {
 	return func(cfg *Config) error {
 		path := strings.Split(name, ".")
 		switch path[0] {
+		case "env":
+			cfg.Environment = value
+			return nil
 		case "current-context":
 			cfg.CurrentContext = value
 			return nil

--- a/internal/config/update.go
+++ b/internal/config/update.go
@@ -26,13 +26,13 @@ import (
 
 // SaveServer is a configuration change that persists the supplied server configuration. If the server exists,
 // it is overwritten; otherwise a new named server is created.
-func SaveServer(name string, srv *Server) Change {
+func SaveServer(name string, srv *Server, env string) Change {
 	return func(cfg *Config) error {
 		mergeServers(cfg, []NamedServer{{Name: name, Server: *srv}})
 		mergeAuthorizations(cfg, []NamedAuthorization{{Name: name}})
 
 		// Make sure we capture the current value of the default server roots
-		return defaultServerRoots(cfg, findServer(cfg.Servers, name))
+		return defaultServerRoots(env, findServer(cfg.Servers, name))
 	}
 }
 

--- a/redskyctl/internal/commands/login/login.go
+++ b/redskyctl/internal/commands/login/login.go
@@ -169,7 +169,7 @@ func (o *Options) LoadConfig() error {
 		}
 
 		// We need to save the server in the loader so default values are loaded on top of them
-		if err := o.Config.Update(config.SaveServer(o.Name, &config.Server{Identifier: o.Server, Authorization: config.AuthorizationServer{Issuer: o.Issuer}})); err != nil {
+		if err := o.Config.Update(config.SaveServer(o.Name, &config.Server{Identifier: o.Server, Authorization: config.AuthorizationServer{Issuer: o.Issuer}}, cfg.Environment())); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
I finally relented.

A couple of notes:
1. Only `redskyctl login` has an `--env` flag (and it's hidden), if specified it will save the value in the config file for all subsequent calls (including future calls to `login`)
2. I did not expose environment name on the configuration `Reader` interface (if we want to add environment specific behavior we should add something like `Production() bool` to that interface
3. Since you no longer need to overwrite the `--server` value, the config context stays "default"
4. The environment controls the _default_ values. You can still configure a "development" environment with `.io` domain names if we decide to tie more behavior to the environment in the future.