### PR TITLE
Make helm format

### DIFF
--- a/docs/redskyctl/redskyctl_authorize-cluster.md
+++ b/docs/redskyctl/redskyctl_authorize-cluster.md
@@ -14,7 +14,6 @@ redskyctl authorize-cluster [flags]
 
 ```
       --client-name string   Client name to use for registration.
-      --helm-values          Generate a Helm values file instead of a secret.
   -h, --help                 help for authorize-cluster
 ```
 

--- a/docs/redskyctl/redskyctl_generate_secret.md
+++ b/docs/redskyctl/redskyctl_generate_secret.md
@@ -14,9 +14,8 @@ redskyctl generate secret [flags]
 
 ```
       --client-name string   Client name to use for registration.
-      --helm-values          Generate a Helm values file instead of a secret.
   -h, --help                 help for secret
-  -o, --output format        Output format. One of: json|yaml (default "yaml")
+  -o, --output format        Output format. One of: json|yaml|helm (default "yaml")
 ```
 
 ### Options inherited from parent commands

--- a/redskyctl/internal/commander/commander.go
+++ b/redskyctl/internal/commander/commander.go
@@ -82,8 +82,8 @@ func SetExperimentsAPI(api *experimentsv1alpha1.API, cfg config.Config, cmd *cob
 }
 
 // SetPrinter assigns the resource printer during the pre-run of the supplied command
-func SetPrinter(meta TableMeta, printer *ResourcePrinter, cmd *cobra.Command) {
-	pf := newPrintFlags(meta, cmd.Annotations)
+func SetPrinter(meta TableMeta, printer *ResourcePrinter, cmd *cobra.Command, additionalFormats map[string]AdditionalFormat) {
+	pf := newPrintFlags(meta, cmd.Annotations, additionalFormats)
 	pf.addFlags(cmd)
 	AddPreRunE(cmd, func(*cobra.Command, []string) error {
 		return pf.toPrinter(printer)
@@ -91,12 +91,12 @@ func SetPrinter(meta TableMeta, printer *ResourcePrinter, cmd *cobra.Command) {
 }
 
 // SetKubePrinter assigns a client-go enabled resource printer during the pre-run of the supplied command
-func SetKubePrinter(printer *ResourcePrinter, cmd *cobra.Command) {
+func SetKubePrinter(printer *ResourcePrinter, cmd *cobra.Command, additionalFormats map[string]AdditionalFormat) {
 	kp := &kubePrinter{scheme: runtime.NewScheme()}
 	_ = clientgoscheme.AddToScheme(kp.scheme)
 	_ = redskyv1alpha1.AddToScheme(kp.scheme)
 	_ = redskyv1beta1.AddToScheme(kp.scheme)
-	pf := newPrintFlags(kp, cmd.Annotations)
+	pf := newPrintFlags(kp, cmd.Annotations, additionalFormats)
 	pf.addFlags(cmd)
 	AddPreRunE(cmd, func(*cobra.Command, []string) error {
 		if err := pf.toPrinter(&kp.printer); err != nil {

--- a/redskyctl/internal/commands/authorize_cluster/authorize_cluster.go
+++ b/redskyctl/internal/commands/authorize_cluster/authorize_cluster.go
@@ -51,11 +51,6 @@ func NewCommand(o *Options) *cobra.Command {
 }
 
 func (o *Options) authorizeCluster(ctx context.Context) error {
-	// If we are generating Helm values, just call the generator directly and return
-	if o.HelmValues {
-		return o.generate(ctx)
-	}
-
 	// Fork `kubectl apply` and get a pipe to write manifests to
 	kubectlApply, err := o.Config.Kubectl(ctx, "apply", "-f", "-")
 	if err != nil {

--- a/redskyctl/internal/commands/authorize_cluster/generator.go
+++ b/redskyctl/internal/commands/authorize_cluster/generator.go
@@ -85,7 +85,7 @@ func NewGeneratorCommand(o *GeneratorOptions) *cobra.Command {
 
 	o.addFlags(cmd)
 
-	commander.SetKubePrinter(&o.Printer, cmd)
+	commander.SetKubePrinter(&o.Printer, cmd, nil)
 	commander.ExitOnError(cmd)
 	return cmd
 }
@@ -157,7 +157,7 @@ func (o *GeneratorOptions) generate(ctx context.Context) error {
 
 	// Use an alternate printer just for Helm values
 	if o.HelmValues {
-		o.Printer = &helmValuesPrinter{}
+		o.Printer = commander.ResourcePrinterFunc(printHelmValues)
 	}
 
 	return o.Printer.PrintObj(secret, o.Out)
@@ -246,11 +246,8 @@ func localClientInformation(ctrl *config.Controller) *registration.ClientInforma
 	return resp
 }
 
-type helmValuesPrinter struct {
-}
-
-func (h helmValuesPrinter) PrintObj(i interface{}, w io.Writer) error {
-	secret, ok := i.(*corev1.Secret)
+func printHelmValues(obj interface{}, w io.Writer) error {
+	secret, ok := obj.(*corev1.Secret)
 	if !ok {
 		return nil
 	}

--- a/redskyctl/internal/commands/experiments/get.go
+++ b/redskyctl/internal/commands/experiments/get.go
@@ -61,7 +61,7 @@ func NewGetCommand(o *GetOptions) *cobra.Command {
 
 	_ = cmd.MarkZshCompPositionalArgumentWords(1, validTypes()...)
 
-	commander.SetPrinter(&experimentsMeta{}, &o.Printer, cmd)
+	commander.SetPrinter(&experimentsMeta{}, &o.Printer, cmd, nil)
 	commander.ExitOnError(cmd)
 	return cmd
 }

--- a/redskyctl/internal/commands/generate/rbac.go
+++ b/redskyctl/internal/commands/generate/rbac.go
@@ -81,7 +81,7 @@ func NewRBACCommand(o *RBACOptions) *cobra.Command {
 
 	_ = cmd.MarkFlagFilename("filename", "yml", "yaml")
 
-	commander.SetKubePrinter(&o.Printer, cmd)
+	commander.SetKubePrinter(&o.Printer, cmd, nil)
 	commander.ExitOnError(cmd)
 	return cmd
 }

--- a/redskyctl/internal/commands/generate/trial.go
+++ b/redskyctl/internal/commands/generate/trial.go
@@ -61,7 +61,7 @@ func NewTrialCommand(o *TrialOptions) *cobra.Command {
 	_ = cmd.MarkFlagFilename("filename", "yml", "yaml")
 	_ = cmd.MarkFlagRequired("filename")
 
-	commander.SetKubePrinter(&o.Printer, cmd)
+	commander.SetKubePrinter(&o.Printer, cmd, nil)
 	commander.ExitOnError(cmd)
 	return cmd
 }

--- a/redskyctl/internal/commands/grant_permissions/generator.go
+++ b/redskyctl/internal/commands/grant_permissions/generator.go
@@ -67,7 +67,7 @@ func NewGeneratorCommand(o *GeneratorOptions) *cobra.Command {
 
 	o.addFlags(cmd)
 
-	commander.SetKubePrinter(&o.Printer, cmd)
+	commander.SetKubePrinter(&o.Printer, cmd, nil)
 	commander.ExitOnError(cmd)
 	return cmd
 }


### PR DESCRIPTION
When generating a secret, we allow you to specify `--helm-values` and it will emit the YAML necessary for configuring the Helm chart. This PR just makes "helm" an output format so `--helm-values` is now `-o helm`.