### PR TITLE
fix: Remove CrashBackoffLoop from pod checks

### DIFF
--- a/internal/ready/ready_test.go
+++ b/internal/ready/ready_test.go
@@ -126,6 +126,41 @@ func TestReadinessChecker_CheckConditions(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc:           "pod-status-not-ready",
+			conditionTypes: []string{ConditionTypePodReady},
+			ready:          false,
+			err: &ReadinessError{
+				Reason: "Error",
+				error:  "container error",
+			},
+			objs: []runtime.Object{
+				&appsv1.StatefulSet{
+					Spec: appsv1.StatefulSetSpec{
+						Selector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"test": "test"},
+						},
+					},
+				},
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"test": "test"}},
+					Spec: corev1.PodSpec{
+						RestartPolicy: corev1.RestartPolicyNever,
+					},
+					Status: corev1.PodStatus{
+						ContainerStatuses: []corev1.ContainerStatus{
+							{
+								State: corev1.ContainerState{
+									Terminated: &corev1.ContainerStateTerminated{
+										Reason: "Error",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	ctx := context.TODO()

--- a/internal/ready/ready_test.go
+++ b/internal/ready/ready_test.go
@@ -161,6 +161,41 @@ func TestReadinessChecker_CheckConditions(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc:           "container-oom",
+			conditionTypes: []string{ConditionTypePodReady},
+			ready:          false,
+			err: &ReadinessError{
+				Reason: "OOMKilled",
+				error:  "container error",
+			},
+			objs: []runtime.Object{
+				&appsv1.StatefulSet{
+					Spec: appsv1.StatefulSetSpec{
+						Selector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"test": "test"},
+						},
+					},
+				},
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"test": "test"}},
+					Spec: corev1.PodSpec{
+						RestartPolicy: corev1.RestartPolicyNever,
+					},
+					Status: corev1.PodStatus{
+						ContainerStatuses: []corev1.ContainerStatus{
+							{
+								LastTerminationState: corev1.ContainerState{
+									Terminated: &corev1.ContainerStateTerminated{
+										Reason: "OOMKilled",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	ctx := context.TODO()


### PR DESCRIPTION
This fixes an issue where we might misidentify a failing pod and fail a trial.

One scenario happens when a previous pod is in a CrashLoopBackOff state. If a new
pod does not come up healthy in time we check the pod status, we would trigger
this as a hard failure and cause the trial to fail.

Another scenario happens when a pod relies on the platform to handle dependencies
being available. If PodA checks for ServiceBs availability during startup and
terminates if ServiceB is unavailable, kubernetes will mark this pod as
being stuck in a CrashLoopBackOff.

Signed-off-by: Brad Beam <brad.beam@stormforge.io>