### PR TITLE
chore: Update kind

### DIFF
--- a/.github/workflows/kubematrix.yaml
+++ b/.github/workflows/kubematrix.yaml
@@ -12,21 +12,19 @@ jobs:
         # Version listings can be found here:
         # https://github.com/kubernetes-sigs/kind/releases
         node:
-          - v1.18.2
-          - v1.17.5
-          - v1.16.9
-          - v1.15.11
+          - v1.19.1
+          - v1.18.8
+          - v1.17.11
+          - v1.16.15
+          - v1.15.12
           - v1.14.10
-          #- v1.13.12
-          #- v1.12.10
-          #- v1.11.10
     steps:
       - name: Check out code
         uses: actions/checkout@v2
       - name: KinD (Kubernetes in Docker) Initialization
-        uses: helm/kind-action@v1.0.0-rc.1
+        uses: helm/kind-action@v1.0.0
         with:
-          version: v0.8.1
+          version: v0.9.0
           node_image: kindest/node:${{ matrix.node }}
       - name: Install Kustomize
         run: |
@@ -39,7 +37,7 @@ jobs:
           checkName: "Build and Deploy"
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           intervalSeconds: 30
-          timeoutSeconds: 900
+          timeoutSeconds: 1800
       - name: Fail early if we don't have a successful build
         if: steps.wait-for-build.outputs.conclusion != 'success'
         run: |

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -54,9 +54,9 @@ jobs:
         run: git fetch --prune --unshallow
       # Launch KinD early so we can do other things while the control plane converges
       - name: KinD (Kubernetes in Docker) Initialization
-        uses: helm/kind-action@v1.0.0-rc.1
+        uses: helm/kind-action@v1.0.0
         with:
-          version: v0.8.1
+          version: v0.9.0
           wait: 0s
       - name: Set up Google Cloud Platform
         if: github.event.pull_request.head.repo.fork == false


### PR DESCRIPTION
This updates the KinD version we are using and brings in updates to the node images.
We now test 1.19.

Additionally, we're updating the timeout for waiting on the master workflow to complete
since there seem to be longer delays in getting minikube up and stabilized.

Signed-off-by: Brad Beam <brad.beam@carbonrelay.com>