### PR TITLE
Error rate objective

### DIFF
--- a/api/apps/v1alpha1/application_defaults.go
+++ b/api/apps/v1alpha1/application_defaults.go
@@ -134,6 +134,9 @@ func (in *Objective) Default() {
 			corev1.ResourceMemory: resource.MustParse("1"),
 		})
 
+	case "error-rate", "error-ratio", "errors":
+		defaultErrorRateObjective(in, ErrorRateRequests)
+
 	default:
 
 		latency := LatencyType(strings.ReplaceAll(in.Name, "latency", ""))
@@ -187,12 +190,27 @@ func defaultLatencyObjective(obj *Objective, latency LatencyType) {
 	}
 }
 
+func defaultErrorRateObjective(obj *Objective, errorRate ErrorRateType) {
+	if obj.ErrorRate == nil {
+		if countConfigs(obj) != 0 {
+			return
+		}
+		obj.ErrorRate = &ErrorRateObjective{}
+	}
+
+	if obj.ErrorRate.ErrorRateType == "" {
+		obj.ErrorRate.ErrorRateType = errorRate
+	}
+}
+
 func defaultObjectiveName(obj *Objective) {
 	switch {
 	case obj.Requests != nil:
 		obj.Name = "requests"
 	case obj.Latency != nil:
 		obj.Name = "latency-" + string(obj.Latency.LatencyType)
+	case obj.ErrorRate != nil:
+		obj.Name = "error-rate"
 	}
 }
 
@@ -202,6 +220,9 @@ func countConfigs(obj *Objective) int {
 		c++
 	}
 	if obj.Latency != nil {
+		c++
+	}
+	if obj.ErrorRate != nil {
 		c++
 	}
 	return c

--- a/api/apps/v1alpha1/application_types.go
+++ b/api/apps/v1alpha1/application_types.go
@@ -154,7 +154,7 @@ type RequestsObjective struct {
 	Weights corev1.ResourceList `json:"weights,omitempty"`
 }
 
-// LatencyObject is used to optimize the responsiveness of an application in a specific scenario.
+// LatencyObjective is used to optimize the responsiveness of an application in a specific scenario.
 type LatencyObjective struct {
 	// The latency to optimize. Can be one of the following values:
 	// `minimum` (or `min`), `maximum` (or `max`), `mean` (or `average`, `avg`),

--- a/api/apps/v1alpha1/application_types.go
+++ b/api/apps/v1alpha1/application_types.go
@@ -138,6 +138,8 @@ type Objective struct {
 	Requests *RequestsObjective `json:"requests,omitempty"`
 	// Latency is used to optimize the responsiveness of an application.
 	Latency *LatencyObjective `json:"latency,omitempty"`
+	// ErrorRate is used to optimize the failure rate of an application.
+	ErrorRate *ErrorRateObjective `json:"errorRate,omitempty"`
 
 	// Internal use field for marking objectives as having been implemented. For example,
 	// it may be impossible to optimize for some objectives based on the current state.
@@ -176,6 +178,24 @@ const (
 	LatencyPercentile50 LatencyType = "percentile_50"
 	LatencyPercentile95 LatencyType = "percentile_95"
 	LatencyPercentile99 LatencyType = "percentile_99"
+)
+
+// ErrorRateObjective is used to optimize the error rate of an application in a specific scenario.
+type ErrorRateObjective struct {
+	// The error rate to optimize. Can be one of the following values: `requests`.
+	ErrorRateType
+}
+
+// UnmarshalJSON allows an error rate objective to be specified as a simple string.
+func (in *ErrorRateObjective) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &in.ErrorRateType)
+}
+
+// ErrorRateType describes something which can fail.
+type ErrorRateType string
+
+const (
+	ErrorRateRequests ErrorRateType = "requests"
 )
 
 // StormForger describes global configuration related to StormForger.

--- a/redskyctl/internal/commands/generate/experiment/locust/objectives.go
+++ b/redskyctl/internal/commands/generate/experiment/locust/objectives.go
@@ -33,6 +33,9 @@ func addLocustObjectives(app *redskyappsv1alpha1.Application, list *corev1.List)
 		case obj.Latency != nil:
 			addLocustLatencyMetric(obj, list)
 
+		case obj.ErrorRate != nil:
+			addLocustErrorRateMetric(obj, list)
+
 		}
 	}
 
@@ -67,6 +70,26 @@ func addLocustLatencyMetric(obj *redskyappsv1alpha1.Objective, list *corev1.List
 		Type:     redskyv1beta1.MetricPrometheus,
 		Port:     intstr.FromInt(9090),
 		Query:    `scalar(` + m + `{job="trialRun",instance="{{ .Trial.Name }}"})`,
+		Min:      obj.Min,
+		Max:      obj.Max,
+		Optimize: obj.Optimize,
+	})
+	obj.Implemented = true
+}
+
+func addLocustErrorRateMetric(obj *redskyappsv1alpha1.Objective, list *corev1.List) {
+	if obj.ErrorRate.ErrorRateType != redskyappsv1alpha1.ErrorRateRequests {
+		// This is not an error rate that Locust can produce, skip it
+		return
+	}
+
+	exp := k8s.FindOrAddExperiment(list)
+	exp.Spec.Metrics = append(exp.Spec.Metrics, redskyv1beta1.Metric{
+		Name:     obj.Name,
+		Minimize: true,
+		Type:     redskyv1beta1.MetricPrometheus,
+		Port:     intstr.FromInt(9090),
+		Query:    `scalar(failure_count{job="trialRun",instance="{{ .Trial.Name }}"} / request_count{job="trialRun",instance="{{ .Trial.Name }}"})`,
 		Min:      obj.Min,
 		Max:      obj.Max,
 		Optimize: obj.Optimize,

--- a/redskyctl/internal/commands/generate/experiment/locust/scenarios.go
+++ b/redskyctl/internal/commands/generate/experiment/locust/scenarios.go
@@ -91,7 +91,7 @@ func AddTrialJob(sc *redskyappsv1alpha1.Scenario, app *redskyappsv1alpha1.Applic
 
 func ensureLocustFile(s *redskyappsv1alpha1.Scenario, ldr ifc.Loader, list *corev1.List) (*corev1.VolumeMount, *corev1.Volume, error) {
 	if s.Locust.Locustfile == "" {
-		return nil, nil, fmt.Errorf("missing Locust file")
+		return nil, nil, fmt.Errorf("missing Locust file for scenario %q", s.Name)
 	}
 
 	// TODO Try to find it first...


### PR DESCRIPTION
This PR adds a new objective to the application named "error rate". It can be used with both StormForger and Locust.

To make your experiment optimize for the per-request error rate add an objective named either `error-rate`, `error-ratio`, or `errors`. Alternatively, you can name your objective whatever you like and add `errorRate: requests` to the objective.