### PR TITLE
Parameter defaults from baselines

### DIFF
--- a/redskyctl/internal/commands/generate/experiment/containerresources.go
+++ b/redskyctl/internal/commands/generate/experiment/containerresources.go
@@ -233,8 +233,8 @@ func toIntWithRange(name corev1.ResourceName, q resource.Quantity) (value *intst
 		max = int32(math.Pow(2, math.Ceil(math.Log2(float64(scaled.IntVal*2)))))
 	case corev1.ResourceCPU:
 		scaled = intstr.FromInt(int(q.ScaledValue(resource.Milli)))
-		min = int32((float64(scaled.IntVal) / 200) * 100)
-		max = int32((float64(scaled.IntVal) / 50) * 100)
+		min = int32(math.Floor(float64(scaled.IntVal)/20)) * 10
+		max = int32(math.Ceil(float64(scaled.IntVal)/10)) * 20
 	}
 
 	return &scaled, min, max

--- a/redskyctl/internal/commands/generate/experiment/containerresources.go
+++ b/redskyctl/internal/commands/generate/experiment/containerresources.go
@@ -229,7 +229,7 @@ func toIntWithRange(name corev1.ResourceName, q resource.Quantity) (value *intst
 	switch name {
 	case corev1.ResourceMemory:
 		scaled = intstr.FromInt(int(q.ScaledValue(resource.Mega)))
-		min = int32(math.Pow(2, math.Ceil(math.Log2(float64(scaled.IntVal/2)))))
+		min = int32(math.Pow(2, math.Floor(math.Log2(float64(scaled.IntVal/2)))))
 		max = int32(math.Pow(2, math.Ceil(math.Log2(float64(scaled.IntVal*2)))))
 	case corev1.ResourceCPU:
 		scaled = intstr.FromInt(int(q.ScaledValue(resource.Milli)))

--- a/redskyctl/internal/commands/generate/experiment/containerresources_test.go
+++ b/redskyctl/internal/commands/generate/experiment/containerresources_test.go
@@ -52,7 +52,7 @@ func TestToIntWithRange(t *testing.T) {
 			input:    "2505m",
 			baseline: 2505,
 			min:      1250,
-			max:      5020,
+			max:      4000,
 		},
 		{
 			name:     corev1.ResourceCPU,
@@ -94,40 +94,41 @@ func TestToIntWithRange(t *testing.T) {
 			input:    "4.0",
 			baseline: 4000,
 			min:      2000,
-			max:      8000,
+			max:      4000,
 		},
 		{
 			name:     corev1.ResourceMemory,
 			input:    "4000Mi",
 			baseline: 4195,
 			min:      2048,
-			max:      16384,
+			max:      4195,
 		},
 		{
 			name:     corev1.ResourceMemory,
 			input:    "4000M",
 			baseline: 4000,
 			min:      1024,
-			max:      8192,
+			max:      4096,
 		},
 		{
 			name:     corev1.ResourceMemory,
 			input:    "4Gi",
 			baseline: 4295,
 			min:      2048,
-			max:      16384,
+			max:      4295,
 		},
 		{
 			name:     corev1.ResourceMemory,
 			input:    "4G",
 			baseline: 4000,
 			min:      1024,
-			max:      8192,
+			max:      4096,
 		},
 	}
 	for _, c := range cases {
 		t.Run(string(c.name)+c.input, func(t *testing.T) {
-			baseline, min, max := toIntWithRange(c.name, resource.MustParse(c.input))
+			resources := map[corev1.ResourceName]resource.Quantity{c.name: resource.MustParse(c.input)}
+			baseline, min, max := toIntWithRange(resources, c.name)
 			assert.Equal(t, c.baseline, baseline.IntVal, "baseline")
 			assert.Equal(t, c.min, min, "minimum")
 			assert.Equal(t, c.max, max, "maximum")

--- a/redskyctl/internal/commands/generate/experiment/containerresources_test.go
+++ b/redskyctl/internal/commands/generate/experiment/containerresources_test.go
@@ -58,14 +58,14 @@ func TestToIntWithRange(t *testing.T) {
 			name:     corev1.ResourceMemory,
 			input:    "64Mi",
 			baseline: 68,
-			min:      64,
+			min:      32,
 			max:      256,
 		},
 		{
 			name:     corev1.ResourceMemory,
 			input:    "128Mi",
 			baseline: 135,
-			min:      128,
+			min:      64,
 			max:      512,
 		},
 		{
@@ -93,14 +93,14 @@ func TestToIntWithRange(t *testing.T) {
 			name:     corev1.ResourceMemory,
 			input:    "4000Mi",
 			baseline: 4195,
-			min:      4096,
+			min:      2048,
 			max:      16384,
 		},
 		{
 			name:     corev1.ResourceMemory,
 			input:    "4000M",
 			baseline: 4000,
-			min:      2048,
+			min:      1024,
 			max:      8192,
 		},
 	}

--- a/redskyctl/internal/commands/generate/experiment/containerresources_test.go
+++ b/redskyctl/internal/commands/generate/experiment/containerresources_test.go
@@ -1,0 +1,127 @@
+/*
+ Copyright 2021 GramLabs, Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package experiment
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestToIntWithRange(t *testing.T) {
+	cases := []struct {
+		name     corev1.ResourceName
+		input    string
+		baseline int32
+		min      int32
+		max      int32
+	}{
+		{
+			name:     corev1.ResourceCPU,
+			input:    "0.1",
+			baseline: 100,
+			min:      50,
+			max:      200,
+		},
+		{
+			name:     corev1.ResourceCPU,
+			input:    "250m",
+			baseline: 250,
+			min:      125,
+			max:      500,
+		},
+		{
+			name:     corev1.ResourceCPU,
+			input:    "500m",
+			baseline: 500,
+			min:      250,
+			max:      1000,
+		},
+		{
+			name:     corev1.ResourceMemory,
+			input:    "64Mi",
+			baseline: 68,
+			min:      64,
+			max:      256,
+		},
+		{
+			name:     corev1.ResourceMemory,
+			input:    "128Mi",
+			baseline: 135,
+			min:      128,
+			max:      512,
+		},
+		{
+			name:     corev1.ResourceMemory,
+			input:    "64M",
+			baseline: 64,
+			min:      32,
+			max:      128,
+		},
+		{
+			name:     corev1.ResourceMemory,
+			input:    "128M",
+			baseline: 128,
+			min:      64,
+			max:      256,
+		},
+		{
+			name:     corev1.ResourceCPU,
+			input:    "4.0",
+			baseline: 4000,
+			min:      2000,
+			max:      8000,
+		},
+		{
+			name:     corev1.ResourceMemory,
+			input:    "4000Mi",
+			baseline: 4195,
+			min:      4096,
+			max:      16384,
+		},
+		{
+			name:     corev1.ResourceMemory,
+			input:    "4000M",
+			baseline: 4000,
+			min:      2048,
+			max:      8192,
+		},
+	}
+	for _, c := range cases {
+		t.Run(string(c.name)+c.input, func(t *testing.T) {
+			baseline, min, max := toIntWithRange(c.name, resource.MustParse(c.input))
+			assert.Equal(t, c.baseline, baseline.IntVal, "baseline")
+			assert.Equal(t, c.min, min, "minimum")
+			assert.Equal(t, c.max, max, "maximum")
+
+			// Check the value against what we are going to render into the template
+			switch c.name {
+			case corev1.ResourceMemory:
+				inputValue := resource.MustParse(c.input)
+				templateValue := resource.MustParse(fmt.Sprintf("%dM", baseline.IntVal))
+				assert.Equal(t, inputValue.ScaledValue(resource.Mega), templateValue.ScaledValue(resource.Mega))
+			case corev1.ResourceCPU:
+				inputValue := resource.MustParse(c.input)
+				templateValue := resource.MustParse(fmt.Sprintf("%dm", baseline.IntVal))
+				assert.Equal(t, inputValue.ScaledValue(resource.Milli), templateValue.ScaledValue(resource.Milli))
+			}
+		})
+	}
+}

--- a/redskyctl/internal/commands/generate/experiment/containerresources_test.go
+++ b/redskyctl/internal/commands/generate/experiment/containerresources_test.go
@@ -1,17 +1,17 @@
 /*
- Copyright 2021 GramLabs, Inc.
+Copyright 2021 GramLabs, Inc.
 
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 package experiment
@@ -99,6 +99,20 @@ func TestToIntWithRange(t *testing.T) {
 		{
 			name:     corev1.ResourceMemory,
 			input:    "4000M",
+			baseline: 4000,
+			min:      1024,
+			max:      8192,
+		},
+		{
+			name:     corev1.ResourceMemory,
+			input:    "4Gi",
+			baseline: 4295,
+			min:      2048,
+			max:      16384,
+		},
+		{
+			name:     corev1.ResourceMemory,
+			input:    "4G",
 			baseline: 4000,
 			min:      1024,
 			max:      8192,

--- a/redskyctl/internal/commands/generate/experiment/containerresources_test.go
+++ b/redskyctl/internal/commands/generate/experiment/containerresources_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 GramLabs, Inc.
+Copyright 2020 GramLabs, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/redskyctl/internal/commands/generate/experiment/containerresources_test.go
+++ b/redskyctl/internal/commands/generate/experiment/containerresources_test.go
@@ -44,8 +44,15 @@ func TestToIntWithRange(t *testing.T) {
 			name:     corev1.ResourceCPU,
 			input:    "250m",
 			baseline: 250,
-			min:      125,
+			min:      120,
 			max:      500,
+		},
+		{
+			name:     corev1.ResourceCPU,
+			input:    "2505m",
+			baseline: 2505,
+			min:      1250,
+			max:      5020,
 		},
 		{
 			name:     corev1.ResourceCPU,

--- a/redskyctl/internal/commands/generate/experiment/replicas.go
+++ b/redskyctl/internal/commands/generate/experiment/replicas.go
@@ -154,6 +154,16 @@ func (r *applicationResource) replicasParameters(name nameGen) []redskyv1beta1.P
 		baselineReplicas := intstr.FromInt(int(r.replicas[i]))
 		var minReplicas, maxReplicas int32 = 1, 5
 
+		// Do not explicitly enable something that was disabled
+		if baselineReplicas.IntVal <= 0 {
+			continue
+		}
+
+		// Only adjust the max replica count if necessary
+		if baselineReplicas.IntVal > maxReplicas {
+			maxReplicas = baselineReplicas.IntVal
+		}
+
 		parameters = append(parameters, redskyv1beta1.Parameter{
 			Name:     name(&r.targetRef, r.replicaPaths[i], "replicas"),
 			Min:      minReplicas,


### PR DESCRIPTION
The current experiment generation logic uses a fixed parameter range. It is possible that this will produce an invalid experiment if the baseline value falls outside the the fixed range.

This change adjusts the fixed range when a baseline value is present, see the test for examples.