### PR TITLE
feat: Add support for helmRepository

### DIFF
--- a/api/v1alpha1/trial_types.go
+++ b/api/v1alpha1/trial_types.go
@@ -123,6 +123,8 @@ type SetupTask struct {
 	HelmValues []HelmValue `json:"helmValues,omitempty"`
 	// The Helm values, ignored unless helmChart is also set
 	HelmValuesFrom []HelmValuesFromSource `json:"helmValuesFrom,omitempty"`
+	// The Helm repository to fetch the chart from
+	HelmRepository string `json:"helmRepository,omitempty"`
 }
 
 // PatchOperation represents a patch used to prepare the cluster for a trial run, includes the evaluated

--- a/api/v1alpha1/zz_generated.conversion.go
+++ b/api/v1alpha1/zz_generated.conversion.go
@@ -1102,6 +1102,7 @@ func autoConvert_v1alpha1_SetupTask_To_v1beta1_SetupTask(in *SetupTask, out *v1b
 	} else {
 		out.HelmValuesFrom = nil
 	}
+	out.HelmRepository = in.HelmRepository
 	return nil
 }
 
@@ -1142,6 +1143,7 @@ func autoConvert_v1beta1_SetupTask_To_v1alpha1_SetupTask(in *v1beta1.SetupTask, 
 	} else {
 		out.HelmValuesFrom = nil
 	}
+	out.HelmRepository = in.HelmRepository
 	return nil
 }
 

--- a/api/v1beta1/trial_types.go
+++ b/api/v1beta1/trial_types.go
@@ -123,6 +123,8 @@ type SetupTask struct {
 	HelmValues []HelmValue `json:"helmValues,omitempty"`
 	// The Helm values, ignored unless helmChart is also set
 	HelmValuesFrom []HelmValuesFromSource `json:"helmValuesFrom,omitempty"`
+	// The Helm repository to fetch the chart from
+	HelmRepository string `json:"helmRepository,omitempty"`
 }
 
 // PatchOperation represents a patch used to prepare the cluster for a trial run, includes the evaluated

--- a/config/crd/bases/redskyops.dev_experiments.yaml
+++ b/config/crd/bases/redskyops.dev_experiments.yaml
@@ -512,6 +512,8 @@ spec:
                               type: string
                             helmChartVersion:
                               type: string
+                            helmRepository:
+                              type: string
                             helmValues:
                               type: array
                               items:
@@ -6863,6 +6865,8 @@ spec:
                             helmChart:
                               type: string
                             helmChartVersion:
+                              type: string
+                            helmRepository:
                               type: string
                             helmValues:
                               type: array

--- a/config/crd/bases/redskyops.dev_trials.yaml
+++ b/config/crd/bases/redskyops.dev_trials.yaml
@@ -296,6 +296,8 @@ spec:
                       type: string
                     helmChartVersion:
                       type: string
+                    helmRepository:
+                      type: string
                     helmValues:
                       type: array
                       items:
@@ -6455,6 +6457,8 @@ spec:
                     helmChart:
                       type: string
                     helmChartVersion:
+                      type: string
+                    helmRepository:
                       type: string
                     helmValues:
                       type: array

--- a/docs/api/v1alpha1/trial.md
+++ b/docs/api/v1alpha1/trial.md
@@ -131,6 +131,7 @@ SetupTask represents the configuration necessary to apply application state to t
 | `helmChartVersion` | The Helm chart version, empty means use the latest | _string_ | false |
 | `helmValues` | The Helm values to set, ignored unless helmChart is also set | _[][HelmValue](#helmvalue)_ | false |
 | `helmValuesFrom` | The Helm values, ignored unless helmChart is also set | _[][HelmValuesFromSource](#helmvaluesfromsource)_ | false |
+| `helmRepository` | The Helm repository to fetch the chart from | _string_ | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/docs/api/v1beta1/trial.md
+++ b/docs/api/v1beta1/trial.md
@@ -131,6 +131,7 @@ SetupTask represents the configuration necessary to apply application state to t
 | `helmChartVersion` | The Helm chart version, empty means use the latest | _string_ | false |
 | `helmValues` | The Helm values to set, ignored unless helmChart is also set | _[][HelmValue](#helmvalue)_ | false |
 | `helmValuesFrom` | The Helm values, ignored unless helmChart is also set | _[][HelmValuesFromSource](#helmvaluesfromsource)_ | false |
+| `helmRepository` | The Helm repository to fetch the chart from | _string_ | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/internal/setup/job.go
+++ b/internal/setup/job.go
@@ -190,11 +190,16 @@ func NewJob(t *redskyv1beta1.Trial, mode string) (*batchv1.Job, error) {
 				}
 			}
 
+			if task.HelmRepository != "" {
+				helmConfig.Repo = task.HelmRepository
+			}
+
 			// Record the base64 encoded YAML representation in the environment
 			b, err := yaml.Marshal(helmConfig)
 			if err != nil {
 				return nil, err
 			}
+
 			c.Env = append(c.Env, corev1.EnvVar{Name: "HELM_CONFIG", Value: base64.StdEncoding.EncodeToString(b)})
 		}
 
@@ -222,6 +227,7 @@ type helmGeneratorConfig struct {
 	ReleaseName       string               `json:"releaseName"`
 	Chart             string               `json:"chart"`
 	Version           string               `json:"version"`
+	Repo              string               `json:"repo,omitempty"`
 	Values            []helmGeneratorValue `json:"values"`
 }
 


### PR DESCRIPTION
This introduces the ability to specify a helm repository when deploying
a helm chart.

Signed-off-by: Brad Beam <brad.beam@carbonrelay.com>