### PR TITLE
Fix browser error message on login

### DIFF
--- a/redskyctl/internal/commands/login/login.go
+++ b/redskyctl/internal/commands/login/login.go
@@ -336,14 +336,19 @@ func (o *Options) openBrowser(loc string) error {
 		return err
 	}
 
-	// Do not open the browser for root
+	// Do not open the browser for root, but assume they still have one
 	if u.Uid == "0" {
 		_, _ = fmt.Fprintf(o.Out, "%s\n", loc)
 		return nil
 	}
 
+	// Print the URL and open it
 	_, _ = fmt.Fprintf(o.Out, browserPrompt, loc)
-	return browser.OpenURL(loc)
+	if err := browser.OpenURL(loc); err != nil {
+		return fmt.Errorf("failed to open browser, use 'redskyctl login --url' instead")
+	}
+
+	return nil
 }
 
 // configureCallbackServer configures an HTTP server using the supplied callback redirect URL for the listen address

--- a/redskyctl/internal/commands/results/results.go
+++ b/redskyctl/internal/commands/results/results.go
@@ -70,8 +70,14 @@ func NewCommand(o *Options) *cobra.Command {
 }
 
 func (o *Options) Complete() {
+	// Default to listening on an ephemeral port
 	if o.ServerAddress == "" {
 		o.ServerAddress = ":0"
+	}
+
+	// If we are just printing a URL we can't rely on the heartbeat to keep the process alive
+	if o.DisplayURL {
+		o.IdleTimeout = 0
 	}
 }
 
@@ -115,7 +121,10 @@ func (o *Options) openBrowser(loc string) error {
 	}
 
 	_, _ = fmt.Fprintf(o.Out, "Opening %s in your default browser...", loc)
-	return browser.OpenURL(loc)
+	if err := browser.OpenURL(loc); err != nil {
+		return fmt.Errorf("failed to open browser, use 'redskyctl results --url' instead")
+	}
+	return nil
 }
 
 func (o *Options) handleAPI(ctx context.Context, serveMux *http.ServeMux, prefix string) error {


### PR DESCRIPTION
This changes the error message from whatever `exec` reports to be something more useful.

The reason we don't want to silently ignore the error is that `redskyctl` is running an HTTP server on `localhost` and if they don't have a browser that can hit that localhost server when Auth0 redirects them, the authorization flow will not complete.

When using `redskyctl login --url` we use a device flow instead of an authorization code flow, with the device flow the browser and `redskyctl` do not need to be on the same system (which is more likely the case when opening the browser fails).