### PR TITLE
fix: Explicitly overwrite kustomize during install

### DIFF
--- a/hack/install_kustomize.sh
+++ b/hack/install_kustomize.sh
@@ -3,6 +3,7 @@
 set -e
 
 echo "Install kustomize"
+sudo snap remove kustomize
 curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | \
   bash
-[[ ! -f /usr/local/bin/kustomize ]] && sudo mv ./kustomize /usr/local/bin/kustomize
+sudo mv ./kustomize /usr/local/bin/kustomize


### PR DESCRIPTION
This is to address an issue recently introduced by github runners.

Signed-off-by: Brad Beam <brad.beam@carbonrelay.com>