### PR TITLE
Add baseline enforcement when creating the experiment

### DIFF
--- a/controllers/server_controller.go
+++ b/controllers/server_controller.go
@@ -194,7 +194,16 @@ func (r *ServerReconciler) listTrials(ctx context.Context, trialList *redskyv1be
 // server will be copied back into cluster along with the URLs needed for future interactions with server.
 func (r *ServerReconciler) createExperiment(ctx context.Context, log logr.Logger, exp *redskyv1beta1.Experiment) (*ctrl.Result, error) {
 	// Convert the cluster state into a server representation
-	n, e, b := server.FromCluster(exp)
+	n, e, b, err := server.FromCluster(exp)
+	if err != nil {
+		if server.FailExperiment(exp, "InvalidExperimentDefinition", err) {
+			err := r.Update(ctx, exp)
+			return controller.RequeueConflict(err)
+		}
+		return &ctrl.Result{}, err
+	}
+
+	// Create the experiment remotely
 	ee, err := r.ExperimentsAPI.CreateExperiment(ctx, n, *e)
 	if err != nil {
 		if server.FailExperiment(exp, "ServerCreateFailed", err) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -261,37 +261,6 @@ func TestFromCluster(t *testing.T) {
 				},
 			},
 		},
-		{
-			desc: "baseline missing",
-			in: &redskyv1beta1.Experiment{
-				Spec: redskyv1beta1.ExperimentSpec{
-					Parameters: []redskyv1beta1.Parameter{
-						{Name: "one", Min: 0, Max: 1, Baseline: &one},
-						{Name: "two", Min: 0, Max: 1, Baseline: &two},
-						{Name: "three", Min: 0, Max: 1},
-					},
-				},
-			},
-			out: &redskyapi.Experiment{
-				Parameters: []redskyapi.Parameter{
-					{
-						Type:   redskyapi.ParameterTypeInteger,
-						Name:   "one",
-						Bounds: &redskyapi.Bounds{Min: "0", Max: "1"},
-					},
-					{
-						Type:   redskyapi.ParameterTypeInteger,
-						Name:   "two",
-						Bounds: &redskyapi.Bounds{Min: "0", Max: "1"},
-					},
-					{
-						Type:   redskyapi.ParameterTypeInteger,
-						Name:   "three",
-						Bounds: &redskyapi.Bounds{Min: "0", Max: "1"},
-					},
-				},
-			},
-		},
 	}
 	for _, c := range cases {
 		t.Run(c.desc, func(t *testing.T) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -228,8 +228,8 @@ func TestFromCluster(t *testing.T) {
 				Spec: redskyv1beta1.ExperimentSpec{
 					Parameters: []redskyv1beta1.Parameter{
 						{Name: "one", Min: 0, Max: 1, Baseline: &one},
-						{Name: "two", Min: 0, Max: 1, Baseline: &two},
-						{Name: "three", Min: 0, Max: 1, Baseline: &three},
+						{Name: "two", Min: 0, Max: 2, Baseline: &two},
+						{Name: "three", Values: []string{"three"}, Baseline: &three},
 					},
 				},
 			},
@@ -243,12 +243,12 @@ func TestFromCluster(t *testing.T) {
 					{
 						Type:   redskyapi.ParameterTypeInteger,
 						Name:   "two",
-						Bounds: &redskyapi.Bounds{Min: "0", Max: "1"},
+						Bounds: &redskyapi.Bounds{Min: "0", Max: "2"},
 					},
 					{
-						Type:   redskyapi.ParameterTypeInteger,
+						Type:   redskyapi.ParameterTypeCategorical,
 						Name:   "three",
-						Bounds: &redskyapi.Bounds{Min: "0", Max: "1"},
+						Values: []string{"three"},
 					},
 				},
 			},
@@ -295,10 +295,12 @@ func TestFromCluster(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.desc, func(t *testing.T) {
-			name, out, baseline := FromCluster(c.in)
-			assert.Equal(t, c.in.Name, name.Name())
-			assert.Equal(t, c.out, out)
-			assert.Equal(t, c.baseline, baseline)
+			name, out, baseline, err := FromCluster(c.in)
+			if assert.NoError(t, err) {
+				assert.Equal(t, c.in.Name, name.Name())
+				assert.Equal(t, c.out, out)
+				assert.Equal(t, c.baseline, baseline)
+			}
 		})
 	}
 }

--- a/redskyctl/internal/commands/generate/trial.go
+++ b/redskyctl/internal/commands/generate/trial.go
@@ -83,7 +83,10 @@ func (o *TrialOptions) generate() error {
 	}
 
 	// Convert the experiment so we can use it to collect the suggested assignments
-	_, serverExperiment, _ := server.FromCluster(exp)
+	_, serverExperiment, _, err := server.FromCluster(exp)
+	if err != nil {
+		return err
+	}
 	ta := experimentsv1alpha1.TrialAssignments{}
 	if err := o.SuggestAssignments(serverExperiment, &ta); err != nil {
 		return err


### PR DESCRIPTION
This is the safest implementation of this validation (right now). Although this validation is not specific to the server implementation, it needed to be pushed there because there is no [validation hook](https://book.kubebuilder.io/cronjob-tutorial/webhook-implementation.html) on admittance of experiments: trying to do the validation in the "experiment controller" would lead to a race with the "server controller". One more thing for the list of "if we only had a webhook".