### PR TITLE
fix: Remove resources from prometheus server deployment

### DIFF
--- a/config/prometheus/prometheus-server-deployment.yaml
+++ b/config/prometheus/prometheus-server-deployment.yaml
@@ -94,13 +94,6 @@ spec:
           timeoutSeconds: 30
           failureThreshold: 3
           successThreshold: 1
-        resources:
-          requests:
-            cpu: 25m
-            memory: 25M
-          limits:
-            cpu: 100m
-            memory: 200M
         volumeMounts:
           - name: config-volume
             mountPath: /etc/config


### PR DESCRIPTION
We recently introduces resource constraints for the prometheus server deployment
but these are too low and cause the server to get OOMKilled. We need to do a
better job at tuning the scrape config, but this will help in the mean time.

Signed-off-by: Brad Beam <brad.beam@carbonrelay.com>