### PR TITLE
fix: Present setup task mode as an environment variable

### DIFF
--- a/internal/setup/job.go
+++ b/internal/setup/job.go
@@ -93,6 +93,7 @@ func NewJob(t *redskyv1beta1.Trial, mode string) (*batchv1.Job, error) {
 				{Name: "NAMESPACE", Value: t.Namespace},
 				{Name: "NAME", Value: task.Name},
 				{Name: "TRIAL", Value: t.Name},
+				{Name: "MODE", Value: mode},
 			},
 			SecurityContext: &corev1.SecurityContext{
 				RunAsUser:                &id,

--- a/internal/setup/job_test.go
+++ b/internal/setup/job_test.go
@@ -26,7 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func Test(t *testing.T) {
+func TestNewJob(t *testing.T) {
 	testCases := []struct {
 		desc    string
 		trial   *redsky.Trial

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -86,10 +86,13 @@ func UpdateStatus(t *redskyv1beta1.Trial, probeTime *metav1.Time) bool {
 
 // GetTrialConditionType returns the trial condition type used to report status for the specified job
 func GetTrialConditionType(j *batchv1.Job) (redskyv1beta1.TrialConditionType, error) {
-	// TODO This should just be a label or annotation on the job
 	for _, c := range j.Spec.Template.Spec.Containers {
-		if len(c.Args) > 0 {
-			switch c.Args[0] {
+		for _, env := range c.Env {
+			if env.Name != "MODE" {
+				continue
+			}
+
+			switch env.Value {
 			case ModeCreate:
 				return redskyv1beta1.TrialSetupCreated, nil
 			case ModeDelete:

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2020 GramLabs, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package setup_test
+
+import (
+	"fmt"
+	"testing"
+
+	redsky "github.com/redskyops/redskyops-controller/api/v1beta1"
+	"github.com/redskyops/redskyops-controller/internal/setup"
+	"github.com/stretchr/testify/assert"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestGetTrialConditionType(t *testing.T) {
+	testCases := []struct {
+		desc          string
+		job           *batchv1.Job
+		expectedError bool
+		conditionType redsky.TrialConditionType
+	}{
+		{
+			desc: "no mode",
+			job: &batchv1.Job{
+				Spec: batchv1.JobSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Env: []corev1.EnvVar{},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedError: true,
+		},
+		{
+			desc: "create",
+			job: &batchv1.Job{
+				Spec: batchv1.JobSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Env: []corev1.EnvVar{
+										{
+											Name:  "MODE",
+											Value: setup.ModeCreate,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			conditionType: redsky.TrialSetupCreated,
+			expectedError: false,
+		},
+		{
+			desc: "delete",
+			job: &batchv1.Job{
+				Spec: batchv1.JobSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Env: []corev1.EnvVar{
+										{
+											Name:  "MODE",
+											Value: setup.ModeDelete,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			conditionType: redsky.TrialSetupDeleted,
+			expectedError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%q", tc.desc), func(t *testing.T) {
+			condType, err := setup.GetTrialConditionType(tc.job)
+			if tc.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, tc.conditionType, condType)
+		})
+	}
+}

--- a/internal/template/function.go
+++ b/internal/template/function.go
@@ -90,7 +90,9 @@ func cpuUtilization(data MetricData, labelArgs ...string) (string, error) {
 	cpuUtilizationQueryTemplate := `
 scalar(
   sum(
-    increase(container_cpu_usage_seconds_total{container="", image=""}[{{ .Range }}]) by (pod)
+    sum(
+      increase(container_cpu_usage_seconds_total{container="", image=""}[{{ .Range }}])
+    ) by (pod)
     *
     on (pod) group_left kube_pod_labels{{ .Labels }}
   )

--- a/internal/template/template_test.go
+++ b/internal/template/template_test.go
@@ -215,7 +215,9 @@ var (
 	expectedCPUUtilizationQueryWithParams = `
 scalar(
   sum(
-    increase(container_cpu_usage_seconds_total{container="", image=""}[5s]) by (pod)
+    sum(
+      increase(container_cpu_usage_seconds_total{container="", image=""}[5s])
+    ) by (pod)
     *
     on (pod) group_left kube_pod_labels{label_component="bob",label_component="tom"}
   )
@@ -230,7 +232,9 @@ scalar(
 	expectedCPUUtilizationQueryWithoutParams = `
 scalar(
   sum(
-    increase(container_cpu_usage_seconds_total{container="", image=""}[5s]) by (pod)
+    sum(
+      increase(container_cpu_usage_seconds_total{container="", image=""}[5s])
+    ) by (pod)
     *
     on (pod) group_left kube_pod_labels{namespace="default"}
   )


### PR DESCRIPTION
When exposing container arguments, there may be the need to trigger special behavior
depending on the setup task mode ( create or delete ). Previously this was handled by
adding the mode to the container arguments. This now changes to be exposed as an
environment variable.

Signed-off-by: Brad Beam <brad.beam@carbonrelay.com>