### PR TITLE
Refactor experiment reader

### DIFF
--- a/redskyctl/internal/commander/commander.go
+++ b/redskyctl/internal/commander/commander.go
@@ -52,9 +52,9 @@ type IOStreams struct {
 	ErrOut io.Writer
 }
 
-// FileReader returns a read closer for the specified filename. If the filename is logically
-// empty (i.e. "" or "-"), the input stream is returned.
-func (s *IOStreams) FileReader(filename string) (io.ReadCloser, error) {
+// OpenFile returns a read closer for the specified filename. If the filename is logically
+// empty (i.e. "-"), the input stream is returned.
+func (s *IOStreams) OpenFile(filename string) (io.ReadCloser, error) {
 	if filename == "-" {
 		return ioutil.NopCloser(s.In), nil
 	}

--- a/redskyctl/internal/commander/commander.go
+++ b/redskyctl/internal/commander/commander.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"os/exec"
 
@@ -49,6 +50,15 @@ type IOStreams struct {
 	Out io.Writer
 	// ErrOut is used to access the standard error output stream (or it's override)
 	ErrOut io.Writer
+}
+
+// FileReader returns a read closer for the specified filename. If the filename is logically
+// empty (i.e. "" or "-"), the input stream is returned.
+func (s *IOStreams) FileReader(filename string) (io.ReadCloser, error) {
+	if filename == "-" {
+		return ioutil.NopCloser(s.In), nil
+	}
+	return os.Open(filename)
 }
 
 // SetStreams updates the streams using the supplied command

--- a/redskyctl/internal/commander/reader.go
+++ b/redskyctl/internal/commander/reader.go
@@ -49,7 +49,7 @@ func NewResourceReader() *ResourceReader {
 	_ = redskyv1beta1.AddToScheme(rr.Scheme)
 	_ = redskyv1alpha1.AddToScheme(rr.Scheme)
 
-	// Allow single experiments to fulfil target an experiment list
+	// Allow single experiments to target an experiment list
 	_ = addExperimentListConversions(rr.Scheme)
 
 	return rr
@@ -104,11 +104,13 @@ func (r *ResourceReader) objectKind(obj runtime.Object) (schema.GroupVersionKind
 	if err != nil {
 		return schema.GroupVersionKind{}, err
 	}
+
 	gvk, ok := r.PreferredVersion.KindForGroupVersionKinds(gvks)
 	if !ok {
 		// Your code must supply a GroupVersioner to disambiguate this case
 		panic("read destination type is ambiguous in scheme")
 	}
+
 	return gvk, nil
 }
 
@@ -119,6 +121,7 @@ func (r *ResourceReader) decoder(mediaType string) (runtime.Decoder, error) {
 	if !ok {
 		return nil, fmt.Errorf("could not find serializer for %s", mediaType)
 	}
+
 	return cs.DecoderToVersion(info.Serializer, r.PreferredVersion), nil
 }
 
@@ -132,6 +135,7 @@ func mediaType(r io.ReadCloser) string {
 			mt = runtime.ContentTypeJSON
 		}
 	}
+
 	return mt
 }
 
@@ -145,6 +149,7 @@ func (onlyVersion) KindForGroupVersionKinds(kinds []schema.GroupVersionKind) (sc
 	if len(kinds) == 1 {
 		return kinds[0], true
 	}
+
 	return schema.GroupVersionKind{}, false
 }
 
@@ -167,5 +172,6 @@ func addExperimentListConversions(s *runtime.Scheme) error {
 	}); err != nil {
 		return err
 	}
+
 	return nil
 }

--- a/redskyctl/internal/commander/reader.go
+++ b/redskyctl/internal/commander/reader.go
@@ -1,0 +1,170 @@
+/*
+Copyright 2020 GramLabs, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package commander
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	redskyv1alpha1 "github.com/redskyops/redskyops-controller/api/v1alpha1"
+	redskyv1beta1 "github.com/redskyops/redskyops-controller/api/v1beta1"
+	"github.com/redskyops/redskyops-controller/internal/controller"
+	"k8s.io/apimachinery/pkg/conversion"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// ResourceReader helps properly decode Kubernetes resources on the CLI. It is meant to be a
+// lighter weight alternative to the cli-runtime resource.Builder.
+type ResourceReader struct {
+	Scheme           *runtime.Scheme
+	PreferredVersion runtime.GroupVersioner
+}
+
+// NewResourceReader returns a new resource reader for the supplied byte stream.
+func NewResourceReader() *ResourceReader {
+	rr := &ResourceReader{
+		Scheme:           runtime.NewScheme(),
+		PreferredVersion: OnlyVersion,
+	}
+
+	// Always add our types
+	_ = redskyv1beta1.AddToScheme(rr.Scheme)
+	_ = redskyv1alpha1.AddToScheme(rr.Scheme)
+
+	// Allow single experiments to fulfil target an experiment list
+	_ = addExperimentListConversions(rr.Scheme)
+
+	return rr
+}
+
+// ReadInto reads the
+func (r *ResourceReader) ReadInto(reader io.ReadCloser, target runtime.Object) error {
+	// Determine the GVK for the type we are supposed to be populating
+	gvk, err := r.objectKind(target)
+	if err != nil {
+		return err
+	}
+
+	mt := mediaType(reader)
+	decoder, err := r.decoder(mt)
+	if err != nil {
+		return err
+	}
+
+	// TODO For lists we should consider yaml.NewDocumentDecoder(reader) so we can read a stream
+
+	// Read in the raw bytes
+	defer func() { _ = reader.Close() }()
+	data, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return err
+	}
+
+	// Decode the raw data
+	obj, _, err := decoder.Decode(data, &gvk, target)
+	if err != nil {
+		return err
+	}
+
+	// If decode returned an object of a different type we should try to force the conversion
+	if obj != target {
+		if err := r.Scheme.Convert(obj, target, r.PreferredVersion); err != nil {
+			return err
+		}
+	}
+
+	// Fill in the default values for the target
+	target.GetObjectKind().SetGroupVersionKind(gvk)
+	r.Scheme.Default(target)
+
+	return nil
+}
+
+func (r *ResourceReader) objectKind(obj runtime.Object) (schema.GroupVersionKind, error) {
+	gvks, _, err := r.Scheme.ObjectKinds(obj)
+	if err != nil {
+		return schema.GroupVersionKind{}, err
+	}
+	gvk, ok := r.PreferredVersion.KindForGroupVersionKinds(gvks)
+	if !ok {
+		// Your code must supply a GroupVersioner to disambiguate this case
+		panic("read destination type is ambiguous in scheme")
+	}
+	return gvk, nil
+}
+
+func (r *ResourceReader) decoder(mediaType string) (runtime.Decoder, error) {
+	// Create the conversion serializer with our negotiation logic in it
+	cs := controller.NewConversionSerializer(r.Scheme)
+	info, ok := runtime.SerializerInfoForMediaType(cs.SupportedMediaTypes(), mediaType)
+	if !ok {
+		return nil, fmt.Errorf("could not find serializer for %s", mediaType)
+	}
+	return cs.DecoderToVersion(info.Serializer, r.PreferredVersion), nil
+}
+
+// mediaType returns the presumed media type for the supplied read closer.
+func mediaType(r io.ReadCloser) string {
+	// For now just assume YAML unless we got a JSON file
+	mt := runtime.ContentTypeYAML
+	if f, ok := r.(*os.File); ok {
+		switch filepath.Ext(f.Name()) {
+		case "json":
+			mt = runtime.ContentTypeJSON
+		}
+	}
+	return mt
+}
+
+// OnlyVersion is a group version that only resolves if there is a single possible kind
+var OnlyVersion runtime.GroupVersioner = onlyVersion{}
+
+type onlyVersion struct{}
+
+func (onlyVersion) Identifier() string { return "only" }
+func (onlyVersion) KindForGroupVersionKinds(kinds []schema.GroupVersionKind) (schema.GroupVersionKind, bool) {
+	if len(kinds) == 1 {
+		return kinds[0], true
+	}
+	return schema.GroupVersionKind{}, false
+}
+
+// addExperimentListConversions adds conversions from a single experiment to a list of experiments; for example
+// when a command can handle a list but the user only supplies a single experiment.
+func addExperimentListConversions(s *runtime.Scheme) error {
+	// Convert from a single experiment to a list of experiments
+	if err := s.AddConversionFunc((*redskyv1beta1.Experiment)(nil), (*redskyv1beta1.ExperimentList)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		b.(*redskyv1beta1.ExperimentList).Items = []redskyv1beta1.Experiment{*a.(*redskyv1beta1.Experiment)}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	// Convert from a single v1alpha1 experiment to a list of experiments
+	if err := s.AddConversionFunc((*redskyv1alpha1.Experiment)(nil), (*redskyv1beta1.ExperimentList)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		l := b.(*redskyv1beta1.ExperimentList)
+		l.Items = make([]redskyv1beta1.Experiment, 1)
+		return scope.Convert(a, &l.Items[0], scope.Flags())
+	}); err != nil {
+		return err
+	}
+	return nil
+}

--- a/redskyctl/internal/commander/reader.go
+++ b/redskyctl/internal/commander/reader.go
@@ -55,7 +55,8 @@ func NewResourceReader() *ResourceReader {
 	return rr
 }
 
-// ReadInto reads the
+// ReadInto decodes the supplied byte stream into the target runtime object. The default values
+// and type information of the target object will be populated.
 func (r *ResourceReader) ReadInto(reader io.ReadCloser, target runtime.Object) error {
 	// Determine the GVK for the type we are supposed to be populating
 	gvk, err := r.objectKind(target)

--- a/redskyctl/internal/commands/check/experiment.go
+++ b/redskyctl/internal/commands/check/experiment.go
@@ -60,7 +60,7 @@ func NewExperimentCommand(o *ExperimentOptions) *cobra.Command {
 }
 
 func (o *ExperimentOptions) checkExperiment() error {
-	r, err := o.FileReader(o.Filename)
+	r, err := o.IOStreams.OpenFile(o.Filename)
 	if err != nil {
 		return err
 	}

--- a/redskyctl/internal/commands/generate/generate.go
+++ b/redskyctl/internal/commands/generate/generate.go
@@ -17,21 +17,11 @@ limitations under the License.
 package generate
 
 import (
-	"fmt"
-	"io"
-	"io/ioutil"
-	"path/filepath"
-
-	redskyv1alpha1 "github.com/redskyops/redskyops-controller/api/v1alpha1"
-	redskyv1beta1 "github.com/redskyops/redskyops-controller/api/v1beta1"
-	"github.com/redskyops/redskyops-controller/internal/controller"
 	"github.com/redskyops/redskyops-controller/redskyctl/internal/commands/authorize_cluster"
 	"github.com/redskyops/redskyops-controller/redskyctl/internal/commands/grant_permissions"
 	"github.com/redskyops/redskyops-controller/redskyctl/internal/commands/initialize"
 	"github.com/redskyops/redskyops-go/pkg/config"
 	"github.com/spf13/cobra"
-	"k8s.io/apimachinery/pkg/conversion"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // Options includes the configuration for the subcommands
@@ -57,74 +47,4 @@ func NewCommand(o *Options) *cobra.Command {
 	cmd.AddCommand(initialize.NewGeneratorCommand(&initialize.GeneratorOptions{Config: o.Config}))
 
 	return cmd
-}
-
-// readExperiments unmarshals experiment data
-func readExperiments(filename string, defaultReader io.Reader, list *redskyv1beta1.ExperimentList) error {
-	if filename == "" {
-		return nil
-	}
-
-	// Read the file
-	var data []byte
-	var err error
-	if filename == "-" {
-		data, err = ioutil.ReadAll(defaultReader)
-	} else {
-		data, err = ioutil.ReadFile(filename)
-	}
-	if err != nil {
-		return err
-	}
-
-	// Create a decoder
-	scheme := runtime.NewScheme()
-	_ = redskyv1beta1.AddToScheme(scheme)
-	_ = redskyv1alpha1.AddToScheme(scheme)
-	_ = registerListConversions(scheme)
-	cs := controller.NewConversionSerializer(scheme)
-	mediaType := runtime.ContentTypeYAML
-	switch filepath.Ext(filename) {
-	case "json":
-		mediaType = runtime.ContentTypeJSON
-	}
-	info, ok := runtime.SerializerInfoForMediaType(cs.SupportedMediaTypes(), mediaType)
-	if !ok {
-		return fmt.Errorf("could not find serializer for %s", mediaType)
-	}
-	decoder := cs.DecoderToVersion(info.Serializer, runtime.InternalGroupVersioner)
-
-	// NOTE: This attempts to read an "ExperimentList", a stream of experiment YAML documents IS NOT an experiment list
-	// TODO If the mediaType is YAML we should use a `yaml.NewDocumentDecoder(...)` to get individual documents
-	gvk := redskyv1beta1.GroupVersion.WithKind("ExperimentList")
-	obj, _, err := decoder.Decode(data, &gvk, list)
-	if err != nil {
-		return err
-	}
-
-	// If the decoded object was not what we were looking, attempt to convert it
-	if obj != list {
-		return scheme.Convert(obj, list, nil)
-	}
-	return nil
-}
-
-func registerListConversions(s *runtime.Scheme) error {
-	// Convert from a single experiment to a list of experiments
-	if err := s.AddConversionFunc((*redskyv1beta1.Experiment)(nil), (*redskyv1beta1.ExperimentList)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		b.(*redskyv1beta1.ExperimentList).Items = []redskyv1beta1.Experiment{*a.(*redskyv1beta1.Experiment)}
-		return nil
-	}); err != nil {
-		return err
-	}
-
-	// Convert from a single v1alpha1 experiment to a list of experiments
-	if err := s.AddConversionFunc((*redskyv1alpha1.Experiment)(nil), (*redskyv1beta1.ExperimentList)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		l := b.(*redskyv1beta1.ExperimentList)
-		l.Items = make([]redskyv1beta1.Experiment, 1)
-		return scope.Convert(a, &l.Items[0], scope.Flags())
-	}); err != nil {
-		return err
-	}
-	return nil
 }

--- a/redskyctl/internal/commands/generate/generate_test.go
+++ b/redskyctl/internal/commands/generate/generate_test.go
@@ -103,10 +103,9 @@ func TestGenerate(t *testing.T) {
 			},
 		},
 		{
-			// TODO: I'd expect this to exit 1, but it doesn't?
 			desc:          "gen rbac (no args)",
 			args:          []string{"rbac"},
-			expectedError: false,
+			expectedError: true,
 		},
 		{
 			// TODO: Need to get an experiment that actually requires additional rbac

--- a/redskyctl/internal/commands/generate/rbac.go
+++ b/redskyctl/internal/commands/generate/rbac.go
@@ -80,6 +80,7 @@ func NewRBACCommand(o *RBACOptions) *cobra.Command {
 	cmd.Flags().BoolVar(&o.ClusterRoleBinding, "cluster-role-binding", o.ClusterRoleBinding, "When generating a cluster role, also generate a cluster role binding.")
 
 	_ = cmd.MarkFlagFilename("filename", "yml", "yaml")
+	_ = cmd.MarkFlagRequired("filename")
 
 	commander.SetKubePrinter(&o.Printer, cmd, nil)
 	commander.ExitOnError(cmd)
@@ -96,9 +97,15 @@ func (o *RBACOptions) Complete() {
 }
 
 func (o *RBACOptions) generate() error {
+	r, err := o.FileReader(o.Filename)
+	if err != nil {
+		return err
+	}
+
 	// Read the experiments
 	experimentList := &redskyv1beta1.ExperimentList{}
-	if err := readExperiments(o.Filename, o.In, experimentList); err != nil {
+	rr := commander.NewResourceReader()
+	if err := rr.ReadInto(r, experimentList); err != nil {
 		return err
 	}
 

--- a/redskyctl/internal/commands/generate/rbac.go
+++ b/redskyctl/internal/commands/generate/rbac.go
@@ -97,7 +97,7 @@ func (o *RBACOptions) Complete() {
 }
 
 func (o *RBACOptions) generate() error {
-	r, err := o.FileReader(o.Filename)
+	r, err := o.IOStreams.OpenFile(o.Filename)
 	if err != nil {
 		return err
 	}

--- a/redskyctl/internal/commands/generate/trial.go
+++ b/redskyctl/internal/commands/generate/trial.go
@@ -66,16 +66,18 @@ func NewTrialCommand(o *TrialOptions) *cobra.Command {
 }
 
 func (o *TrialOptions) generate() error {
-	// Read the experiments
-	experimentList := &redskyv1beta1.ExperimentList{}
-	if err := readExperiments(o.Filename, o.In, experimentList); err != nil {
+	r, err := o.FileReader(o.Filename)
+	if err != nil {
 		return err
 	}
-	if len(experimentList.Items) != 1 {
-		return fmt.Errorf("trial generation requires a single experiment as input")
+
+	// Read the experiment
+	exp := &redskyv1beta1.Experiment{}
+	rr := commander.NewResourceReader()
+	if err := rr.ReadInto(r, exp); err != nil {
+		return err
 	}
 
-	exp := &experimentList.Items[0]
 	if len(exp.Spec.Parameters) == 0 {
 		return fmt.Errorf("experiment must contain at least one parameter")
 	}

--- a/redskyctl/internal/commands/generate/trial.go
+++ b/redskyctl/internal/commands/generate/trial.go
@@ -66,7 +66,7 @@ func NewTrialCommand(o *TrialOptions) *cobra.Command {
 }
 
 func (o *TrialOptions) generate() error {
-	r, err := o.FileReader(o.Filename)
+	r, err := o.IOStreams.OpenFile(o.Filename)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
I know this conflicts with #138 but there are a couple of difference here. Most importantly, it's no longer "readExperiment" because nothing in the logic tied things to experiments. This fixes the awkward "I just want to read a single experiment" problem we had before because now you can just choose to read a single experiment instead of a list.

There is also a de-coupling of the file IO from the reading: e.g. the filename itself is no longer passed down (however we do try to recover the `os.File` to check for the filename extension). This makes it easier to pass in any reader without using "-" as a filename programmatically.

Finally any defaults registered with the scheme are applied and the target's type metadata is populated for verification.

My plan is to also use this for reading in the new "Application" type in #184.