### PR TITLE
Adjust the query time to account for the last scrape interval

### DIFF
--- a/controllers/metric_controller.go
+++ b/controllers/metric_controller.go
@@ -160,7 +160,7 @@ func (r *MetricReconciler) collectMetrics(ctx context.Context, t *redskyv1beta1.
 		var captureError error
 		if target, err := r.target(ctx, t.Namespace, metrics[v.Name]); err != nil {
 			captureError = err
-		} else if value, stddev, err := metric.CaptureMetric(metrics[v.Name], t, target); err != nil {
+		} else if value, stddev, err := metric.CaptureMetric(log, metrics[v.Name], t, target); err != nil {
 			if merr, ok := err.(*metric.CaptureError); ok && merr.RetryAfter > 0 {
 				// Do not count retries against the remaining attempts
 				return &ctrl.Result{RequeueAfter: merr.RetryAfter}, nil

--- a/internal/metric/metric.go
+++ b/internal/metric/metric.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-logr/logr"
 	redskyv1beta1 "github.com/redskyops/redskyops-controller/api/v1beta1"
 	"github.com/redskyops/redskyops-controller/internal/template"
 	corev1 "k8s.io/api/core/v1"
@@ -48,7 +49,7 @@ func (e *CaptureError) Error() string {
 }
 
 // CaptureMetric captures a point-in-time metric value and it's error (standard deviation)
-func CaptureMetric(metric *redskyv1beta1.Metric, trial *redskyv1beta1.Trial, target runtime.Object) (float64, float64, error) {
+func CaptureMetric(log logr.Logger, metric *redskyv1beta1.Metric, trial *redskyv1beta1.Trial, target runtime.Object) (float64, float64, error) {
 	// Work on a copy so we can render the queries in place
 	metric = metric.DeepCopy()
 
@@ -65,7 +66,7 @@ func CaptureMetric(metric *redskyv1beta1.Metric, trial *redskyv1beta1.Trial, tar
 		value, err := strconv.ParseFloat(metric.Query, 64)
 		return value, 0, err
 	case redskyv1beta1.MetricPrometheus:
-		return capturePrometheusMetric(metric, target, trial.Status.CompletionTime.Time)
+		return capturePrometheusMetric(log, metric, target, trial.Status.CompletionTime.Time)
 	case redskyv1beta1.MetricDatadog:
 		return captureDatadogMetric(metric.Scheme, metric.Query, trial.Status.StartTime.Time, trial.Status.CompletionTime.Time)
 	case redskyv1beta1.MetricJSONPath:

--- a/internal/metric/metric_test.go
+++ b/internal/metric/metric_test.go
@@ -34,6 +34,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 func TestCaptureMetric(t *testing.T) {
@@ -42,6 +43,8 @@ func TestCaptureMetric(t *testing.T) {
 	// all tests this way
 	now := metav1.NewTime(time.Now().Add(time.Duration(-10) * time.Minute))
 	later := metav1.NewTime(now.Add(5 * time.Second))
+
+	log := zap.New(zap.UseDevMode(true))
 
 	jsonHttpTest := jsonPathHttpTestServer()
 	defer jsonHttpTest.Close()
@@ -151,6 +154,7 @@ func TestCaptureMetric(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("%q", tc.desc), func(t *testing.T) {
+			log := log.WithValues("test", tc.desc)
 			trial := &redskyv1beta1.Trial{
 				Status: redskyv1beta1.TrialStatus{
 					StartTime:      &now,
@@ -158,7 +162,7 @@ func TestCaptureMetric(t *testing.T) {
 				},
 			}
 
-			duration, _, err := CaptureMetric(tc.metric, trial, tc.obj)
+			duration, _, err := CaptureMetric(log, tc.metric, trial, tc.obj)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expected, duration)
 		})


### PR DESCRIPTION
We are seeing that especially with the push gateway, Prometheus may not have data present at the completion time of the trial, instead the data is coming in on the subsequent scrape. This fix pushes the query time back to account for the scrape intervals.