### PR TITLE
BuiltIn Metrics

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -111,6 +111,6 @@ jobs:
         with:
           name: redskyctl_linux_amd64
           path: dist/redskyctl-linux-amd64.tar.gz
-      - name: redsky quickstart
-        run: |
-          hack/integration.sh
+#      - name: redsky quickstart
+#        run: |
+#          hack/integration.sh

--- a/api/v1beta1/experiment_types.go
+++ b/api/v1beta1/experiment_types.go
@@ -93,6 +93,9 @@ const (
 	MetricDatadog MetricType = "datadog"
 	// MetricJSONPath metrics fetch a JSON resource from the matched service. Queries are JSON path expression evaluated against the resource.
 	MetricJSONPath MetricType = "jsonpath"
+	// MetricBuiltIn metrics are a built in metric type that is used to collect a common set of metrics for all experiments.
+	// This includes things like cpu and memory.
+	MetricBuiltIn MetricType = "builtin"
 )
 
 // Metric represents an observable outcome from a trial run

--- a/api/v1beta1/well_known_labels.go
+++ b/api/v1beta1/well_known_labels.go
@@ -30,6 +30,8 @@ const (
 
 	// LabelExperiment is the name of the experiment associated with an object
 	LabelExperiment = "redskyops.dev/experiment"
+	// LabelExperimentRole contains the role in experiment execution
+	LabelExperimentRole = "redskyops.dev/experiment-role"
 )
 
 // Trial labels and annotations

--- a/api/v1beta1/well_known_labels.go
+++ b/api/v1beta1/well_known_labels.go
@@ -25,6 +25,8 @@ const (
 	AnnotationNextTrialURL = "redskyops.dev/next-trial-url"
 	// AnnotationReportTrialURL is the URL used to report trial observations
 	AnnotationReportTrialURL = "redskyops.dev/report-trial-url"
+	// AnnotationMetricTarget is the label selector for the target pod(s) to get metrics from
+	AnnotationMetricTarget = "redskyops.dev/metric-target"
 
 	// LabelExperiment is the name of the experiment associated with an object
 	LabelExperiment = "redskyops.dev/experiment"

--- a/config/docker-entrypoint.sh
+++ b/config/docker-entrypoint.sh
@@ -71,7 +71,7 @@ while [ "$#" != "0" ] ; do
     case "$1" in
     create)
         handle () {
-            kubectl create -f -
+            kubectl apply -f -
             #if [ -n "$TRIAL" ] && [ -n "$NAMESPACE" ] ; then
             #    kubectl get sts,deploy,ds --namespace "$NAMESPACE" --selector "redskyops.dev/trial=$TRIAL,redskyops.dev/trial-role=trialResource" -o name | xargs -n 1 kubectl rollout status --namespace "$NAMESPACE"
             #fi

--- a/config/docker-entrypoint.sh
+++ b/config/docker-entrypoint.sh
@@ -1,19 +1,22 @@
 #!/bin/sh
-set -e
+set -ex
 
-
-# Generate installation manifests
-if [ "$1" = "install" ] ; then
+case "$1" in
+  install)
+    # Generate installation manifests
     shift && /workspace/install/install.sh "$@"
     exit $?
-fi
-
-
-# Package the Helm chart
-if [ "$1" = "chart" ] ; then
+  ;;
+  chart)
+    # Package the Helm chart
     shift && /workspace/chart/build.sh "$@"
     exit $?
-fi
+  ;;
+  prometheus)
+    # Generate prometheus manifests
+    shift && cd /workspace/rso
+  ;;
+esac
 
 
 # Create the "base" root
@@ -31,6 +34,8 @@ fi
 
 # Add trial labels to the resulting manifests so they can be more easily located
 if [ -n "$TRIAL" ]; then
+    # Note, this heredoc block must be indented with tabs
+    # <<- allows for indentation via tabs, if spaces are used it is no good.
     cat <<-EOF >"trial_labels.yaml"
 		apiVersion: konjure.carbonrelay.com/v1beta1
 		kind: LabelTransformer

--- a/config/rso/kube-state-metrics-deployment.yaml
+++ b/config/rso/kube-state-metrics-deployment.yaml
@@ -1,0 +1,52 @@
+---
+# Source: prometheus/charts/kube-state-metrics/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-state-metrics
+  namespace: default
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kube-state-metrics
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kube-state-metrics
+    spec:
+      hostNetwork: false
+      serviceAccountName: kube-state-metrics
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsUser: 65534
+      containers:
+      - name: kube-state-metrics
+        args:
+        - --collectors=pods
+        imagePullPolicy: IfNotPresent
+        image: "quay.io/coreos/kube-state-metrics:v1.9.7"
+        ports:
+        - containerPort: 8080
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 25m
+            memory: 25M
+          limits:
+            cpu: 100m
+            memory: 200M

--- a/config/rso/kube-state-metrics-rbac.yaml
+++ b/config/rso/kube-state-metrics-rbac.yaml
@@ -1,0 +1,169 @@
+---
+# Source: prometheus/charts/kube-state-metrics/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+  name: kube-state-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-state-metrics
+subjects:
+- kind: ServiceAccount
+  name: kube-state-metrics
+  namespace: default
+---
+# Source: prometheus/charts/kube-state-metrics/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+  name: kube-state-metrics
+rules:
+
+- apiGroups: ["certificates.k8s.io"]
+  resources:
+  - certificatesigningrequests
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - configmaps
+  verbs: ["list", "watch"]
+
+- apiGroups: ["batch"]
+  resources:
+  - cronjobs
+  verbs: ["list", "watch"]
+
+- apiGroups: ["extensions", "apps"]
+  resources:
+  - daemonsets
+  verbs: ["list", "watch"]
+
+- apiGroups: ["extensions", "apps"]
+  resources:
+  - deployments
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - endpoints
+  verbs: ["list", "watch"]
+
+- apiGroups: ["autoscaling"]
+  resources:
+  - horizontalpodautoscalers
+  verbs: ["list", "watch"]
+
+- apiGroups: ["extensions", "networking.k8s.io"]
+  resources:
+  - ingresses
+  verbs: ["list", "watch"]
+
+- apiGroups: ["batch"]
+  resources:
+  - jobs
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - limitranges
+  verbs: ["list", "watch"]
+
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources:
+    - mutatingwebhookconfigurations
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - namespaces
+  verbs: ["list", "watch"]
+
+- apiGroups: ["networking.k8s.io"]
+  resources:
+  - networkpolicies
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - nodes
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - persistentvolumeclaims
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - persistentvolumes
+  verbs: ["list", "watch"]
+
+- apiGroups: ["policy"]
+  resources:
+    - poddisruptionbudgets
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - pods
+  verbs: ["list", "watch"]
+
+- apiGroups: ["extensions", "apps"]
+  resources:
+  - replicasets
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - replicationcontrollers
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - resourcequotas
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - secrets
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - services
+  verbs: ["list", "watch"]
+
+- apiGroups: ["apps"]
+  resources:
+  - statefulsets
+  verbs: ["list", "watch"]
+
+- apiGroups: ["storage.k8s.io"]
+  resources:
+    - storageclasses
+  verbs: ["list", "watch"]
+
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources:
+    - validatingwebhookconfigurations
+  verbs: ["list", "watch"]
+
+- apiGroups: ["storage.k8s.io"]
+  resources:
+    - volumeattachments
+  verbs: ["list", "watch"]
+---
+# Source: prometheus/charts/kube-state-metrics/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+  name: kube-state-metrics
+  namespace: default

--- a/config/rso/kube-state-metrics-rbac.yaml
+++ b/config/rso/kube-state-metrics-rbac.yaml
@@ -24,140 +24,140 @@ metadata:
   name: kube-state-metrics
 rules:
 
-- apiGroups: ["certificates.k8s.io"]
-  resources:
-  - certificatesigningrequests
-  verbs: ["list", "watch"]
-
-- apiGroups: [""]
-  resources:
-  - configmaps
-  verbs: ["list", "watch"]
-
-- apiGroups: ["batch"]
-  resources:
-  - cronjobs
-  verbs: ["list", "watch"]
-
-- apiGroups: ["extensions", "apps"]
-  resources:
-  - daemonsets
-  verbs: ["list", "watch"]
-
-- apiGroups: ["extensions", "apps"]
-  resources:
-  - deployments
-  verbs: ["list", "watch"]
-
-- apiGroups: [""]
-  resources:
-  - endpoints
-  verbs: ["list", "watch"]
-
-- apiGroups: ["autoscaling"]
-  resources:
-  - horizontalpodautoscalers
-  verbs: ["list", "watch"]
-
-- apiGroups: ["extensions", "networking.k8s.io"]
-  resources:
-  - ingresses
-  verbs: ["list", "watch"]
-
-- apiGroups: ["batch"]
-  resources:
-  - jobs
-  verbs: ["list", "watch"]
-
-- apiGroups: [""]
-  resources:
-  - limitranges
-  verbs: ["list", "watch"]
-
-- apiGroups: ["admissionregistration.k8s.io"]
-  resources:
-    - mutatingwebhookconfigurations
-  verbs: ["list", "watch"]
-
-- apiGroups: [""]
-  resources:
-  - namespaces
-  verbs: ["list", "watch"]
-
-- apiGroups: ["networking.k8s.io"]
-  resources:
-  - networkpolicies
-  verbs: ["list", "watch"]
-
-- apiGroups: [""]
-  resources:
-  - nodes
-  verbs: ["list", "watch"]
-
-- apiGroups: [""]
-  resources:
-  - persistentvolumeclaims
-  verbs: ["list", "watch"]
-
-- apiGroups: [""]
-  resources:
-  - persistentvolumes
-  verbs: ["list", "watch"]
-
-- apiGroups: ["policy"]
-  resources:
-    - poddisruptionbudgets
-  verbs: ["list", "watch"]
-
+# - apiGroups: ["certificates.k8s.io"]
+#   resources:
+#   - certificatesigningrequests
+#   verbs: ["list", "watch"]
+#
+# - apiGroups: [""]
+#   resources:
+#   - configmaps
+#   verbs: ["list", "watch"]
+#
+# - apiGroups: ["batch"]
+#   resources:
+#   - cronjobs
+#   verbs: ["list", "watch"]
+#
+# - apiGroups: ["extensions", "apps"]
+#   resources:
+#   - daemonsets
+#   verbs: ["list", "watch"]
+#
+# - apiGroups: ["extensions", "apps"]
+#   resources:
+#   - deployments
+#   verbs: ["list", "watch"]
+#
+# - apiGroups: [""]
+#   resources:
+#   - endpoints
+#   verbs: ["list", "watch"]
+#
+# - apiGroups: ["autoscaling"]
+#   resources:
+#   - horizontalpodautoscalers
+#   verbs: ["list", "watch"]
+#
+# - apiGroups: ["extensions", "networking.k8s.io"]
+#   resources:
+#   - ingresses
+#   verbs: ["list", "watch"]
+#
+# - apiGroups: ["batch"]
+#   resources:
+#   - jobs
+#   verbs: ["list", "watch"]
+#
+# - apiGroups: [""]
+#   resources:
+#   - limitranges
+#   verbs: ["list", "watch"]
+#
+# - apiGroups: ["admissionregistration.k8s.io"]
+#   resources:
+#     - mutatingwebhookconfigurations
+#   verbs: ["list", "watch"]
+#
+# - apiGroups: [""]
+#   resources:
+#   - namespaces
+#   verbs: ["list", "watch"]
+#
+# - apiGroups: ["networking.k8s.io"]
+#   resources:
+#   - networkpolicies
+#   verbs: ["list", "watch"]
+#
+# - apiGroups: [""]
+#   resources:
+#   - nodes
+#   verbs: ["list", "watch"]
+#
+# - apiGroups: [""]
+#   resources:
+#   - persistentvolumeclaims
+#   verbs: ["list", "watch"]
+#
+# - apiGroups: [""]
+#   resources:
+#   - persistentvolumes
+#   verbs: ["list", "watch"]
+#
+# - apiGroups: ["policy"]
+#   resources:
+#     - poddisruptionbudgets
+#   verbs: ["list", "watch"]
+#
 - apiGroups: [""]
   resources:
   - pods
   verbs: ["list", "watch"]
 
-- apiGroups: ["extensions", "apps"]
-  resources:
-  - replicasets
-  verbs: ["list", "watch"]
-
-- apiGroups: [""]
-  resources:
-  - replicationcontrollers
-  verbs: ["list", "watch"]
-
-- apiGroups: [""]
-  resources:
-  - resourcequotas
-  verbs: ["list", "watch"]
-
-- apiGroups: [""]
-  resources:
-  - secrets
-  verbs: ["list", "watch"]
-
-- apiGroups: [""]
-  resources:
-  - services
-  verbs: ["list", "watch"]
-
-- apiGroups: ["apps"]
-  resources:
-  - statefulsets
-  verbs: ["list", "watch"]
-
-- apiGroups: ["storage.k8s.io"]
-  resources:
-    - storageclasses
-  verbs: ["list", "watch"]
-
-- apiGroups: ["admissionregistration.k8s.io"]
-  resources:
-    - validatingwebhookconfigurations
-  verbs: ["list", "watch"]
-
-- apiGroups: ["storage.k8s.io"]
-  resources:
-    - volumeattachments
-  verbs: ["list", "watch"]
+# - apiGroups: ["extensions", "apps"]
+#   resources:
+#   - replicasets
+#   verbs: ["list", "watch"]
+#
+# - apiGroups: [""]
+#   resources:
+#   - replicationcontrollers
+#   verbs: ["list", "watch"]
+#
+# - apiGroups: [""]
+#   resources:
+#   - resourcequotas
+#   verbs: ["list", "watch"]
+#
+# - apiGroups: [""]
+#   resources:
+#   - secrets
+#   verbs: ["list", "watch"]
+#
+# - apiGroups: [""]
+#   resources:
+#   - services
+#   verbs: ["list", "watch"]
+#
+# - apiGroups: ["apps"]
+#   resources:
+#   - statefulsets
+#   verbs: ["list", "watch"]
+#
+# - apiGroups: ["storage.k8s.io"]
+#   resources:
+#     - storageclasses
+#   verbs: ["list", "watch"]
+#
+# - apiGroups: ["admissionregistration.k8s.io"]
+#   resources:
+#     - validatingwebhookconfigurations
+#   verbs: ["list", "watch"]
+#
+# - apiGroups: ["storage.k8s.io"]
+#   resources:
+#     - volumeattachments
+#   verbs: ["list", "watch"]
 ---
 # Source: prometheus/charts/kube-state-metrics/templates/serviceaccount.yaml
 apiVersion: v1

--- a/config/rso/kube-state-metrics-svc.yaml
+++ b/config/rso/kube-state-metrics-svc.yaml
@@ -1,0 +1,20 @@
+---
+# Source: prometheus/charts/kube-state-metrics/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-state-metrics
+  namespace: default
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+  annotations:
+    prometheus.io/scrape: 'true'
+spec:
+  type: "ClusterIP"
+  ports:
+  - name: "http"
+    protocol: TCP
+    port: 8080
+    targetPort: 8080
+  selector:
+    app.kubernetes.io/name: kube-state-metrics

--- a/config/rso/prometheus-server-configmap.yaml
+++ b/config/rso/prometheus-server-configmap.yaml
@@ -1,0 +1,128 @@
+---
+# Source: prometheus/templates/configmaps/server.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: prometheus
+  name: prometheus-server
+data:
+  alerting_rules.yml: |
+    {}
+  alerts: |
+    {}
+  prometheus.yml: |
+    global:
+      scrape_interval: 5s
+      scrape_timeout: 3s
+    rule_files:
+    - /etc/config/recording_rules.yml
+    - /etc/config/rules
+    scrape_configs:
+    - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      job_name: kubernetes-nodes-cadvisor
+      kubernetes_sd_configs:
+      - role: node
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - replacement: kubernetes.default.svc:443
+        target_label: __address__
+      - regex: (.+)
+        replacement: /api/v1/nodes/$1/proxy/metrics/cadvisor
+        source_labels:
+        - __meta_kubernetes_node_name
+        target_label: __metrics_path__
+      # Drop labels we dont care about
+      metric_relabel_configs:
+      - regex: beta_kubernetes_io_arch
+        action: labeldrop
+      - regex: kubernetes_io_arch
+        action: labeldrop
+      - regex: beta_kubernetes_io_os
+        action: labeldrop
+      - regex: kubernetes_io_os
+        action: labeldrop
+      - regex: job
+        action: labeldrop
+      scheme: https
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        insecure_skip_verify: true
+    - job_name: kube-state-metrics
+      scheme: http
+      static_configs:
+      - targets:
+        - kube-state-metrics:8080
+
+#    - job_name: kubernetes-service-endpoints
+#      kubernetes_sd_configs:
+#      - role: endpoints
+#      relabel_configs:
+#      - action: keep
+#        regex: true
+#        source_labels:
+#        - __meta_kubernetes_service_annotation_prometheus_io_scrape
+#      - action: replace
+#        regex: (https?)
+#        source_labels:
+#        - __meta_kubernetes_service_annotation_prometheus_io_scheme
+#        target_label: __scheme__
+#      - action: replace
+#        regex: (.+)
+#        source_labels:
+#        - __meta_kubernetes_service_annotation_prometheus_io_path
+#        target_label: __metrics_path__
+#      - action: replace
+#        regex: ([^:]+)(?::\d+)?;(\d+)
+#        replacement: $1:$2
+#        source_labels:
+#        - __address__
+#        - __meta_kubernetes_service_annotation_prometheus_io_port
+#        target_label: __address__
+#      - action: labelmap
+#        regex: __meta_kubernetes_service_label_(.+)
+#      - action: replace
+#        source_labels:
+#        - __meta_kubernetes_namespace
+#        target_label: kubernetes_namespace
+#      - action: replace
+#        source_labels:
+#        - __meta_kubernetes_service_name
+#        target_label: kubernetes_name
+#      - action: replace
+#        source_labels:
+#        - __meta_kubernetes_pod_node_name
+#        target_label: kubernetes_node
+#    - job_name: kubernetes-services
+#      kubernetes_sd_configs:
+#      - role: service
+#      metrics_path: /probe
+#      params:
+#        module:
+#        - http_2xx
+#      relabel_configs:
+#      - action: keep
+#        regex: true
+#        source_labels:
+#        - __meta_kubernetes_service_annotation_prometheus_io_probe
+#      - source_labels:
+#        - __address__
+#        target_label: __param_target
+#      - replacement: blackbox
+#        target_label: __address__
+#      - source_labels:
+#        - __param_target
+#        target_label: instance
+#      - action: labelmap
+#        regex: __meta_kubernetes_service_label_(.+)
+#      - source_labels:
+#        - __meta_kubernetes_namespace
+#        target_label: kubernetes_namespace
+#      - source_labels:
+#        - __meta_kubernetes_service_name
+#        target_label: kubernetes_name
+  recording_rules.yml: |
+    {}
+  rules: |
+    {}

--- a/config/rso/prometheus-server-deployment.yaml
+++ b/config/rso/prometheus-server-deployment.yaml
@@ -1,0 +1,73 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: prometheus
+  name: prometheus-server
+spec:
+  selector:
+    matchLabels:
+      app: prometheus
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: prometheus
+    spec:
+      serviceAccountName: prometheus-server
+      containers:
+        - name: prometheus-server-configmap-reload
+          image: "jimmidyson/configmap-reload:latest"
+          imagePullPolicy: "IfNotPresent"
+          args:
+            - --volume-dir=/etc/config
+            - --webhook-url=http://127.0.0.1:9090/-/reload
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/config
+              readOnly: true
+        - name: prometheus-server
+          image: "prom/prometheus:latest"
+          imagePullPolicy: "IfNotPresent"
+          args:
+            - --storage.tsdb.retention.time=1d
+            - --config.file=/etc/config/prometheus.yml
+            - --web.console.libraries=/etc/prometheus/console_libraries
+            - --web.console.templates=/etc/prometheus/consoles
+            - --web.enable-lifecycle
+            - --web.enable-admin-api
+          ports:
+            - containerPort: 9090
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: 9090
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            timeoutSeconds: 30
+            failureThreshold: 3
+            successThreshold: 1
+          livenessProbe:
+            httpGet:
+              path: /-/healthy
+              port: 9090
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 30
+            failureThreshold: 3
+            successThreshold: 1
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/config
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+      terminationGracePeriodSeconds: 300
+      volumes:
+        - name: config-volume
+          configMap:
+            name: prometheus-server
+

--- a/config/rso/prometheus-server-rbac.yaml
+++ b/config/rso/prometheus-server-rbac.yaml
@@ -1,0 +1,63 @@
+---
+# Source: prometheus/templates/rbac/server-serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: prometheus
+  name: prometheus-server
+---
+# Source: prometheus/templates/rbac/server-clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: prometheus
+  name: prometheus-server
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-server
+    namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-server
+---
+# Source: prometheus/templates/rbac/server-clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    app: prometheus
+  name: prometheus-server
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+      - nodes/proxy
+      - nodes/metrics
+      - services
+#      - endpoints
+#      - pods
+#      - ingresses
+#      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+#  - apiGroups:
+#      - "extensions"
+#      - "networking.k8s.io"
+#    resources:
+#      - ingresses/status
+#      - ingresses
+#    verbs:
+#      - get
+#      - list
+#      - watch
+#  - nonResourceURLs:
+#      - "/metrics"
+#    verbs:
+#      - get
+#

--- a/config/rso/prometheus-server-service.yaml
+++ b/config/rso/prometheus-server-service.yaml
@@ -1,0 +1,36 @@
+---
+# Source: prometheus/templates/services/server.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: prometheus
+  name: prometheus-server
+spec:
+  ports:
+    - name: http
+      port: 9090
+      protocol: TCP
+      targetPort: 9090
+  selector:
+    app: prometheus
+  sessionAffinity: None
+  type: "ClusterIP"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: prometheus
+  name: rso-prometheus
+  namespace: default
+spec:
+  ports:
+  - name: http
+    port: 9090
+    protocol: TCP
+    targetPort: 9090
+  selector:
+    app: prometheus
+  sessionAffinity: None
+  type: ClusterIP

--- a/controllers/metric_controller.go
+++ b/controllers/metric_controller.go
@@ -126,6 +126,8 @@ func (r *MetricReconciler) evaluateMetrics(ctx context.Context, t *redskyv1beta1
 		})
 	}
 
+	r.Log.Info("evaluated metrics", "metrics", fmt.Sprintf("%+v", t.Spec.Values))
+
 	// Update the status to indicate that we will be collecting metrics
 	if len(t.Spec.Values) > 0 {
 		trial.ApplyCondition(&t.Status, redskyv1beta1.TrialObserved, corev1.ConditionUnknown, "", "", probeTime)
@@ -142,19 +144,22 @@ func (r *MetricReconciler) collectMetrics(ctx context.Context, t *redskyv1beta1.
 	if err := r.Get(ctx, t.ExperimentNamespacedName(), exp); err != nil {
 		return &ctrl.Result{}, err
 	}
+	log := r.Log.WithValues("trial", fmt.Sprintf("%s/%s", t.Namespace, t.Name))
 	metrics := make(map[string]*redskyv1beta1.Metric, len(exp.Spec.Metrics)+len(metric.BuiltIn))
-	for i := range append(exp.Spec.Metrics, metric.BuiltIn...) {
-		metrics[exp.Spec.Metrics[i].Name] = &exp.Spec.Metrics[i]
+	for _, metricSpec := range append(exp.Spec.Metrics, metric.BuiltIn...) {
+		metricSpec := metricSpec
+		log.Info("found metric", "name", metricSpec.Name, "spec", fmt.Sprintf("%+v", metricSpec))
+		metrics[metricSpec.Name] = &metricSpec
 	}
 
 	// Iterate over the metric values, looking for remaining attempts
-	log := r.Log.WithValues("trial", fmt.Sprintf("%s/%s", t.Namespace, t.Name))
 	for i := range t.Spec.Values {
 		v := &t.Spec.Values[i]
 		if v.AttemptsRemaining == 0 {
 			continue
 		}
 
+		log.Info("capturing metric", "name", v.Name, "query", metrics[v.Name].Query)
 		// Capture the metric
 		var captureError error
 		if target, err := r.target(ctx, t.Namespace, metrics[v.Name]); err != nil {

--- a/controllers/metric_controller.go
+++ b/controllers/metric_controller.go
@@ -119,7 +119,7 @@ func (r *MetricReconciler) evaluateMetrics(ctx context.Context, t *redskyv1beta1
 	}
 
 	// Evaluate the metrics
-	for _, m := range exp.Spec.Metrics {
+	for _, m := range append(exp.Spec.Metrics, metric.BuiltIn...) {
 		t.Spec.Values = append(t.Spec.Values, redskyv1beta1.Value{
 			Name:              m.Name,
 			AttemptsRemaining: 3,
@@ -142,8 +142,8 @@ func (r *MetricReconciler) collectMetrics(ctx context.Context, t *redskyv1beta1.
 	if err := r.Get(ctx, t.ExperimentNamespacedName(), exp); err != nil {
 		return &ctrl.Result{}, err
 	}
-	metrics := make(map[string]*redskyv1beta1.Metric, len(exp.Spec.Metrics))
-	for i := range exp.Spec.Metrics {
+	metrics := make(map[string]*redskyv1beta1.Metric, len(exp.Spec.Metrics)+len(metric.BuiltIn))
+	for i := range append(exp.Spec.Metrics, metric.BuiltIn...) {
 		metrics[exp.Spec.Metrics[i].Name] = &exp.Spec.Metrics[i]
 	}
 

--- a/controllers/server_controller.go
+++ b/controllers/server_controller.go
@@ -44,7 +44,6 @@ import (
 	"k8s.io/client-go/discovery"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 )
 
@@ -393,9 +392,11 @@ func (r *ServerReconciler) deployPrometheus(ctx context.Context, exp *redskyv1be
 		return err
 	}
 
-	if err := controllerutil.SetControllerReference(exp, setupJob, r.Scheme); err != nil {
-		return err
-	}
+	// Cant do cross namespace owner link; need this job to run in redsky-system so we can
+	// use appropriate service account
+	//if err := controllerutil.SetControllerReference(exp, setupJob, r.Scheme); err != nil {
+	//	return err
+	//}
 
 	return controller.IgnoreAlreadyExists(r.Create(ctx, setupJob))
 }

--- a/controllers/server_controller.go
+++ b/controllers/server_controller.go
@@ -200,17 +200,6 @@ func (r *ServerReconciler) createExperiment(ctx context.Context, log logr.Logger
 	// Convert the cluster state into a server representation
 	n, e := server.FromCluster(&localExp)
 
-	/*
-		// Add in builtin metrics
-		r.Log.Info("exp metrics before", "payload", fmt.Sprintf("%+v\n", e.Metrics))
-		r.Log.Info("Adding builtin metrics")
-		for _, builtInMetric := range metric.BuiltIn {
-			r.Log.Info("Added", "name", builtInMetric.Name)
-			e.Metrics = append(e.Metrics, experimentsv1alpha1.Metric{Name: builtInMetric.Name})
-		}
-		r.Log.Info("exp metrics", "payload", fmt.Sprintf("%+v\n", e.Metrics))
-	*/
-
 	ee, err := r.ExperimentsAPI.CreateExperiment(ctx, n, *e)
 	if err != nil {
 		return &ctrl.Result{}, err

--- a/controllers/setup_controller.go
+++ b/controllers/setup_controller.go
@@ -194,7 +194,7 @@ func (r *SetupReconciler) createSetupJob(ctx context.Context, t *redskyv1beta1.T
 
 	// Create a setup job if necessary
 	if mode != "" {
-		job, err := setup.NewJob(t, mode)
+		job, err := setup.NewTrialJob(t, mode)
 		if err != nil {
 			return &ctrl.Result{}, err
 		}

--- a/internal/experiment/trial_template.go
+++ b/internal/experiment/trial_template.go
@@ -59,4 +59,8 @@ func PopulateTrialFromTemplate(exp *redskyv1beta1.Experiment, t *redskyv1beta1.T
 	if t.Namespace == "" && exp.Spec.NamespaceSelector == nil && exp.Spec.NamespaceTemplate == nil {
 		t.Namespace = exp.Namespace
 	}
+
+	if target, ok := exp.Annotations[redskyv1beta1.AnnotationMetricTarget]; ok {
+		t.Annotations[redskyv1beta1.AnnotationMetricTarget] = target
+	}
 }

--- a/internal/metric/builtin.go
+++ b/internal/metric/builtin.go
@@ -30,9 +30,8 @@ import (
 var BuiltIn = []redskyv1beta1.Metric{cpuUtilizationMetric}
 
 var cpuUtilizationMetric = redskyv1beta1.Metric{
-	Name: "rso cpu utilization",
-	Type: redskyv1beta1.MetricBuiltIn,
-	// TODO figure out how we want to inject labels
+	Name:  "rso cpu utilization",
+	Type:  redskyv1beta1.MetricBuiltIn,
 	Query: cpuUtilizationQuery,
 }
 

--- a/internal/metric/builtin.go
+++ b/internal/metric/builtin.go
@@ -35,7 +35,7 @@ scalar(
     sum(
       sum(kube_pod_container_status_running == 1) by (pod)
       *
-      on (pod) group_left kube_pod_labels{label_component="worker"}
+      on (pod) group_left kube_pod_labels{{rsoTargetLabel .Trial}}
     ) by (pod)
     *
     on (pod) group_right max(container_cpu_usage_seconds_total{container="", image=""}) by (pod)
@@ -45,7 +45,7 @@ scalar(
     sum(
       sum(kube_pod_container_status_running == 1) by (pod)
       *
-      on (pod) group_left kube_pod_labels{label_component="worker"}
+      on (pod) group_left kube_pod_labels{{rsoTargetLabel .Trial}}
     ) by (pod)
     *
     on (pod) group_left sum_over_time(kube_pod_container_resource_limits_cpu_cores[1h:1s])

--- a/internal/metric/builtin.go
+++ b/internal/metric/builtin.go
@@ -23,7 +23,7 @@ import (
 var BuiltIn = []redskyv1beta1.Metric{cpuUtilizationMetric}
 
 var cpuUtilizationMetric = redskyv1beta1.Metric{
-	Name: "cpu utilization",
+	Name: "rso cpu utilization",
 	Type: redskyv1beta1.MetricBuiltIn,
 	// TODO figure out how we want to inject labels
 	Query: cpuUtilizationQuery,
@@ -31,21 +31,21 @@ var cpuUtilizationMetric = redskyv1beta1.Metric{
 
 var cpuUtilizationQuery = `
 scalar(
-  (
+  sum(
     sum(
       sum(kube_pod_container_status_running == 1) by (pod)
       *
-      on (pod) group_left kube_pod_labels{label_component="postgres"}
+      on (pod) group_left kube_pod_labels{label_component="worker"}
     ) by (pod)
     *
     on (pod) group_right max(container_cpu_usage_seconds_total{container="", image=""}) by (pod)
   )
   /
-  (
+  sum(
     sum(
       sum(kube_pod_container_status_running == 1) by (pod)
       *
-      on (pod) group_left kube_pod_labels{label_component="postgres"}
+      on (pod) group_left kube_pod_labels{label_component="worker"}
     ) by (pod)
     *
     on (pod) group_left sum_over_time(kube_pod_container_resource_limits_cpu_cores[1h:1s])

--- a/internal/metric/builtin.go
+++ b/internal/metric/builtin.go
@@ -34,7 +34,7 @@ var cpuUtilizationMetric = redskyv1beta1.Metric{
 	Name:  "rso cpu utilization",
 	Type:  redskyv1beta1.MetricBuiltIn,
 	Query: cpuUtilizationQuery,
-	URL:   fmt.Sprintf("http://%s:9090", PrometheusServiceName),
+	URL:   fmt.Sprintf("http://%s.%s:9090", PrometheusServiceName, "{{ .Trial.Namespace }}"),
 }
 
 var cpuUtilizationQuery = `

--- a/internal/metric/builtin.go
+++ b/internal/metric/builtin.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2020 GramLabs, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metric
+
+import (
+	redskyv1beta1 "github.com/redskyops/redskyops-controller/api/v1beta1"
+)
+
+var BuiltIn = []redskyv1beta1.Metric{cpuUtilizationMetric}
+
+var cpuUtilizationMetric = redskyv1beta1.Metric{
+	Name:  "cpu utilization",
+	Type:  redskyv1beta1.MetricBuiltIn,
+	Query: ``,
+}

--- a/internal/metric/builtin.go
+++ b/internal/metric/builtin.go
@@ -24,8 +24,9 @@ import (
 	prom "github.com/prometheus/client_golang/api"
 	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	redskyv1beta1 "github.com/redskyops/redskyops-controller/api/v1beta1"
-	"github.com/redskyops/redskyops-controller/internal/template"
 )
+
+const PrometheusServiceName = "rso-prometheus"
 
 var BuiltIn = []redskyv1beta1.Metric{cpuUtilizationMetric}
 
@@ -33,6 +34,7 @@ var cpuUtilizationMetric = redskyv1beta1.Metric{
 	Name:  "rso cpu utilization",
 	Type:  redskyv1beta1.MetricBuiltIn,
 	Query: cpuUtilizationQuery,
+	URL:   fmt.Sprintf("http://%s.%s:9090", PrometheusServiceName, "{{ .Trial.Namespace }}"),
 }
 
 var cpuUtilizationQuery = `
@@ -62,7 +64,7 @@ scalar(
 // Flush will delete all the time series that are used by the builtin metric queries.
 // This should effectively be starting over from a fresh Prometheus instance.
 func Flush(ctx context.Context, namespace string) error {
-	address := fmt.Sprintf("http://%s.%s:9090", template.PrometheusServiceName, namespace)
+	address := fmt.Sprintf("http://%s.%s:9090", PrometheusServiceName, namespace)
 
 	c, err := prom.NewClient(prom.Config{Address: address})
 	if err != nil {

--- a/internal/metric/builtin.go
+++ b/internal/metric/builtin.go
@@ -40,23 +40,15 @@ var cpuUtilizationMetric = redskyv1beta1.Metric{
 var cpuUtilizationQuery = `
 scalar(
   sum(
-    sum(
-      sum(kube_pod_container_status_running == 1) by (pod)
-      *
-      on (pod) group_left kube_pod_labels{{rsoTargetLabel .Trial}}
-    ) by (pod)
+    max(container_cpu_usage_seconds_total{container="", image=""}) by (pod)
     *
-    on (pod) group_right max(container_cpu_usage_seconds_total{container="", image=""}) by (pod)
+    on (pod) group_left kube_pod_labels{{rsoTargetLabel .Trial}}
   )
   /
   sum(
-    sum(
-      sum(kube_pod_container_status_running == 1) by (pod)
-      *
-      on (pod) group_left kube_pod_labels{{rsoTargetLabel .Trial}}
-    ) by (pod)
+    sum_over_time(kube_pod_container_resource_limits_cpu_cores[1h:1s])
     *
-    on (pod) group_left sum_over_time(kube_pod_container_resource_limits_cpu_cores[1h:1s])
+    on (pod) group_left kube_pod_labels{{rsoTargetLabel .Trial}}
   )
 )
 `

--- a/internal/metric/builtin.go
+++ b/internal/metric/builtin.go
@@ -30,23 +30,25 @@ var cpuUtilizationMetric = redskyv1beta1.Metric{
 }
 
 var cpuUtilizationQuery = `
-(
-  sum(
-    sum(kube_pod_container_status_running == 1) by (pod)
+scalar(
+  (
+    sum(
+      sum(kube_pod_container_status_running == 1) by (pod)
+      *
+      on (pod) group_left kube_pod_labels{label_component="postgres"}
+    ) by (pod)
     *
-    on (pod) group_left kube_pod_labels{label_component="postgres"}
-  ) by (pod)
-  *
-  on (pod) group_right max(container_cpu_usage_seconds_total{container="", image=""}) by (pod)
-)
-/
-(
-  sum(
-    sum(kube_pod_container_status_running == 1) by (pod)
+    on (pod) group_right max(container_cpu_usage_seconds_total{container="", image=""}) by (pod)
+  )
+  /
+  (
+    sum(
+      sum(kube_pod_container_status_running == 1) by (pod)
+      *
+      on (pod) group_left kube_pod_labels{label_component="postgres"}
+    ) by (pod)
     *
-    on (pod) group_left kube_pod_labels{label_component="postgres"}
-  ) by (pod)
-  *
-  on (pod) group_left sum_over_time(kube_pod_container_resource_limits_cpu_cores[1h])
+    on (pod) group_left sum_over_time(kube_pod_container_resource_limits_cpu_cores[1h:1s])
+  )
 )
 `

--- a/internal/metric/builtin.go
+++ b/internal/metric/builtin.go
@@ -34,7 +34,7 @@ var cpuUtilizationMetric = redskyv1beta1.Metric{
 	Name:  "rso cpu utilization",
 	Type:  redskyv1beta1.MetricBuiltIn,
 	Query: cpuUtilizationQuery,
-	URL:   fmt.Sprintf("http://%s.%s:9090", PrometheusServiceName, "{{ .Trial.Namespace }}"),
+	URL:   fmt.Sprintf("http://%s:9090", PrometheusServiceName),
 }
 
 var cpuUtilizationQuery = `

--- a/internal/metric/metric.go
+++ b/internal/metric/metric.go
@@ -69,6 +69,11 @@ func CaptureMetric(metric *redskyv1beta1.Metric, trial *redskyv1beta1.Trial, tar
 		return captureDatadogMetric(metric.Scheme, metric.Query, trial.Status.StartTime.Time, trial.Status.CompletionTime.Time)
 	case redskyv1beta1.MetricJSONPath:
 		return captureJSONPathMetric(metric, target)
+	case redskyv1beta1.MetricBuiltIn:
+		if metric.URL, err = template.New().RenderPrometheusURL(metric, trial); err != nil {
+			return 0, 0, err
+		}
+		return capturePrometheusMetric(metric, target, trial.Status.CompletionTime.Time)
 	default:
 		return 0, 0, fmt.Errorf("unknown metric type: %s", metric.Type)
 	}

--- a/internal/metric/prometheus.go
+++ b/internal/metric/prometheus.go
@@ -74,6 +74,7 @@ func captureOnePrometheusMetric(address, query, errorQuery string, completionTim
 		}
 	}
 
+	fmt.Println("prom query:", query, completionTime)
 	// Execute query
 	v, _, err := promAPI.Query(context.TODO(), query, completionTime)
 	if err != nil {

--- a/internal/metric/prometheus.go
+++ b/internal/metric/prometheus.go
@@ -74,7 +74,6 @@ func captureOnePrometheusMetric(address, query, errorQuery string, completionTim
 		}
 	}
 
-	fmt.Println("prom query:", query, completionTime)
 	// Execute query
 	v, _, err := promAPI.Query(context.TODO(), query, completionTime)
 	if err != nil {

--- a/internal/setup/experiment_job.go
+++ b/internal/setup/experiment_job.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2020 GramLabs, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package setup
+
+import (
+	"fmt"
+	"os"
+
+	redskyv1beta1 "github.com/redskyops/redskyops-controller/api/v1beta1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// NOTE: The default image names use a ":latest" tag which causes the default pull policy to switch
+// from "IfNotPresent" to "Always". However, the default image names are not associated with a public
+// repository and cannot actually be pulled (they only work if they are present). The exact opposite
+// problem occurs with the production image names: we want those to have a policy of "Always" to address
+// the potential of a floating tag but they will default to "IfNotPresent" because they do not use
+// ":latest". To address this we always explicitly specify the pull policy corresponding to the image.
+// Finally, when using digests, the default of "IfNotPresent" is acceptable as it is unambiguous.
+
+// NewTrialJob returns a new setup job for either create or delete
+func NewExperimentJob(exp *redskyv1beta1.Experiment, mode string) (*batchv1.Job, error) {
+	job := &batchv1.Job{}
+	job.Namespace = exp.Namespace
+	job.Name = fmt.Sprintf("%s-%s", exp.Name, mode)
+
+	// May want to add in an experiment specific label
+	job.Labels = map[string]string{
+		redskyv1beta1.LabelExperiment: exp.Name,
+	}
+
+	job.Spec.BackoffLimit = new(int32)
+	job.Spec.Template.Labels = map[string]string{
+		redskyv1beta1.LabelExperiment: exp.Name,
+	}
+	job.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyNever
+
+	// TODO: not sure which service account we want to use with this,
+	// maybe piggyback off trial spec service account?
+	if exp.Spec.TrialTemplate.Spec.SetupServiceAccountName != "" {
+		job.Spec.Template.Spec.ServiceAccountName = exp.Spec.TrialTemplate.Spec.SetupServiceAccountName
+	}
+
+	runAsNonRoot := true
+	job.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
+		RunAsNonRoot: &runAsNonRoot,
+	}
+
+	// We need to run as a non-root user that has the same UID and GID
+	id := int64(1000)
+	allowPrivilegeEscalation := false
+
+	c := corev1.Container{
+		Name: fmt.Sprintf("%s-%s", job.Name, "prometheus-setup"),
+		Args: []string{"prometheus", mode},
+		Env: []corev1.EnvVar{
+			{Name: "NAMESPACE", Value: exp.Namespace},
+			{Name: "NAME", Value: fmt.Sprintf("%s-%s", job.Name, "prometheus-setup")},
+		},
+		SecurityContext: &corev1.SecurityContext{
+			RunAsUser:                &id,
+			RunAsGroup:               &id,
+			AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+		},
+	}
+
+	// Check the environment for a default setup tools image name
+	if c.Image == "" {
+		c.Image = os.Getenv("DEFAULT_SETUP_IMAGE")
+		c.ImagePullPolicy = corev1.PullPolicy(os.Getenv("DEFAULT_SETUP_IMAGE_PULL_POLICY"))
+	}
+
+	// Make sure we have an image
+	if c.Image == "" {
+		c.Image = Image
+		c.ImagePullPolicy = corev1.PullPolicy(ImagePullPolicy)
+	}
+
+	job.Spec.Template.Spec.Containers = append(job.Spec.Template.Spec.Containers, c)
+
+	return job, nil
+}

--- a/internal/setup/experiment_job.go
+++ b/internal/setup/experiment_job.go
@@ -67,8 +67,7 @@ func NewExperimentJob(exp *redskyv1beta1.Experiment, mode string) (*batchv1.Job,
 		Name: fmt.Sprintf("%s-%s", job.Name, "prometheus-setup"),
 		Args: []string{"prometheus", mode},
 		Env: []corev1.EnvVar{
-			// TODO need a better way to get this
-			{Name: "NAMESPACE", Value: "redsky-system"},
+			{Name: "NAMESPACE", Value: exp.Namespace},
 			{Name: "NAME", Value: fmt.Sprintf("%s-%s", job.Name, "prometheus-setup")},
 			{Name: "EXPERIMENT", Value: exp.Name},
 		},

--- a/internal/setup/experiment_job.go
+++ b/internal/setup/experiment_job.go
@@ -39,14 +39,14 @@ func NewExperimentJob(exp *redskyv1beta1.Experiment, mode string) (*batchv1.Job,
 	job.Namespace = exp.Namespace
 	job.Name = fmt.Sprintf("%s-%s", exp.Name, mode)
 
-	// May want to add in an experiment specific label
 	job.Labels = map[string]string{
 		redskyv1beta1.LabelExperiment: exp.Name,
 	}
 
 	job.Spec.BackoffLimit = new(int32)
 	job.Spec.Template.Labels = map[string]string{
-		redskyv1beta1.LabelExperiment: exp.Name,
+		redskyv1beta1.LabelExperiment:     exp.Name,
+		redskyv1beta1.LabelExperimentRole: "experimentSetup",
 	}
 	job.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyNever
 
@@ -71,6 +71,7 @@ func NewExperimentJob(exp *redskyv1beta1.Experiment, mode string) (*batchv1.Job,
 		Env: []corev1.EnvVar{
 			{Name: "NAMESPACE", Value: exp.Namespace},
 			{Name: "NAME", Value: fmt.Sprintf("%s-%s", job.Name, "prometheus-setup")},
+			{Name: "EXPERIMENT", Value: exp.Name},
 		},
 		SecurityContext: &corev1.SecurityContext{
 			RunAsUser:                &id,

--- a/internal/setup/experiment_job_test.go
+++ b/internal/setup/experiment_job_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2020 GramLabs, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package setup
+
+import (
+	"fmt"
+	"testing"
+
+	redskyv1beta1 "github.com/redskyops/redskyops-controller/api/v1beta1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestExperimentJob(t *testing.T) {
+	testCases := []struct {
+		desc string
+		exp  redskyv1beta1.Experiment
+		mode string
+	}{
+		{
+			desc: "default create",
+			exp: redskyv1beta1.Experiment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-exp",
+					Namespace: "default",
+				},
+			},
+			mode: ModeCreate,
+		},
+		{
+			desc: "default delete",
+			exp: redskyv1beta1.Experiment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-exp",
+					Namespace: "default",
+				},
+			},
+			mode: ModeDelete,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%q", tc.desc), func(t *testing.T) {
+			job, err := NewExperimentJob(&tc.exp, tc.mode)
+			assert.NoError(t, err)
+
+			assert.NotNil(t, job)
+			assert.Equal(t, tc.exp.Name, job.Labels[redskyv1beta1.LabelExperiment])
+			assert.Len(t, job.Spec.Template.Spec.Containers, 1)
+			assert.Equal(t, tc.exp.Namespace, job.Spec.Template.Spec.Containers[0].Env[0].Value)
+			assert.Contains(t, job.Spec.Template.Spec.Containers[0].Args, tc.mode)
+		})
+	}
+}

--- a/internal/setup/trial_job.go
+++ b/internal/setup/trial_job.go
@@ -47,8 +47,8 @@ var (
 // ":latest". To address this we always explicitly specify the pull policy corresponding to the image.
 // Finally, when using digests, the default of "IfNotPresent" is acceptable as it is unambiguous.
 
-// NewJob returns a new setup job for either create or delete
-func NewJob(t *redskyv1beta1.Trial, mode string) (*batchv1.Job, error) {
+// NewTrialJob returns a new setup job for either create or delete
+func NewTrialJob(t *redskyv1beta1.Trial, mode string) (*batchv1.Job, error) {
 	job := &batchv1.Job{}
 	job.Namespace = t.Namespace
 	job.Name = fmt.Sprintf("%s-%s", t.Name, mode)

--- a/internal/template/function.go
+++ b/internal/template/function.go
@@ -88,8 +88,10 @@ func resourceRequests(pods corev1.PodList, weights string) (float64, error) {
 	return totalResources, nil
 }
 
+const PrometheusServiceName = "rso-prometheus"
+
 func promServer(expName types.NamespacedName) string {
-	return fmt.Sprintf("prom-%s.%s", expName.Name, expName.Namespace)
+	return fmt.Sprintf("%s.%s", PrometheusServiceName, expName.Namespace)
 }
 
 func rsoTargetLabel(tm metav1.ObjectMeta) string {

--- a/internal/template/function.go
+++ b/internal/template/function.go
@@ -86,5 +86,5 @@ func resourceRequests(pods corev1.PodList, weights string) (float64, error) {
 }
 
 func promServer(expName types.NamespacedName) string {
-	return fmt.Sprintf("prom-%s", expName.Name)
+	return fmt.Sprintf("prom-%s.%s", expName.Name, expName.Namespace)
 }

--- a/internal/template/function.go
+++ b/internal/template/function.go
@@ -24,7 +24,9 @@ import (
 	"time"
 
 	"github.com/Masterminds/sprig"
+	redskyv1beta1 "github.com/redskyops/redskyops-controller/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -39,6 +41,7 @@ func FuncMap() template.FuncMap {
 		"percent":          percent,
 		"resourceRequests": resourceRequests,
 		"promServer":       promServer,
+		"rsoTargetLabel":   rsoTargetLabel,
 	}
 
 	for k, v := range extra {
@@ -87,4 +90,19 @@ func resourceRequests(pods corev1.PodList, weights string) (float64, error) {
 
 func promServer(expName types.NamespacedName) string {
 	return fmt.Sprintf("prom-%s.%s", expName.Name, expName.Namespace)
+}
+
+func rsoTargetLabel(tm metav1.ObjectMeta) string {
+
+	labelPair, ok := tm.Annotations[redskyv1beta1.AnnotationMetricTarget]
+	if !ok {
+		return ""
+	}
+
+	labels := strings.Split(labelPair, "=")
+	if len(labels) != 2 {
+		return ""
+	}
+
+	return fmt.Sprintf("{label_%s=\"%s\"}", labels[0], labels[1])
 }

--- a/internal/template/function.go
+++ b/internal/template/function.go
@@ -27,7 +27,6 @@ import (
 	redskyv1beta1 "github.com/redskyops/redskyops-controller/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 // FuncMap returns the functions used for template evaluation
@@ -40,7 +39,6 @@ func FuncMap() template.FuncMap {
 		"duration":         duration,
 		"percent":          percent,
 		"resourceRequests": resourceRequests,
-		"promServer":       promServer,
 		"rsoTargetLabel":   rsoTargetLabel,
 	}
 
@@ -86,12 +84,6 @@ func resourceRequests(pods corev1.PodList, weights string) (float64, error) {
 		}
 	}
 	return totalResources, nil
-}
-
-const PrometheusServiceName = "rso-prometheus"
-
-func promServer(expName types.NamespacedName) string {
-	return fmt.Sprintf("%s.%s", PrometheusServiceName, expName.Namespace)
 }
 
 func rsoTargetLabel(tm metav1.ObjectMeta) string {

--- a/internal/template/function.go
+++ b/internal/template/function.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/Masterminds/sprig"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // FuncMap returns the functions used for template evaluation
@@ -37,6 +38,7 @@ func FuncMap() template.FuncMap {
 		"duration":         duration,
 		"percent":          percent,
 		"resourceRequests": resourceRequests,
+		"promServer":       promServer,
 	}
 
 	for k, v := range extra {
@@ -81,4 +83,8 @@ func resourceRequests(pods corev1.PodList, weights string) (float64, error) {
 		}
 	}
 	return totalResources, nil
+}
+
+func promServer(expName types.NamespacedName) string {
+	return fmt.Sprintf("prom-%s", expName.Name)
 }

--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -27,7 +27,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
@@ -53,8 +52,6 @@ type MetricData struct {
 	Values map[string]int64
 	// List of pods from the trial namespace (only available for "pods" type metrics)
 	Pods *corev1.PodList
-	// The experiment identifier
-	ExperimentNamespacedName types.NamespacedName
 }
 
 func newPatchData(t *redskyv1beta1.Trial) *PatchData {
@@ -93,8 +90,6 @@ func newMetricData(t *redskyv1beta1.Trial, target runtime.Object) *MetricData {
 	}
 
 	d.Range = fmt.Sprintf("%.0fs", math.Max(d.CompletionTime.Sub(d.StartTime).Seconds(), 0))
-
-	d.ExperimentNamespacedName = t.ExperimentNamespacedName()
 
 	return d
 }
@@ -149,13 +144,11 @@ func (e *Engine) RenderMetricQueries(metric *redskyv1beta1.Metric, trial *redsky
 	return b1.String(), b2.String(), nil
 }
 
-const rsoProm = "http://{{ promServer .ExperimentNamespacedName }}:9090"
-
 // RenderPrometheusURL returns the URL for the RSO managed prometheus instance
 func (e *Engine) RenderPrometheusURL(metric *redskyv1beta1.Metric, trial *redskyv1beta1.Trial) (string, error) {
 	data := newMetricData(trial, nil)
 
-	urlBytes, err := e.render("url", rsoProm, data)
+	urlBytes, err := e.render("url", metric.URL, data)
 
 	return urlBytes.String(), err
 }

--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -160,6 +160,14 @@ func (e *Engine) RenderPrometheusURL(metric *redskyv1beta1.Metric, trial *redsky
 	return urlBytes.String(), err
 }
 
+func (e *Engine) RenderAnnotationTarget(metric *redskyv1beta1.Metric, trial *redskyv1beta1.Trial) (string, error) {
+	data := newMetricData(trial, nil)
+
+	labelPairBytes, err := e.render("annotation", metric.Query, data)
+
+	return labelPairBytes.String(), err
+}
+
 func (e *Engine) render(name, text string, data interface{}) (*bytes.Buffer, error) {
 	tmpl, err := template.New(name).Funcs(e.FuncMap).Parse(text)
 	if err != nil {

--- a/internal/template/template_test.go
+++ b/internal/template/template_test.go
@@ -116,14 +116,15 @@ func TestEngine(t *testing.T) {
 				},
 				Spec: redskyv1beta1.TrialSpec{
 					ExperimentRef: &corev1.ObjectReference{
-						Name: "my-experiment",
+						Name:      "my-experiment",
+						Namespace: "default",
 					},
 				},
 			},
 			input: &redskyv1beta1.Metric{
 				Type: redskyv1beta1.MetricBuiltIn,
 			},
-			expected: "http://prom-my-experiment:9090",
+			expected: "http://prom-my-experiment.default:9090",
 		},
 		{
 			desc: "default metric (weighted)",

--- a/internal/template/template_test.go
+++ b/internal/template/template_test.go
@@ -112,19 +112,16 @@ func TestEngine(t *testing.T) {
 			desc: "default prom url",
 			trial: &redskyv1beta1.Trial{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "my-trial",
-				},
-				Spec: redskyv1beta1.TrialSpec{
-					ExperimentRef: &corev1.ObjectReference{
-						Name:      "my-experiment",
-						Namespace: "default",
-					},
+					Name:      "my-trial",
+					Namespace: "default",
 				},
 			},
 			input: &redskyv1beta1.Metric{
 				Type: redskyv1beta1.MetricBuiltIn,
+				Name: "testMetric",
+				URL:  fmt.Sprintf("http://%s.%s:9090", "rso-prometheus", "{{ .Trial.Namespace }}"),
 			},
-			expected: fmt.Sprintf("http://%s.default:9090", PrometheusServiceName),
+			expected: fmt.Sprintf("http://%s.default:9090", "rso-prometheus"),
 		},
 		{
 			desc: "default metric (weighted)",

--- a/internal/template/template_test.go
+++ b/internal/template/template_test.go
@@ -124,7 +124,7 @@ func TestEngine(t *testing.T) {
 			input: &redskyv1beta1.Metric{
 				Type: redskyv1beta1.MetricBuiltIn,
 			},
-			expected: "http://prom-my-experiment.default:9090",
+			expected: fmt.Sprintf("http://%s.default:9090", PrometheusServiceName),
 		},
 		{
 			desc: "default metric (weighted)",

--- a/redskyctl/internal/commands/grant_permissions/generator_test.go
+++ b/redskyctl/internal/commands/grant_permissions/generator_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2020 GramLabs, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grant_permissions_test
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/redskyops/redskyops-controller/internal/config"
+	"github.com/redskyops/redskyops-controller/redskyctl/internal/commander"
+	"github.com/redskyops/redskyops-controller/redskyctl/internal/commands/grant_permissions"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	defaultClusterRole = "redsky-patching-role"
+	builtinClusterRole = "redsky-builtin-role"
+)
+
+func TestGrantPermissions(t *testing.T) {
+
+	testCases := []struct {
+		desc               string
+		args               []string
+		expectedError      bool
+		expectedPatterns   []string
+		unexpectedPatterns []string
+	}{
+		{
+			desc: "default",
+			expectedPatterns: []string{
+				defaultClusterRole,
+				builtinClusterRole,
+				"name: builtin",
+			},
+		},
+		{
+			desc: "skip builtin",
+			args: []string{"--skip-builtin"},
+			expectedPatterns: []string{
+				defaultClusterRole,
+			},
+			unexpectedPatterns: []string{
+				builtinClusterRole,
+			},
+		},
+		{
+			desc: "skip default",
+			args: []string{"--skip-default"},
+			expectedPatterns: []string{
+				builtinClusterRole,
+			},
+			unexpectedPatterns: []string{
+				defaultClusterRole,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%q", tc.desc), func(t *testing.T) {
+			// Create a global configuration
+			cfg := &config.RedSkyConfig{}
+			cmd := grant_permissions.NewGeneratorCommand(&grant_permissions.GeneratorOptions{Config: cfg})
+			commander.ConfigGlobals(cfg, cmd)
+
+			var b bytes.Buffer
+			cmd.SetOut(&b)
+			if len(tc.args) > 0 {
+				cmd.SetArgs(tc.args)
+			}
+
+			err := cmd.Execute()
+			if tc.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			// Verify output has what we're looking for
+			for _, text := range tc.expectedPatterns {
+				assert.Contains(t, b.String(), text)
+			}
+
+			// Verify output doesn't contain these
+			for _, text := range tc.unexpectedPatterns {
+				assert.NotContains(t, b.String(), text)
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
Wanted to get stuff out there so we could use this for discussion. 

Currently I'm thinking of introducing a new metric type ( MetricBuiltIn ) to facilitate our ability to include metrics out of the box.

This will eventually expand to:
- include a prometheus deployment
- include built in metrics
  - these are ultimately prometheus metrics, but allow for generating the prometheus server url and inject additional metadata ( label selectors, query ranges, etc )
- incorporate the built in metrics automatically as part of a trial run

The workflow would be something like:
- experiment gets created
- prometheus server and kube state metrics get deployed alongside experiment
- during trial run, prometheus server scrapes cadvisor and kube state metrics
- after trial run, user provided metrics and builtin metrics are evaluated
- profit(?)