### PR TITLE
Authorize cluster patch

### DIFF
--- a/redskyctl/internal/commands/authorize_cluster/authorize_cluster.go
+++ b/redskyctl/internal/commands/authorize_cluster/authorize_cluster.go
@@ -130,15 +130,14 @@ func (o *Options) patchDeployment(ctx context.Context, secretName, secretHash st
 // patchFormat is used to patch the deployment with the secret information
 const patchFormat = `
 spec:
-  metadata:
-    annotations:
-      "redskyops.dev/secretHash": "%s"
   template:
+    metadata:
+      annotations:
+        "redskyops.dev/secretHash": "%s"
     spec:
       containers:
       - name: manager
         envFrom:
         - secretRef:
             name: "%s"
-            optional: false
 `


### PR DESCRIPTION
The main bit of this change is to move the metadata down into the pod template where it will actually trigger a re-deploy when the hash changes (also, explicitly setting `optional: false` is unnecessary).

Secondary concern was the ordering of `%s` placeholders, so I switched to a text template instead of a `Sprintf`.