### PR TITLE
Include resources

### DIFF
--- a/redskyctl/internal/commands/generate/experiment.go
+++ b/redskyctl/internal/commands/generate/experiment.go
@@ -43,6 +43,8 @@ type ExperimentOptions struct {
 	Resources  []string
 	Scenario   string
 	Objectives []string
+
+	IncludeResources bool
 }
 
 // Other possible options:
@@ -76,6 +78,7 @@ func NewExperimentCommand(o *ExperimentOptions) *cobra.Command {
 	cmd.Flags().StringArrayVarP(&o.Resources, "resources", "r", nil, "additional resources to consider")
 	cmd.Flags().StringVarP(&o.Scenario, "scenario", "s", o.Scenario, "the application scenario to generate an experiment for")
 	cmd.Flags().StringArrayVar(&o.Objectives, "objectives", o.Objectives, "the application objectives to generate an experiment for")
+	cmd.Flags().BoolVar(&o.IncludeResources, "include-resources", false, "include the application resources in the output")
 
 	_ = cmd.MarkFlagRequired("filename")
 	_ = cmd.MarkFlagFilename("filename", "yml", "yaml")
@@ -86,6 +89,7 @@ func NewExperimentCommand(o *ExperimentOptions) *cobra.Command {
 
 func (o *ExperimentOptions) generate() error {
 	g := experiment.NewGenerator(filesys.MakeFsOnDisk())
+	g.IncludeApplicationResources = o.IncludeResources
 
 	if o.Filename != "" {
 		r, err := o.IOStreams.OpenFile(o.Filename)

--- a/redskyctl/internal/commands/generate/experiment.go
+++ b/redskyctl/internal/commands/generate/experiment.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"path/filepath"
 	"strings"
+	"unicode"
 
 	"github.com/spf13/cobra"
 	"github.com/thestormforge/konjure/pkg/konjure"
@@ -169,19 +170,46 @@ func (o *ExperimentOptions) defaultNamespace() string {
 }
 
 func (o *ExperimentOptions) defaultName() string {
-	// Use the working directory
-	filename := o.Filename
-	if filename == "" || filepath.Dir(filename) == "/dev/fd" {
-		filename = "./default"
-	}
-
-	// Use the directory name
-	if af, err := filepath.Abs(filename); err == nil {
-		if d := filepath.Base(filepath.Dir(af)); d != "." && d != "/" {
-			return d
+	var d, f = o.Filename, ""
+	for {
+		// Split the path, discard everything if this was a file descriptor path
+		d, f = filepath.Split(d)
+		if d == "/dev/fd/" {
+			d, f = "", ""
 		}
-	}
 
-	// We cannot return empty, use default
-	return "default"
+		// Trim the first extension
+		f = strings.TrimSuffix(f, filepath.Ext(f))
+
+		// https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names
+		f = strings.Map(dnsSubdomainChars, f)
+		f = strings.Trim(f, "-.")
+		if len(f) > 253 {
+			f = f[0:253]
+		}
+
+		// If the name is good, return it
+		if f != "" && f != "application" && f != "app" {
+			return f
+		}
+
+		// Ensure the directory is an absolute path for remaining iterations
+		ad, err := filepath.Abs(d)
+		if err != nil || d == "/" {
+			return "default"
+		}
+
+		// Walk up the tree
+		d = ad
+	}
+}
+
+func dnsSubdomainChars(r rune) rune {
+	if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' || r == '.' {
+		return r
+	}
+	if r >= 'A' && r <= 'Z' {
+		return unicode.ToLower(r)
+	}
+	return -1
 }

--- a/redskyctl/internal/commands/generate/experiment_test.go
+++ b/redskyctl/internal/commands/generate/experiment_test.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2021 GramLabs, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generate
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExperimentOptions_DefaultName(t *testing.T) {
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	dir := strings.ToLower(filepath.Base(wd))
+
+	cases := []struct {
+		filename string
+		expected string
+	}{
+		{
+			filename: "",
+			expected: dir,
+		},
+		{
+			filename: "/dev/fd/3",
+			expected: dir,
+		},
+		{
+			filename: "app.yaml",
+			expected: dir,
+		},
+		{
+			filename: "application.yaml",
+			expected: dir,
+		},
+		{
+			filename: "foo/app.yml",
+			expected: "foo",
+		},
+		{
+			filename: "/foo/bar/app.yml",
+			expected: "bar",
+		},
+		{
+			filename: "/foo/bar/application.yaml",
+			expected: "bar",
+		},
+		{
+			filename: "/foo/bar/my-application.yaml",
+			expected: "my-application",
+		},
+		{
+			filename: "/foo/bar/my-app.yaml",
+			expected: "my-app",
+		},
+		{
+			filename: "/foo/bar/x&#$@z.yaml",
+			expected: "xz",
+		},
+		{
+			filename: "foo-.-.-.-.yml",
+			expected: "foo",
+		},
+		{
+			filename: "/app.yaml",
+			expected: "default",
+		},
+		{
+			filename: "/app/application/app.yaml",
+			expected: "default",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.filename, func(t *testing.T) {
+			actual := (&ExperimentOptions{Filename: c.filename}).defaultName()
+			assert.Equal(t, c.expected, actual)
+		})
+	}
+}

--- a/redskyctl/internal/commands/generate/experiment_test.go
+++ b/redskyctl/internal/commands/generate/experiment_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 GramLabs, Inc.
+Copyright 2020 GramLabs, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Allow application resources to be emitted when generating experiments. Also, the application definition file isn't actually required.