### PR TITLE
Explicit pull policy

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -85,7 +85,7 @@ jobs:
             echo "SETUPTOOLS_IMG=gcr.io/redskyops/setuptools:${TAG}" >> $GITHUB_ENV
             gcloud --quiet auth configure-docker
           fi
-          echo "PULL_POLICY=Always" >> $GITHUB_ENV
+          echo "PULL_POLICY=" >> $GITHUB_ENV
       - name: Build controller
         run: |
           make docker-build-ci

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -54,6 +54,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gobuildcache-
       - name: Set up Google Cloud Platform
+        # FIXME: This needs to get upgraded to fix the build warnings
         uses: GoogleCloudPlatform/github-actions/setup-gcloud@0.1.3
         with:
           service_account_email: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
@@ -79,7 +80,7 @@ jobs:
             printenv DOCKER_PASSWORD | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
           else
             TAG="sha-$(git rev-parse --short HEAD)"
-            echo "DOCKER_TAG=canary"  >> $GITHUB_ENV # TODO This should change to "latest" after the 1.6.0 release
+            echo "DOCKER_TAG=edge"  >> $GITHUB_ENV
             echo "IMG=gcr.io/redskyops/redskyops-controller:${TAG}" >> $GITHUB_ENV
             echo "REDSKYCTL_IMG=gcr.io/redskyops/redskyctl:${TAG}" >> $GITHUB_ENV
             echo "SETUPTOOLS_IMG=gcr.io/redskyops/setuptools:${TAG}" >> $GITHUB_ENV

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -71,7 +71,7 @@ jobs:
           echo "IMG=gcr.io/redskyops/redskyops-controller:${TAG}" >> $GITHUB_ENV
           echo "REDSKYCTL_IMG=gcr.io/redskyops/redskyctl:${TAG}" >> $GITHUB_ENV
           echo "SETUPTOOLS_IMG=gcr.io/redskyops/setuptools:${TAG}" >> $GITHUB_ENV
-          echo "PULL_POLICY=Always" >> $GITHUB_ENV
+          echo "PULL_POLICY=" >> $GITHUB_ENV
           echo "DOCKER_TAG=pr-${{ github.event.number }}" >> $GITHUB_ENV
       - name: Cache Go Modules
         uses: actions/cache@v1

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 IMG ?= controller:latest
 REDSKYCTL_IMG ?= redskyctl:latest
 SETUPTOOLS_IMG ?= setuptools:latest
-PULL_POLICY ?= IfNotPresent
+PULL_POLICY ?= Never
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true,maxDescLen=0"
 

--- a/redskyctl/internal/commands/initialize/generator.go
+++ b/redskyctl/internal/commands/initialize/generator.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"sync"
 
+	"github.com/redskyops/redskyops-controller/internal/setup"
 	"github.com/redskyops/redskyops-controller/redskyctl/internal/commander"
 	"github.com/redskyops/redskyops-controller/redskyctl/internal/commands/authorize_cluster"
 	"github.com/redskyops/redskyops-controller/redskyctl/internal/commands/grant_permissions"
@@ -158,6 +159,7 @@ func (o *GeneratorOptions) generateApplication() (io.Reader, error) {
 		kustomize.WithInstall(),
 		kustomize.WithNamespace(ctrl.Namespace),
 		kustomize.WithImage(o.Image),
+		kustomize.WithImagePullPolicy(setup.ImagePullPolicy),
 		kustomize.WithAPI(apiEnabled),
 	)
 	if err != nil {

--- a/redskyctl/internal/kustomize/options.go
+++ b/redskyctl/internal/kustomize/options.go
@@ -207,3 +207,28 @@ spec:
 		return nil
 	}
 }
+
+func WithImagePullPolicy(pullPolicy string) Option {
+	return func(k *Kustomize) error {
+		controllerPullPolicyPatch := []byte(`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redsky-controller-manager
+  namespace: redsky-system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        imagePullPolicy: ` + pullPolicy)
+
+		if err := k.fs.WriteFile(filepath.Join(k.Base, "pull_policy_patch.yaml"), controllerPullPolicyPatch); err != nil {
+			return err
+		}
+
+		k.kustomize.PatchesStrategicMerge = append(k.kustomize.PatchesStrategicMerge, "pull_policy_patch.yaml")
+
+		return nil
+	}
+}


### PR DESCRIPTION
This brings back the explicit image pull policy from the build environment. This improves support for running the controller locally.

The pull policies are different from before: now we explicitly unset the pull policy for CI builds (which will result in `IfNotPresent` under normal circumstances). For local builds, the pull policy is `Never` because pulling `controller:latest` doesn't make any sense.

NOTE: there is only one pull policy for _both_ images (setup tools and controller). This isn't necessarily ideal, but I think it's good enough for now.

I also changed the Docker `canary` tag to `edge` (which I picked up from the official Docker GitHub Action).