### PR TITLE
fix: Patch trial job instead of delete it

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -33,6 +33,7 @@ rules:
   - create
   - get
   - list
+  - patch
   - watch
 - apiGroups:
   - redskyops.dev

--- a/controllers/trial_job_controller.go
+++ b/controllers/trial_job_controller.go
@@ -199,7 +199,7 @@ func (r *TrialJobReconciler) applyJobStatus(ctx context.Context, t *redskyv1beta
 
 						// Patch the job and set parallelism to 0 to suspend the job and terminate any active pods
 						if err := r.Patch(ctx, job, client.RawPatch(types.StrategicMergePatchType, []byte(`{ "spec": { "parallelism": 0  } }`))); err != nil {
-							r.Log.Error(err, "unable suspend trial job", "job", job, "pod status", podList.Items[i].Status)
+							r.Log.WithValues("trial", fmt.Sprintf("%s/%s", t.Namespace, t.Name), "job", fmt.Sprintf("%s/%s", job.Namespace, job.Name)).Error(err, "unable suspend trial job")
 						}
 						dirty = true
 					}


### PR DESCRIPTION
We can suspend/interrupt a pending trial job by setting the parallelism to 0.
This should allow us to preserve trial run history and handle cases where
the trial job fails to schedule because of resource constraints.

Signed-off-by: Brad Beam <brad.beam@b-rad.info>