### PR TITLE
feat: Add template functions for cpu and memory requests

### DIFF
--- a/internal/template/function.go
+++ b/internal/template/function.go
@@ -39,6 +39,8 @@ func FuncMap() template.FuncMap {
 		"resourceRequests":  resourceRequests,
 		"cpuUtilization":    cpuUtilization,
 		"memoryUtilization": memoryUtilization,
+		"cpuRequests":       cpuRequests,
+		"memoryRequests":    memoryRequests,
 	}
 
 	for k, v := range extra {

--- a/internal/template/template_test.go
+++ b/internal/template/template_test.go
@@ -371,20 +371,16 @@ scalar(
 	expectedMemoryRequestsQueryWithParams = `
 scalar(
   sum(
-    avg_over_time(kube_pod_container_resource_requests_memory_bytes[5s:1s])
+    avg_over_time(kube_pod_container_resource_requests_memory_bytes[5s])
     *
     on (pod) group_left kube_pod_labels{label_component="bob",label_component="tom"}
   )
-  /
-  1024
-  /
-  1024
 )`
 
 	expectedCPURequestsQueryWithParams = `
 scalar(
   sum(
-    avg_over_time(kube_pod_container_resource_requests_cpu_cores[5s:1s])
+    avg_over_time(kube_pod_container_resource_requests_cpu_cores[5s])
     *
     on (pod) group_left kube_pod_labels{label_component="bob",label_component="tom"}
   )

--- a/internal/template/template_test.go
+++ b/internal/template/template_test.go
@@ -237,6 +237,44 @@ func TestEngine_RenderMetricQueries(t *testing.T) {
 			},
 			expectedQuery: expectedMemoryUtilizationQueryWithoutParams,
 		},
+
+		{
+			desc: "function cpuRequests with parameters",
+			metric: redskyv1beta1.Metric{
+				Name:  "testMetric",
+				Query: `{{cpuRequests . "component=bob,component=tom"}}`,
+				Type:  redskyv1beta1.MetricLocal,
+			},
+			trial: redskyv1beta1.Trial{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Status: redskyv1beta1.TrialStatus{
+					StartTime:      &metav1.Time{Time: now.Add(-5 * time.Second)},
+					CompletionTime: &now,
+				},
+			},
+			expectedQuery: expectedCPURequestsQueryWithParams,
+		},
+
+		{
+			desc: "function memoryRequests with parameters",
+			metric: redskyv1beta1.Metric{
+				Name:  "testMetric",
+				Query: `{{memoryRequests . "component=bob,component=tom"}}`,
+				Type:  redskyv1beta1.MetricLocal,
+			},
+			trial: redskyv1beta1.Trial{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Status: redskyv1beta1.TrialStatus{
+					StartTime:      &metav1.Time{Time: now.Add(-5 * time.Second)},
+					CompletionTime: &now,
+				},
+			},
+			expectedQuery: expectedMemoryRequestsQueryWithParams,
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.desc, func(t *testing.T) {
@@ -263,7 +301,7 @@ scalar(
       )
       /
       sum(
-        sum_over_time(kube_pod_container_resource_limits_cpu_cores[5s:1s])
+        sum_over_time(kube_pod_container_resource_requests_cpu_cores[5s:1s])
         *
         on (pod) group_left kube_pod_labels{label_component="bob",label_component="tom"}
       )
@@ -284,7 +322,7 @@ scalar(
       )
       /
       sum(
-        sum_over_time(kube_pod_container_resource_limits_cpu_cores[5s:1s])
+        sum_over_time(kube_pod_container_resource_requests_cpu_cores[5s:1s])
         *
         on (pod) group_left kube_pod_labels{namespace="default"}
       )
@@ -304,7 +342,7 @@ scalar(
         on (pod) group_left kube_pod_labels{label_component="bob",label_component="tom"}
         /
         sum(
-          kube_pod_container_resource_limits_memory_bytes
+          kube_pod_container_resource_requests_memory_bytes
         ) by (pod)
       )
     )
@@ -323,10 +361,32 @@ scalar(
         on (pod) group_left kube_pod_labels{namespace="default"}
         /
         sum(
-          kube_pod_container_resource_limits_memory_bytes
+          kube_pod_container_resource_requests_memory_bytes
         ) by (pod)
       )
     )
   * 100, 0.0001)
+)`
+
+	expectedMemoryRequestsQueryWithParams = `
+scalar(
+  sum(
+    avg_over_time(kube_pod_container_resource_requests_memory_bytes[5s:1s])
+    *
+    on (pod) group_left kube_pod_labels{label_component="bob",label_component="tom"}
+  )
+  /
+  1024
+  /
+  1024
+)`
+
+	expectedCPURequestsQueryWithParams = `
+scalar(
+  sum(
+    avg_over_time(kube_pod_container_resource_requests_cpu_cores[5s:1s])
+    *
+    on (pod) group_left kube_pod_labels{label_component="bob",label_component="tom"}
+  )
 )`
 )

--- a/internal/template/utilization_functions.go
+++ b/internal/template/utilization_functions.go
@@ -75,7 +75,7 @@ func cpuRequests(data MetricData, labelArgs ...string) (string, error) {
 	cpuResourcesQueryTemplate := `
 scalar(
   sum(
-    sum_over_time(kube_pod_container_resource_requests_cpu_cores[{{ .Range }}:1s])
+    avg_over_time(kube_pod_container_resource_requests_cpu_cores[{{ .Range }}])
     *
     on (pod) group_left kube_pod_labels{{ .Labels }}
   )
@@ -85,18 +85,13 @@ scalar(
 }
 
 func memoryRequests(data MetricData, labelArgs ...string) (string, error) {
-	// Returns a value in MB
 	memoryResourcesQueryTemplate := `
 scalar(
   sum(
-    avg_over_time(kube_pod_container_resource_requests_memory_bytes[{{ .Range }}:1s])
+    avg_over_time(kube_pod_container_resource_requests_memory_bytes[{{ .Range }}])
     *
     on (pod) group_left kube_pod_labels{{ .Labels }}
   )
-  /
-  1024
-  /
-  1024
 )`
 
 	return renderUtilization(memoryResourcesQueryTemplate, data, labelArgs...)


### PR DESCRIPTION
This introduces two new template functions, `cpuRequests` and `memoryRequests`, so we can calculate resource usage for the duration of the trial.