### PR TITLE
Fix generated trial image name

### DIFF
--- a/redskyctl/internal/commands/generate/experiment/k8s/helpers.go
+++ b/redskyctl/internal/commands/generate/experiment/k8s/helpers.go
@@ -111,7 +111,11 @@ func TrialJobImage(job string) string {
 	}
 	imageTag := os.Getenv("OPTIMIZE_TRIALS_IMAGE_TAG")
 	if imageTag == "" {
-		imageTag = "0.0.1-" + job
+		imageTagBase := os.Getenv("OPTIMIZE_TRIALS_IMAGE_TAG_BASE")
+		if imageTagBase == "" {
+			imageTagBase = "v0.0.1"
+		}
+		imageTag = imageTagBase + "-" + job
 	}
 	return imageName + ":" + imageTag
 }


### PR DESCRIPTION
So once I actually ran the release I realized that the metadata generator we are using keeps the "v" in both the Git and Docker tags. I also realized there wasn't a way to override the tag name in a way that was independent of the trial job you were trying to add.

My only question here would be if we should reference the `latest` tag instead of the specific version. The downside is that it's easier to break compatibility between what we generate and the images, the upside is that we can iterate on the trial jobs out of band from the controller/tool release cycle. I guess in theory you can always set `OPTIMIZE_TRIALS_IMAGE_TAG_BASE=latest`