### PR TITLE
feat: Add cpu utilization template function

### DIFF
--- a/internal/template/function.go
+++ b/internal/template/function.go
@@ -17,6 +17,7 @@ limitations under the License.
 package template
 
 import (
+	"bytes"
 	"fmt"
 	"strconv"
 	"strings"
@@ -37,6 +38,7 @@ func FuncMap() template.FuncMap {
 		"duration":         duration,
 		"percent":          percent,
 		"resourceRequests": resourceRequests,
+		"cpuUtilization":   cpuUtilization,
 	}
 
 	for k, v := range extra {
@@ -81,4 +83,51 @@ func resourceRequests(pods corev1.PodList, weights string) (float64, error) {
 		}
 	}
 	return totalResources, nil
+}
+
+func cpuUtilization(labelArgs ...string) (string, error) {
+
+	cpuUtilizationQueryTemplate := `
+scalar(
+  sum(
+    max(container_cpu_usage_seconds_total{container="", image=""}) by (pod)
+    *
+    on (pod) group_left kube_pod_labels{{ . }}
+  )
+  /
+  sum(
+    sum_over_time(kube_pod_container_resource_limits_cpu_cores[1h:1s])
+    *
+    on (pod) group_left kube_pod_labels{{ . }}
+  )
+)`
+
+	tmpl, err := template.New("query").Parse(cpuUtilizationQueryTemplate)
+	if err != nil {
+		return "", err
+	}
+
+	var labels []string
+	for _, label := range strings.Split(strings.Join(labelArgs, ","), ",") {
+		kvpair := strings.Split(label, "=")
+		if len(kvpair) != 2 {
+			// Should we continue or hard fail on invalid labels?
+			continue
+		}
+
+		labels = append(labels, fmt.Sprintf("label_%s=\"%s\"", kvpair[0], kvpair[1]))
+	}
+
+	var labelParam string
+	// if 0 labels, should we inject namespace=.Trial.Namespace automatically?
+	if len(labels) > 0 {
+		labelParam = fmt.Sprintf("{%s}", strings.Join(labels, ","))
+	}
+
+	var output bytes.Buffer
+	if err = tmpl.Execute(&output, labelParam); err != nil {
+		return "", err
+	}
+
+	return output.String(), nil
 }

--- a/internal/template/template_test.go
+++ b/internal/template/template_test.go
@@ -197,7 +197,7 @@ var (
 	expectedCPUUtilizationQueryWithParams = `
 scalar(
   sum(
-    max(container_cpu_usage_seconds_total{container="", image=""}) by (pod)
+    increase(container_cpu_usage_seconds_total{container="", image=""}[1h]) by (pod)
     *
     on (pod) group_left kube_pod_labels{label_component="bob",label_component="tom"}
   )
@@ -212,7 +212,7 @@ scalar(
 	expectedCPUUtilizationQueryWithoutParams = `
 scalar(
   sum(
-    max(container_cpu_usage_seconds_total{container="", image=""}) by (pod)
+    increase(container_cpu_usage_seconds_total{container="", image=""}[1h]) by (pod)
     *
     on (pod) group_left kube_pod_labels
   )

--- a/internal/template/template_test.go
+++ b/internal/template/template_test.go
@@ -166,8 +166,17 @@ func TestEngine_RenderMetricQueries(t *testing.T) {
 			desc: "function cpuUtilization with parameters",
 			metric: redskyv1beta1.Metric{
 				Name:  "testMetric",
-				Query: `{{cpuUtilization "component=bob,component=tom"}}`,
+				Query: `{{cpuUtilization . "component=bob,component=tom"}}`,
 				Type:  redskyv1beta1.MetricLocal,
+			},
+			trial: redskyv1beta1.Trial{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Status: redskyv1beta1.TrialStatus{
+					StartTime:      &metav1.Time{Time: now.Add(-5 * time.Second)},
+					CompletionTime: &now,
+				},
 			},
 			expectedQuery: expectedCPUUtilizationQueryWithParams,
 		},
@@ -176,8 +185,17 @@ func TestEngine_RenderMetricQueries(t *testing.T) {
 			desc: "function cpuUtilization without parameters",
 			metric: redskyv1beta1.Metric{
 				Name:  "testMetric",
-				Query: `{{cpuUtilization}}`,
+				Query: `{{cpuUtilization .}}`,
 				Type:  redskyv1beta1.MetricLocal,
+			},
+			trial: redskyv1beta1.Trial{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Status: redskyv1beta1.TrialStatus{
+					StartTime:      &metav1.Time{Time: now.Add(-5 * time.Second)},
+					CompletionTime: &now,
+				},
 			},
 			expectedQuery: expectedCPUUtilizationQueryWithoutParams,
 		},
@@ -197,13 +215,13 @@ var (
 	expectedCPUUtilizationQueryWithParams = `
 scalar(
   sum(
-    increase(container_cpu_usage_seconds_total{container="", image=""}[1h]) by (pod)
+    increase(container_cpu_usage_seconds_total{container="", image=""}[5s]) by (pod)
     *
     on (pod) group_left kube_pod_labels{label_component="bob",label_component="tom"}
   )
   /
   sum(
-    sum_over_time(kube_pod_container_resource_limits_cpu_cores[1h:1s])
+    sum_over_time(kube_pod_container_resource_limits_cpu_cores[5s:1s])
     *
     on (pod) group_left kube_pod_labels{label_component="bob",label_component="tom"}
   )
@@ -212,15 +230,15 @@ scalar(
 	expectedCPUUtilizationQueryWithoutParams = `
 scalar(
   sum(
-    increase(container_cpu_usage_seconds_total{container="", image=""}[1h]) by (pod)
+    increase(container_cpu_usage_seconds_total{container="", image=""}[5s]) by (pod)
     *
-    on (pod) group_left kube_pod_labels
+    on (pod) group_left kube_pod_labels{namespace="default"}
   )
   /
   sum(
-    sum_over_time(kube_pod_container_resource_limits_cpu_cores[1h:1s])
+    sum_over_time(kube_pod_container_resource_limits_cpu_cores[5s:1s])
     *
-    on (pod) group_left kube_pod_labels
+    on (pod) group_left kube_pod_labels{namespace="default"}
   )
 )`
 )


### PR DESCRIPTION
This introduces the cpuUtilization template function which evaluates to
a prometheus query to grab cpu utilization metrics for a trial.

Signed-off-by: Brad Beam <brad.beam@carbonrelay.com>