### PR TITLE
Send Kubernetes labels to the backend

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -47,9 +47,11 @@ func FromCluster(in *redskyv1beta1.Experiment) (redskyapi.ExperimentName, *redsk
 	out.ExperimentMeta.SelfURL = in.Annotations[redskyv1beta1.AnnotationExperimentURL]
 	out.ExperimentMeta.NextTrialURL = in.Annotations[redskyv1beta1.AnnotationNextTrialURL]
 
-	out.Labels = make(map[string]string, len(in.ObjectMeta.Labels))
-	for k, v := range in.ObjectMeta.Labels {
-		out.Labels[strings.TrimPrefix(k, "redskyops.dev/")] = v
+	if l := len(in.ObjectMeta.Labels); l > 0 {
+		out.Labels = make(map[string]string, l)
+		for k, v := range in.ObjectMeta.Labels {
+			out.Labels[strings.TrimPrefix(k, "redskyops.dev/")] = v
+		}
 	}
 
 	out.Optimization = nil

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -22,6 +22,7 @@ import (
 	"math"
 	"path"
 	"strconv"
+	"strings"
 
 	redskyv1beta1 "github.com/redskyops/redskyops-controller/api/v1beta1"
 	"github.com/redskyops/redskyops-controller/internal/experiment"
@@ -45,6 +46,11 @@ func FromCluster(in *redskyv1beta1.Experiment) (redskyapi.ExperimentName, *redsk
 	out.ExperimentMeta.LastModified = in.CreationTimestamp.Time
 	out.ExperimentMeta.SelfURL = in.Annotations[redskyv1beta1.AnnotationExperimentURL]
 	out.ExperimentMeta.NextTrialURL = in.Annotations[redskyv1beta1.AnnotationNextTrialURL]
+
+	out.Labels = make(map[string]string, len(in.ObjectMeta.Labels))
+	for k, v := range in.ObjectMeta.Labels {
+		out.Labels[strings.TrimPrefix(k, "redskyops.dev/")] = v
+	}
 
 	out.Optimization = nil
 	for _, o := range in.Spec.Optimization {


### PR DESCRIPTION
Jumping ahead with this one: we want to make sure the labels that exist on the application prior to creation on the backend are propagated up.