### PR TITLE
Update the image names to the new Docker Hub organization

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -61,12 +61,12 @@ jobs:
       - name: Bootstrap
         run: |
           if [ -z "${GITHUB_REF/refs\/tags\/*/}" ]; then
-            DOCKER_REGISTRY="redskyops"
+            DOCKER_REGISTRY="thestormforge"
             DOCKER_TAG=${GITHUB_REF##*/v}
             echo "IMAGE_TAG=latest" >> $GITHUB_ENV
             echo "VERSION=v${DOCKER_TAG}" >> $GITHUB_ENV
             echo "AC_USERNAME=${{ secrets.AC_USERNAME }}" >> $GITHUB_ENV
-            echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+            echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
           else
             DOCKER_REGISTRY="ghcr.io/thestormforge"
             DOCKER_TAG="sha-$(git rev-parse --short HEAD)"


### PR DESCRIPTION
This changes the name of the image, but I also took the opportunity to move the Docker Hub credentials to the GitHub organization so we can use them for pushing trial job images. The old secrets have already been removed (and deprovisioned on the Docker Hub side).