### PR TITLE
Update suggest to send labels via `CreateTrial`

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -160,14 +160,16 @@ func ToClusterTrial(t *redskyv1beta1.Trial, suggestion *redskyapi.TrialAssignmen
 		}
 	}
 
-	if t.Labels == nil {
-		t.Labels = make(map[string]string)
-	}
-	for k, v := range suggestion.Labels {
-		if v != "" {
-			t.Labels[k] = v
-		} else {
-			delete(t.Labels, k)
+	if len(suggestion.Labels) > 0 {
+		if t.Labels == nil {
+			t.Labels = make(map[string]string, len(suggestion.Labels))
+		}
+		for k, v := range suggestion.Labels {
+			if v != "" {
+				t.Labels[k] = v
+			} else {
+				delete(t.Labels, k)
+			}
 		}
 	}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -160,6 +160,17 @@ func ToClusterTrial(t *redskyv1beta1.Trial, suggestion *redskyapi.TrialAssignmen
 		}
 	}
 
+	if t.Labels == nil {
+		t.Labels = make(map[string]string)
+	}
+	for k, v := range suggestion.Labels {
+		if v != "" {
+			t.Labels[k] = v
+		} else {
+			delete(t.Labels, k)
+		}
+	}
+
 	trial.UpdateStatus(t)
 
 	controllerutil.AddFinalizer(t, Finalizer)

--- a/redskyapi/experiments/v1alpha1/http.go
+++ b/redskyapi/experiments/v1alpha1/http.go
@@ -237,7 +237,7 @@ func (h *httpAPI) CreateTrial(ctx context.Context, u string, asm TrialAssignment
 	}
 
 	switch resp.StatusCode {
-	case http.StatusCreated:
+	case http.StatusCreated, http.StatusAccepted:
 		metaUnmarshal(resp.Header, &ta.TrialMeta)
 		err = json.Unmarshal(body, &ta)
 		return ta, nil // TODO Stop ignoring this when the server starts sending a response body

--- a/redskyapi/experiments/v1alpha1/trial.go
+++ b/redskyapi/experiments/v1alpha1/trial.go
@@ -55,6 +55,8 @@ type TrialAssignments struct {
 
 	// The list of parameter names and their assigned values.
 	Assignments []Assignment `json:"assignments"`
+	// Labels for this trial.
+	Labels map[string]string `json:"labels,omitempty"`
 }
 
 type Value struct {

--- a/redskyctl/internal/commands/experiments/suggest.go
+++ b/redskyctl/internal/commands/experiments/suggest.go
@@ -74,38 +74,32 @@ func (o *SuggestOptions) suggest(ctx context.Context) error {
 		return err
 	}
 
-	ta, err := o.SuggestAssignments(&exp)
-	if err != nil {
+	ta := experimentsv1alpha1.TrialAssignments{}
+	if err := o.SuggestAssignments(&exp, &ta); err != nil {
 		return err
 	}
 
-	t, err := o.ExperimentsAPI.CreateTrial(ctx, exp.TrialsURL, *ta)
+	o.addLabels(&ta)
+
+	_, err = o.ExperimentsAPI.CreateTrial(ctx, exp.TrialsURL, ta)
 	if err != nil {
 		return err
-	}
-
-	if tl := o.trialLabels(); tl != nil && t.LabelsURL != "" {
-		err := o.ExperimentsAPI.LabelTrial(ctx, t.LabelsURL, *tl)
-		if err != nil {
-			return err
-		}
 	}
 
 	return nil
 }
 
 // SuggestAssignments creates new assignments object based on the parameters of the supplied experiment
-func (o *SuggestOptions) SuggestAssignments(exp *experimentsv1alpha1.Experiment) (*experimentsv1alpha1.TrialAssignments, error) {
-	ta := &experimentsv1alpha1.TrialAssignments{}
+func (o *SuggestOptions) SuggestAssignments(exp *experimentsv1alpha1.Experiment, ta *experimentsv1alpha1.TrialAssignments) error {
 	for i := range exp.Parameters {
 		p := &exp.Parameters[i]
 		v, err := o.assign(p)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		ta.Assignments = append(ta.Assignments, experimentsv1alpha1.Assignment{ParameterName: p.Name, Value: v})
 	}
-	return ta, nil
+	return nil
 }
 
 func (o *SuggestOptions) assign(p *experimentsv1alpha1.Parameter) (json.Number, error) {
@@ -133,20 +127,19 @@ func (o *SuggestOptions) assign(p *experimentsv1alpha1.Parameter) (json.Number, 
 	return "0", fmt.Errorf("no assignment for parameter: %s", p.Name)
 }
 
-func (o *SuggestOptions) trialLabels() *experimentsv1alpha1.TrialLabels {
+func (o *SuggestOptions) addLabels(ta *experimentsv1alpha1.TrialAssignments) {
 	if o.Labels == "" {
-		return nil
+		return
 	}
 
-	tl := &experimentsv1alpha1.TrialLabels{Labels: make(map[string]string)}
+	ta.Labels = make(map[string]string)
 	for _, l := range strings.Split(o.Labels, ",") {
 		if p := strings.SplitN(l, "=", 2); len(p) == 2 {
-			tl.Labels[p[0]] = p[1]
+			ta.Labels[p[0]] = p[1]
 		} else if strings.HasSuffix(l, "-") && strings.Trim(l, "-") != "" {
-			tl.Labels[strings.TrimSuffix(l, "-")] = ""
+			ta.Labels[strings.TrimSuffix(l, "-")] = ""
 		}
 	}
-	return tl
 }
 
 func (o *SuggestOptions) defaultValue(p *experimentsv1alpha1.Parameter) (*json.Number, error) {

--- a/redskyctl/internal/commands/experiments/suggest.go
+++ b/redskyctl/internal/commands/experiments/suggest.go
@@ -78,8 +78,9 @@ func (o *SuggestOptions) suggest(ctx context.Context) error {
 	if err := o.SuggestAssignments(&exp, &ta); err != nil {
 		return err
 	}
-
-	o.addLabels(&ta)
+	if err := o.AddLabels(&ta); err != nil {
+		return err
+	}
 
 	_, err = o.ExperimentsAPI.CreateTrial(ctx, exp.TrialsURL, ta)
 	if err != nil {
@@ -127,9 +128,9 @@ func (o *SuggestOptions) assign(p *experimentsv1alpha1.Parameter) (json.Number, 
 	return "0", fmt.Errorf("no assignment for parameter: %s", p.Name)
 }
 
-func (o *SuggestOptions) addLabels(ta *experimentsv1alpha1.TrialAssignments) {
+func (o *SuggestOptions) AddLabels(ta *experimentsv1alpha1.TrialAssignments) error {
 	if o.Labels == "" {
-		return
+		return nil
 	}
 
 	ta.Labels = make(map[string]string)
@@ -140,6 +141,7 @@ func (o *SuggestOptions) addLabels(ta *experimentsv1alpha1.TrialAssignments) {
 			ta.Labels[strings.TrimSuffix(l, "-")] = ""
 		}
 	}
+	return nil
 }
 
 func (o *SuggestOptions) defaultValue(p *experimentsv1alpha1.Parameter) (*json.Number, error) {


### PR DESCRIPTION
It turns out you can only apply labels to completed trials, since manually created trials will be "staged" they cannot be labeled using the `LabelTrial`. This PR adds a label map to the assignments so they can be sent up when the trial is created.