### PR TITLE
Include build metadata in UA string of pre-releases

### DIFF
--- a/internal/version/useragent.go
+++ b/internal/version/useragent.go
@@ -63,13 +63,34 @@ func userAgentString(product, comment string) string {
 	if product == "" {
 		return ""
 	}
-	// TODO Validate "product"
 
+	// TODO Validate "product"
+	ua := strings.Builder{}
+	ua.WriteString(product)
+	ua.WriteRune('/')
+	ua.WriteString(strings.TrimPrefix(Version, "v"))
+
+	// Build the comments using both the user supplied comments and some additional build information
+	var comments []string
+
+	// Only include build metadata for pre-release versions
+	if strings.Contains(Version, "-") && BuildMetadata != "" {
+		comments = append(comments, BuildMetadata)
+	}
+
+	// Clean white space and surrounding comment indicators
+	comment = strings.TrimSpace(comment)
+	comment = strings.TrimLeft(comment, "(")
+	comment = strings.TrimRight(comment, ")")
 	comment = strings.TrimSpace(comment)
 	if comment != "" {
-		comment = " (" + strings.TrimRight(strings.TrimLeft(comment, "("), ")") + ")"
+		comments = append(comments, comment)
 	}
-	// TODO Include build metadata in the comment?
 
-	return product + "/" + strings.TrimLeft(Version, "v") + comment
+	// Only add the comment if it is not empty
+	if len(comments) > 0 {
+		ua.WriteString(" (" + strings.Join(comments, "; ") + ")")
+	}
+
+	return ua.String()
 }

--- a/internal/version/useragent_test.go
+++ b/internal/version/useragent_test.go
@@ -57,6 +57,44 @@ func TestUserAgent(t *testing.T) {
 			comment:  "fluffy comment",
 			expected: "testComment/0.0.0-source (fluffy comment)",
 		},
+		{
+			desc:     "empty comment",
+			product:  "empty",
+			comment:  " (  ) ",
+			expected: "empty/0.0.0-source",
+		},
+		{
+			desc:     "empty comment",
+			product:  "empty",
+			comment:  " ",
+			expected: "empty/0.0.0-source",
+		},
+		{
+			desc:     "white space comment",
+			product:  "empty",
+			comment:  " ( test )",
+			expected: "empty/0.0.0-source (test)",
+		},
+		{
+			desc:    "build meta comment",
+			product: "meta",
+			comment: "test",
+			versionInfo: &Info{
+				Version:       "v1.2.3-next",
+				BuildMetadata: "build.123",
+			},
+			expected: "meta/1.2.3-next (build.123; test)",
+		},
+		{
+			desc:    "build meta comment",
+			product: "meta",
+			comment: "(test)",
+			versionInfo: &Info{
+				Version:       "v1.2.3",
+				BuildMetadata: "build.123",
+			},
+			expected: "meta/1.2.3 (test)",
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
The answer to another of my TODO question is "yes".