### PR TITLE
Redirect not activated tokens to the application

### DIFF
--- a/redskyctl/internal/commands/login/login.go
+++ b/redskyctl/internal/commands/login/login.go
@@ -41,7 +41,7 @@ var (
 	SuccessURL = "https://redskyops.dev/api/auth_success/"
 
 	// NotActivatedURL is the URL where users are redirected if they do not have a valid namespace claim in their access token
-	NotActivatedURL = "https://redskyops.dev/api/auth_not_activated/"
+	NotActivatedURL = "https://app.carbonrelay.io/"
 )
 
 const (


### PR DESCRIPTION
This change pushes non-authorized users directly to the public production application. Generally this will show either the "your service is being allocated" message, it may also have the side effect of actually triggering the allocation.

For users who are not leveraging the production authorization issuer, the behavior will be a little strange: it will appear as if you are being redirected from the development login page to the production login page. This will be improved in a future release.