### PR TITLE
fix: Correct kube-state-metrics address

### DIFF
--- a/config/docker-entrypoint.sh
+++ b/config/docker-entrypoint.sh
@@ -16,9 +16,17 @@ case "$1" in
     # Generate prometheus manifests
     shift && cd /workspace/prometheus
 
+    namePrefix="redsky-"
     if [ -n "$NAMESPACE" ]; then
-      kustomize edit set nameprefix redsky-$NAMESPACE-
+      namePrefix="redsky-$NAMESPACE-"
     fi
+
+    kustomize edit set nameprefix $namePrefix
+
+    # Update static scrape target
+    ## janky busybox sed
+    sed -i -re 's/- (kube-state-metrics:8080)/- '$namePrefix'\1/' prometheus-server-configmap.yaml
+
   ;;
 esac
 

--- a/config/prometheus/kustomization.yaml
+++ b/config/prometheus/kustomization.yaml
@@ -3,8 +3,6 @@ kind: Kustomization
 
 namespace: default
 
-namePrefix: redsky-
-
 resources:
 - ./kube-state-metrics-deployment.yaml
 - ./kube-state-metrics-rbac.yaml

--- a/config/prometheus/prometheus-server-configmap.yaml
+++ b/config/prometheus/prometheus-server-configmap.yaml
@@ -53,7 +53,7 @@ data:
       scheme: http
       static_configs:
       - targets:
-        - redsky-kube-state-metrics:8080
+        - kube-state-metrics:8080
 
   recording_rules.yml: |
     {}


### PR DESCRIPTION
With #168 and the introduction of the redsky-namespace prefix, we broke the scraping
of kube-state-metrics. This corrects that.

Signed-off-by: Brad Beam <brad.beam@carbonrelay.com>