### PR TITLE
feat: Add memory utilization query 

### DIFF
--- a/internal/template/function.go
+++ b/internal/template/function.go
@@ -17,7 +17,6 @@ limitations under the License.
 package template
 
 import (
-	"bytes"
 	"fmt"
 	"strconv"
 	"strings"
@@ -35,10 +34,11 @@ func FuncMap() template.FuncMap {
 	delete(f, "expandenv")
 
 	extra := template.FuncMap{
-		"duration":         duration,
-		"percent":          percent,
-		"resourceRequests": resourceRequests,
-		"cpuUtilization":   cpuUtilization,
+		"duration":          duration,
+		"percent":           percent,
+		"resourceRequests":  resourceRequests,
+		"cpuUtilization":    cpuUtilization,
+		"memoryUtilization": memoryUtilization,
 	}
 
 	for k, v := range extra {
@@ -83,59 +83,4 @@ func resourceRequests(pods corev1.PodList, weights string) (float64, error) {
 		}
 	}
 	return totalResources, nil
-}
-
-func cpuUtilization(data MetricData, labelArgs ...string) (string, error) {
-
-	cpuUtilizationQueryTemplate := `
-scalar(
-  sum(
-    sum(
-      increase(container_cpu_usage_seconds_total{container="", image=""}[{{ .Range }}])
-    ) by (pod)
-    *
-    on (pod) group_left kube_pod_labels{{ .Labels }}
-  )
-  /
-  sum(
-    sum_over_time(kube_pod_container_resource_limits_cpu_cores[{{ .Range }}:1s])
-    *
-    on (pod) group_left kube_pod_labels{{ .Labels }}
-  )
-)`
-
-	tmpl := template.Must(template.New("query").Parse(cpuUtilizationQueryTemplate))
-
-	var labels []string
-	for _, label := range strings.Split(strings.Join(labelArgs, ","), ",") {
-		if label == "" {
-			continue
-		}
-
-		kvpair := strings.Split(label, "=")
-		if len(kvpair) != 2 {
-			return "", fmt.Errorf("invalid label for `cpuUtilization`, expected key=value, got: %s", label)
-		}
-
-		labels = append(labels, fmt.Sprintf("label_%s=\"%s\"", kvpair[0], kvpair[1]))
-	}
-
-	if len(labels) == 0 {
-		labels = append(labels, fmt.Sprintf("namespace=\"%s\"", data.Trial.Namespace))
-	}
-
-	input := struct {
-		MetricData
-		Labels string
-	}{
-		data,
-		fmt.Sprintf("{%s}", strings.Join(labels, ",")),
-	}
-
-	var output bytes.Buffer
-	if err := tmpl.Execute(&output, input); err != nil {
-		return "", err
-	}
-
-	return output.String(), nil
 }

--- a/internal/template/template_test.go
+++ b/internal/template/template_test.go
@@ -214,35 +214,43 @@ func TestEngine_RenderMetricQueries(t *testing.T) {
 var (
 	expectedCPUUtilizationQueryWithParams = `
 scalar(
-  sum(
-    sum(
-      increase(container_cpu_usage_seconds_total{container="", image=""}[5s])
-    ) by (pod)
-    *
-    on (pod) group_left kube_pod_labels{label_component="bob",label_component="tom"}
-  )
-  /
-  sum(
-    sum_over_time(kube_pod_container_resource_limits_cpu_cores[5s:1s])
-    *
-    on (pod) group_left kube_pod_labels{label_component="bob",label_component="tom"}
-  )
+  round(
+    (
+      sum(
+        sum(
+          increase(container_cpu_usage_seconds_total{container="", image=""}[5s])
+        ) by (pod)
+        *
+        on (pod) group_left kube_pod_labels{label_component="bob",label_component="tom"}
+      )
+      /
+      sum(
+        sum_over_time(kube_pod_container_resource_limits_cpu_cores[5s:1s])
+        *
+        on (pod) group_left kube_pod_labels{label_component="bob",label_component="tom"}
+      )
+    )
+  * 100, 0.0001)
 )`
 
 	expectedCPUUtilizationQueryWithoutParams = `
 scalar(
-  sum(
-    sum(
-      increase(container_cpu_usage_seconds_total{container="", image=""}[5s])
-    ) by (pod)
-    *
-    on (pod) group_left kube_pod_labels{namespace="default"}
-  )
-  /
-  sum(
-    sum_over_time(kube_pod_container_resource_limits_cpu_cores[5s:1s])
-    *
-    on (pod) group_left kube_pod_labels{namespace="default"}
-  )
+  round(
+    (
+      sum(
+        sum(
+          increase(container_cpu_usage_seconds_total{container="", image=""}[5s])
+        ) by (pod)
+        *
+        on (pod) group_left kube_pod_labels{namespace="default"}
+      )
+      /
+      sum(
+        sum_over_time(kube_pod_container_resource_limits_cpu_cores[5s:1s])
+        *
+        on (pod) group_left kube_pod_labels{namespace="default"}
+      )
+    )
+  * 100, 0.0001)
 )`
 )

--- a/internal/template/utilization_functions.go
+++ b/internal/template/utilization_functions.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2020 GramLabs, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"text/template"
+)
+
+func cpuUtilization(data MetricData, labelArgs ...string) (string, error) {
+
+	cpuUtilizationQueryTemplate := `
+scalar(
+  sum(
+    sum(
+      increase(container_cpu_usage_seconds_total{container="", image=""}[{{ .Range }}])
+    ) by (pod)
+    *
+    on (pod) group_left kube_pod_labels{{ .Labels }}
+  )
+  /
+  sum(
+    sum_over_time(kube_pod_container_resource_limits_cpu_cores[{{ .Range }}:1s])
+    *
+    on (pod) group_left kube_pod_labels{{ .Labels }}
+  )
+)`
+
+	return renderUtilization(cpuUtilizationQueryTemplate, data, labelArgs...)
+}
+
+func memoryUtilization(data MetricData, labelArgs ...string) (string, error) {
+	memoryUtilizationQueryTemplate := `
+scalar(
+  avg(
+    sum(
+      container_memory_max_usage_bytes
+    ) by (pod)
+    *
+    on (pod) group_left kube_pod_labels{{ .Labels }}
+    /
+    sum(
+      kube_pod_container_resource_limits_memory_bytes
+    ) by (pod)
+  )
+)`
+
+	return renderUtilization(memoryUtilizationQueryTemplate, data, labelArgs...)
+}
+
+func renderUtilization(query string, data MetricData, labelArgs ...string) (string, error) {
+	tmpl := template.Must(template.New("query").Parse(query))
+
+	var labels []string
+	for _, label := range strings.Split(strings.Join(labelArgs, ","), ",") {
+		if label == "" {
+			continue
+		}
+
+		kvpair := strings.Split(label, "=")
+		if len(kvpair) != 2 {
+			return "", fmt.Errorf("invalid label for `cpuUtilization`, expected key=value, got: %s", label)
+		}
+
+		labels = append(labels, fmt.Sprintf("label_%s=\"%s\"", kvpair[0], kvpair[1]))
+	}
+
+	if len(labels) == 0 {
+		labels = append(labels, fmt.Sprintf("namespace=\"%s\"", data.Trial.Namespace))
+	}
+
+	input := struct {
+		MetricData
+		Labels string
+	}{
+		data,
+		fmt.Sprintf("{%s}", strings.Join(labels, ",")),
+	}
+
+	var output bytes.Buffer
+	if err := tmpl.Execute(&output, input); err != nil {
+		return "", err
+	}
+
+	return output.String(), nil
+}


### PR DESCRIPTION
`feat: Add memory utilization query`
This also includes a slight refactor of the utilization queries since there
is a fair amount of shared rendering between them.

`refactor: Change format of utilization value`
This changes the utilization to be a percentage based value and rounds the
digits to 4 decimal places.

Signed-off-by: Brad Beam <brad.beam@carbonrelay.com>
