### PR TITLE
Upgrade optimize-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1
-	github.com/thestormforge/optimize-go v0.0.6
+	github.com/thestormforge/optimize-go v0.0.7
 	github.com/zorkian/go-datadog-api v2.24.0+incompatible
 	golang.org/x/net v0.0.0-20200904194848-62affa334b73
 	golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43

--- a/go.sum
+++ b/go.sum
@@ -590,8 +590,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
-github.com/thestormforge/optimize-go v0.0.6 h1:s2kAn5lWvGujfy5qjbP+RqLvHGVZPImuCpv2cTo17zw=
-github.com/thestormforge/optimize-go v0.0.6/go.mod h1:Gpl/jbX18GH9yFZDW5AoeKPG3OeyrvhHViClCawPODA=
+github.com/thestormforge/optimize-go v0.0.7 h1:INWb8fGUjJ4ZdfbW5fXlI2Na+s9CvudhAOD8gnCUEUk=
+github.com/thestormforge/optimize-go v0.0.7/go.mod h1:Gpl/jbX18GH9yFZDW5AoeKPG3OeyrvhHViClCawPODA=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/timakin/bodyclose v0.0.0-20190930140734-f7f2e9bca95e/go.mod h1:Qimiffbc6q9tBWlVV6x0P9sat/ao1xEkREYPPj9hphk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/redskyctl/internal/commands/authorize_cluster/authorize_cluster.go
+++ b/redskyctl/internal/commands/authorize_cluster/authorize_cluster.go
@@ -126,8 +126,7 @@ func (o *Options) patchDeployment(ctx context.Context, secretName, secretHash st
 	}
 
 	// Execute the patch
-	// TODO Deployment name should come from config (it could be different, e.g. for a Helm installation)
-	name := "redsky-controller-manager"
+	name := ctrl.DeploymentName
 	namespace := ctrl.Namespace
 	patch := buf.String()
 	kubectlPatch, err := o.Config.Kubectl(ctx, "patch", "deployment", name, "--namespace", namespace, "--patch", patch)

--- a/redskyctl/internal/commands/login/login.go
+++ b/redskyctl/internal/commands/login/login.go
@@ -94,8 +94,8 @@ func NewCommand(o *Options) *cobra.Command {
 		RunE:              commander.WithContextE(o.login),
 	}
 
-	// NOTE: --name is an alias of --context for backwards compatibility
 	cmd.Flags().StringVar(&o.Config.Overrides.Context, "name", "", "name of the server configuration to authorize")
+	_ = cmd.Flags().MarkDeprecated("name", "use --context instead")
 
 	cmd.Flags().StringVar(&o.Environment, "env", "", "override the execution environment")
 	cmd.Flags().StringVar(&o.Server, "server", "", "override the Red Sky API server identifier")

--- a/redskyctl/internal/commands/ping/ping.go
+++ b/redskyctl/internal/commands/ping/ping.go
@@ -86,7 +86,7 @@ func hostAndAddrs(ctx context.Context, r config.Reader) (string, []string, error
 		return "", nil, err
 	}
 
-	u, err := url.Parse(srv.RedSky.ExperimentsEndpoint)
+	u, err := url.Parse(srv.API.ExperimentsEndpoint)
 	if err != nil {
 		return "", nil, err
 	}

--- a/redskyctl/internal/commands/results/results.go
+++ b/redskyctl/internal/commands/results/results.go
@@ -24,10 +24,13 @@ import (
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
 	"github.com/thestormforge/optimize-controller/redskyctl/internal/commander"
+	"github.com/thestormforge/optimize-go/pkg/config"
 )
 
 // Options is the configuration for displaying the results UI
 type Options struct {
+	// Config is the Red Sky Configuration to get redirect URLs from
+	Config *config.RedSkyConfig
 	// IOStreams are used to access the standard process streams
 	commander.IOStreams
 
@@ -59,12 +62,17 @@ func NewCommand(o *Options) *cobra.Command {
 }
 
 func (o *Options) results() error {
+	s, err := config.CurrentServer(o.Config.Reader())
+	if err != nil {
+		return err
+	}
+
 	u, err := user.Current()
 	if err != nil {
 		return err
 	}
 
-	loc := "https://app.stormforge.io/experiments"
+	loc := s.Application.ExperimentsEndpoint
 
 	// Do not open the browser for root
 	if o.DisplayURL || u.Uid == "0" {

--- a/redskyctl/internal/commands/revoke/revoke.go
+++ b/redskyctl/internal/commands/revoke/revoke.go
@@ -50,8 +50,8 @@ func NewCommand(o *Options) *cobra.Command {
 		RunE:   commander.WithContextE(o.revoke),
 	}
 
-	// NOTE: --name is an alias of --context for backwards compatibility
 	cmd.Flags().StringVar(&o.Config.Overrides.Context, "name", "", "name of the server configuration to de-authorize")
+	_ = cmd.Flags().MarkDeprecated("name", "use --context instead")
 
 	return cmd
 }

--- a/redskyctl/internal/commands/revoke/revoke.go
+++ b/redskyctl/internal/commands/revoke/revoke.go
@@ -36,9 +36,6 @@ type Options struct {
 	Config *config.RedSkyConfig
 	// IOStreams are used to access the standard process streams
 	commander.IOStreams
-
-	// Name is the key of the authorization in the configuration to remove
-	Name string
 }
 
 // NewCommand creates a new command for executing a logout
@@ -53,14 +50,15 @@ func NewCommand(o *Options) *cobra.Command {
 		RunE:   commander.WithContextE(o.revoke),
 	}
 
-	cmd.Flags().StringVar(&o.Name, "name", "", "name of the server configuration to de-authorize")
+	// NOTE: --name is an alias of --context for backwards compatibility
+	cmd.Flags().StringVar(&o.Config.Overrides.Context, "name", "", "name of the server configuration to de-authorize")
 
 	return cmd
 }
 
 // Run executes the revocation
 func (o *Options) revoke(ctx context.Context) error {
-	ri, err := o.Config.RevocationInfo(o.Name)
+	ri, err := o.Config.RevocationInfo()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Take advantage of new features in optimize-go. The application URLs are nice to have, but the login/revoke changes actually address an issue where doing `redskyctl revoke` with multiple contexts leads to an error.