### PR TITLE
Allow an empty name on the job patch target reference

### DIFF
--- a/internal/patch/patch_test.go
+++ b/internal/patch/patch_test.go
@@ -167,6 +167,21 @@ metadata:
 			},
 			attemptsRemaining: 0,
 		},
+		{
+			desc:  "patchTrial - optional name",
+			trial: trial,
+			patchTemplate: &redsky.PatchTemplate{
+				Type:  redsky.PatchStrategic,
+				Patch: patchSpec,
+				TargetRef: &corev1.ObjectReference{
+					Kind:       "Job",
+					APIVersion: "batch/v1",
+					Name:       "",
+					Namespace:  trial.Namespace,
+				},
+			},
+			attemptsRemaining: 0,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Allow the target reference name to be empty for jobs. The only time patching a job makes sense is the trial job.

There is probably a larger clean up we should do for this: patching the trial job is bit of a hack to begin with, it might be nicer if we were able to better parameterize it to begin with. Short of that, we could _require_ the `name` to be empty for `batch/v1/Job` and stop checking it altogether in `IsTrialJobReference` (requiring an empty name would break existing places where matching is based on the trial name so I'm not doing yet).