### PR TITLE
fix: Fix default case for setup task script

### DIFF
--- a/config/docker-entrypoint.sh
+++ b/config/docker-entrypoint.sh
@@ -16,7 +16,7 @@ case "$1" in
       kubectl wait --for condition=Available=true --timeout 120s deployment.apps ${namePrefix}prometheus-server
     }
   ;;
-  default)
+  *)
     waitFn() { :; }
   ;;
 esac


### PR DESCRIPTION
Shell uses `*` as the default case, not `default` like go. :oops:.

Signed-off-by: Brad Beam <brad.beam@stormforge.io>