### PR TITLE
fix: Always include trial namespace in utilization functions

### DIFF
--- a/internal/template/template_test.go
+++ b/internal/template/template_test.go
@@ -363,13 +363,13 @@ scalar(
           increase(container_cpu_usage_seconds_total{container="", image=""}[5s])
         ) by (pod)
         *
-        on (pod) group_left kube_pod_labels{label_component="bob",label_component="tom"}
+        on (pod) group_left kube_pod_labels{namespace="default",label_component="bob",label_component="tom"}
       )
       /
       sum(
         sum_over_time(kube_pod_container_resource_requests_cpu_cores[5s:1s])
         *
-        on (pod) group_left kube_pod_labels{label_component="bob",label_component="tom"}
+        on (pod) group_left kube_pod_labels{namespace="default",label_component="bob",label_component="tom"}
       )
     )
   * 100, 0.0001)
@@ -405,7 +405,7 @@ scalar(
           container_memory_max_usage_bytes
         ) by (pod)
         *
-        on (pod) group_left kube_pod_labels{label_component="bob",label_component="tom"}
+        on (pod) group_left kube_pod_labels{namespace="default",label_component="bob",label_component="tom"}
         /
         sum(
           kube_pod_container_resource_requests_memory_bytes
@@ -439,7 +439,7 @@ scalar(
   sum(
     avg_over_time(kube_pod_container_resource_requests_memory_bytes[5s])
     *
-    on (pod) group_left kube_pod_labels{label_component="bob",label_component="tom"}
+    on (pod) group_left kube_pod_labels{namespace="default",label_component="bob",label_component="tom"}
   )
 )`
 
@@ -448,7 +448,7 @@ scalar(
   sum(
     avg_over_time(kube_pod_container_resource_requests_cpu_cores[5s])
     *
-    on (pod) group_left kube_pod_labels{label_component="bob",label_component="tom"}
+    on (pod) group_left kube_pod_labels{namespace="default",label_component="bob",label_component="tom"}
   )
 )`
 )

--- a/internal/template/utilization_functions.go
+++ b/internal/template/utilization_functions.go
@@ -100,7 +100,9 @@ scalar(
 func renderUtilization(query string, data MetricData, labelArgs ...string) (string, error) {
 	tmpl := template.Must(template.New("query").Parse(query))
 
-	var labels []string
+	// Always include the trial namespace
+	labels := []string{fmt.Sprintf("namespace=\"%s\"", data.Trial.Namespace)}
+
 	for _, label := range strings.Split(strings.Join(labelArgs, ","), ",") {
 		if label == "" {
 			continue
@@ -112,10 +114,6 @@ func renderUtilization(query string, data MetricData, labelArgs ...string) (stri
 		}
 
 		labels = append(labels, fmt.Sprintf("label_%s=\"%s\"", kvpair[0], kvpair[1]))
-	}
-
-	if len(labels) == 0 {
-		labels = append(labels, fmt.Sprintf("namespace=\"%s\"", data.Trial.Namespace))
 	}
 
 	input := struct {


### PR DESCRIPTION
This addresses an issue where we could include all pods in a cluster with
a matching label set instead of restricting it to only the trial namespace.

Signed-off-by: Brad Beam <brad.beam@carbonrelay.com>