### PR TITLE
Improve some usage strings

### DIFF
--- a/redskyctl/internal/commander/commander.go
+++ b/redskyctl/internal/commander/commander.go
@@ -137,7 +137,7 @@ func ConfigGlobals(cfg *internalconfig.RedSkyConfig, cmd *cobra.Command) {
 	root.PersistentFlags().StringVar(&cfg.Filename, "redskyconfig", cfg.Filename, "path to the redskyconfig `file` to use")
 	root.PersistentFlags().StringVar(&cfg.Overrides.Context, "context", "", "the `name` of the redskyconfig context to use, NOT THE KUBE CONTEXT")
 	root.PersistentFlags().StringVar(&cfg.Overrides.KubeConfig, "kubeconfig", "", "path to the kubeconfig `file` to use for CLI requests")
-	root.PersistentFlags().StringVarP(&cfg.Overrides.Namespace, "namespace", "n", "", "if present, the namespace scope for this CLI request")
+	root.PersistentFlags().StringVarP(&cfg.Overrides.Namespace, "namespace", "n", "", "the Kubernetes namespace scope for this CLI request")
 
 	_ = root.MarkFlagFilename("redskyconfig")
 	_ = root.MarkFlagFilename("kubeconfig")

--- a/redskyctl/internal/commands/authorize_cluster/generator.go
+++ b/redskyctl/internal/commands/authorize_cluster/generator.go
@@ -101,7 +101,7 @@ func clusterName() string {
 }
 
 func (o *GeneratorOptions) addFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&o.ClientName, "client-name", o.ClientName, "client name to use for registration")
+	cmd.Flags().StringVar(&o.ClientName, "client-name", o.ClientName, "client `name` to use for registration")
 	cmd.Flags().BoolVar(&o.AllowUnauthorized, "allow-unauthorized", o.AllowUnauthorized, "generate a secret without authorization, if necessary")
 	_ = cmd.Flags().MarkHidden("allow-unauthorized")
 }

--- a/redskyctl/internal/commands/check/experiment.go
+++ b/redskyctl/internal/commands/check/experiment.go
@@ -51,7 +51,7 @@ func NewExperimentCommand(o *ExperimentOptions) *cobra.Command {
 		RunE:   commander.WithoutArgsE(o.checkExperiment),
 	}
 
-	cmd.Flags().StringVarP(&o.Filename, "filename", "f", "", "file that contains the experiment to check")
+	cmd.Flags().StringVarP(&o.Filename, "filename", "f", "", "`file` that contains the experiment to check")
 
 	_ = cmd.MarkFlagFilename("filename", "yml", "yaml")
 	_ = cmd.MarkFlagRequired("filename")

--- a/redskyctl/internal/commands/experiments/suggest.go
+++ b/redskyctl/internal/commands/experiments/suggest.go
@@ -65,10 +65,10 @@ func NewSuggestCommand(o *SuggestOptions) *cobra.Command {
 		RunE: commander.WithContextE(o.suggest),
 	}
 
-	cmd.Flags().StringToStringVarP(&o.Assignments, "assign", "A", nil, "assign an explicit value to a parameter")
+	cmd.Flags().StringToStringVarP(&o.Assignments, "assign", "A", nil, "assign an explicit `key=value` to a parameter")
 	cmd.Flags().BoolVar(&o.AllowInteractive, "interactive", false, "allow interactive prompts for unspecified parameter assignments")
-	cmd.Flags().StringVar(&o.DefaultBehavior, "default", "", "select the behavior for default values")
-	cmd.Flags().StringVarP(&o.Labels, "labels", "l", "", "comma separated labels to apply to the trial")
+	cmd.Flags().StringVar(&o.DefaultBehavior, "default", "", "select the `behavior` for default values")
+	cmd.Flags().StringVarP(&o.Labels, "labels", "l", "", "comma separated `key=value` labels to apply to the trial")
 
 	commander.SetFlagValues(cmd, "default", DefaultNone, DefaultMinimum, DefaultMaximum, DefaultRandom)
 

--- a/redskyctl/internal/commands/export/export.go
+++ b/redskyctl/internal/commands/export/export.go
@@ -98,7 +98,7 @@ func NewCommand(o *Options) *cobra.Command {
 		RunE: commander.WithContextE(o.runner),
 	}
 
-	cmd.Flags().StringSliceVarP(&o.inputFiles, "filename", "f", []string{""}, "experiment and related manifests to export, - for stdin")
+	cmd.Flags().StringSliceVarP(&o.inputFiles, "filename", "f", []string{""}, "experiment and related manifest `files` to export, - for stdin")
 	cmd.Flags().BoolVarP(&o.patchOnly, "patch", "p", false, "export only the patch")
 	cmd.Flags().BoolVarP(&o.patchedTarget, "patched-target", "t", false, "export only the patched resource")
 

--- a/redskyctl/internal/commands/generate/rbac.go
+++ b/redskyctl/internal/commands/generate/rbac.go
@@ -76,7 +76,7 @@ func NewRBACCommand(o *RBACOptions) *cobra.Command {
 		RunE: commander.WithoutArgsE(o.generate),
 	}
 
-	cmd.Flags().StringVarP(&o.Filename, "filename", "f", o.Filename, "file that contains the experiment to extract roles from")
+	cmd.Flags().StringVarP(&o.Filename, "filename", "f", o.Filename, "`file` that contains the experiment to extract roles from")
 	cmd.Flags().StringVar(&o.Name, "role-name", o.Name, "name of the cluster role to generate (default is to use a generated name)")
 	cmd.Flags().BoolVar(&o.IncludeNames, "include-names", o.IncludeNames, "include resource names in the generated role")
 	cmd.Flags().BoolVar(&o.ClusterRole, "cluster-role", o.ClusterRole, "generate a cluster role")

--- a/redskyctl/internal/commands/generate/trial.go
+++ b/redskyctl/internal/commands/generate/trial.go
@@ -51,11 +51,11 @@ func NewTrialCommand(o *TrialOptions) *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&o.Filename, "filename", "f", o.Filename, "file that contains the experiment to generate trials for")
-	cmd.Flags().StringVarP(&o.Labels, "labels", "l", "", "comma separated labels to apply to the trial")
+	cmd.Flags().StringVarP(&o.Labels, "labels", "l", "", "comma separated `key=value` labels to apply to the trial")
 
-	cmd.Flags().StringToStringVarP(&o.Assignments, "assign", "A", nil, "assign an explicit value to a parameter")
+	cmd.Flags().StringToStringVarP(&o.Assignments, "assign", "A", nil, "assign an explicit `key=value` to a parameter")
 	cmd.Flags().BoolVar(&o.AllowInteractive, "interactive", o.AllowInteractive, "allow interactive prompts for unspecified parameter assignments")
-	cmd.Flags().StringVar(&o.DefaultBehavior, "default", "", "select the behavior for default values")
+	cmd.Flags().StringVar(&o.DefaultBehavior, "default", "", "select the `behavior` for default values")
 
 	_ = cmd.MarkFlagFilename("filename", "yml", "yaml")
 	_ = cmd.MarkFlagRequired("filename")


### PR DESCRIPTION
This just removes some of the "`string`" flag placeholder names. There are still some left so this doesn't get all of them, in particular I'm not sure what the placeholder should be for the Kube namespace and what I would have for usage.