### PR TITLE
Add the Push Gateway URL to the trial job

### DIFF
--- a/internal/setup/job.go
+++ b/internal/setup/job.go
@@ -24,7 +24,6 @@ import (
 
 	redskyv1beta1 "github.com/redskyops/redskyops-controller/api/v1beta1"
 	"github.com/redskyops/redskyops-controller/internal/template"
-	"github.com/redskyops/redskyops-controller/internal/trial"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -124,7 +123,7 @@ func NewJob(t *redskyv1beta1.Trial, mode string) (*batchv1.Job, error) {
 		}
 
 		// Add the trial assignments to the environment
-		c.Env = trial.AppendAssignmentEnv(t, c.Env)
+		c.Env = AppendAssignmentEnv(t, c.Env)
 
 		// Add the configured volume mounts
 		c.VolumeMounts = append(c.VolumeMounts, task.VolumeMounts...)

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -158,7 +158,7 @@ func AppendAssignmentEnv(t *redskyv1beta1.Trial, env []corev1.EnvVar) []corev1.E
 func AppendPrometheusEnv(t *redskyv1beta1.Trial, env []corev1.EnvVar) []corev1.EnvVar {
 	for i := range t.Spec.SetupTasks {
 		if IsPrometheusSetupTask(&t.Spec.SetupTasks[i]) {
-			url := "http://prometheus:9091/metrics/trial/" + t.Name
+			url := fmt.Sprintf("http://redsky-%s-prometheus:9091/metrics/trial/%s", t.Namespace, t.Name)
 			return append(env, corev1.EnvVar{Name: "PUSHGATEWAY_URL", Value: url})
 		}
 	}

--- a/internal/trial/job.go
+++ b/internal/trial/job.go
@@ -23,6 +23,7 @@ import (
 
 	redskyv1beta1 "github.com/redskyops/redskyops-controller/api/v1beta1"
 	"github.com/redskyops/redskyops-controller/internal/meta"
+	"github.com/redskyops/redskyops-controller/internal/setup"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -69,7 +70,8 @@ func NewJob(t *redskyv1beta1.Trial) *batchv1.Job {
 	// Expose the current assignments as environment variables to every container (except the default sleep container added below)
 	for i := range job.Spec.Template.Spec.Containers {
 		c := &job.Spec.Template.Spec.Containers[i]
-		c.Env = AppendAssignmentEnv(t, c.Env)
+		c.Env = setup.AppendAssignmentEnv(t, c.Env)
+		c.Env = setup.AppendPrometheusEnv(t, c.Env)
 	}
 
 	// Containers cannot be empty, inject a sleep by default

--- a/internal/trial/trial.go
+++ b/internal/trial/trial.go
@@ -90,15 +90,6 @@ func IsTrialJobReference(t *redskyv1beta1.Trial, ref *corev1.ObjectReference) bo
 	return true
 }
 
-// AppendAssignmentEnv appends an environment variable for each trial assignment
-func AppendAssignmentEnv(t *redskyv1beta1.Trial, env []corev1.EnvVar) []corev1.EnvVar {
-	for _, a := range t.Spec.Assignments {
-		name := strings.ReplaceAll(strings.ToUpper(a.Name), ".", "_")
-		env = append(env, corev1.EnvVar{Name: name, Value: a.Value.String()})
-	}
-	return env
-}
-
 // NeedsCleanup checks to see if a trial's TTL has expired
 func NeedsCleanup(t *redskyv1beta1.Trial) bool {
 	// Already deleted or still active, no cleanup necessary


### PR DESCRIPTION
What do you think of this? Basically if we see the Prometheus setup task, we add a `PUSHGATEWAY_URL` environment variable to the trial job so inside the trial job all you need to do is `echo "foo 1" | curl --data-binary @- "$PUSHGATEWAY_URL"` to push metrics out (labeled with the trial name).

There is weird circular dependency with setup and trial that I had to switch around so I could properly check to see if the setup task image was the default image or not.