### PR TITLE
New application command

### DIFF
--- a/api/apps/v1alpha1/well_known_labels.go
+++ b/api/apps/v1alpha1/well_known_labels.go
@@ -24,4 +24,7 @@ const (
 
 	// LabelScenario is the application scenario associated with an object.
 	LabelScenario = "redskyops.dev/scenario"
+
+	// AnnotationLastScanned is the timestamp of the last application scan.
+	AnnotationLastScanned = "apps.stormforge.io/last-scanned"
 )

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1
-	github.com/thestormforge/konjure v0.3.0-beta.4
+	github.com/thestormforge/konjure v0.3.0-beta.5
 	github.com/thestormforge/optimize-go v0.0.8
 	github.com/yujunz/go-getter v1.5.1-lite.0.20201201013212-6d9c071adddf
 	github.com/zorkian/go-datadog-api v2.24.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -624,8 +624,8 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
-github.com/thestormforge/konjure v0.3.0-beta.4 h1:G4KQIsvvLDWiKNz3rVBcDUGApYsLENzMWQMriN9fNB8=
-github.com/thestormforge/konjure v0.3.0-beta.4/go.mod h1:8gIqMRKShWB7ejEA+JCN8DUeeDe9CTIc3eXyniFdNj8=
+github.com/thestormforge/konjure v0.3.0-beta.5 h1:WHZECa4ea9Y86BIjsk0kqqNXlFZOxeOTx5sljYM8xks=
+github.com/thestormforge/konjure v0.3.0-beta.5/go.mod h1:8gIqMRKShWB7ejEA+JCN8DUeeDe9CTIc3eXyniFdNj8=
 github.com/thestormforge/optimize-go v0.0.8 h1:nIdz5pSz00eHzBS8Ueti3xmNP9MB9l15/NTob6k6Whg=
 github.com/thestormforge/optimize-go v0.0.8/go.mod h1:ZWRi49lIlw4g3JyP9Aog+zQI/rb7+81HOyHcccVqnfU=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=

--- a/internal/application/application.go
+++ b/internal/application/application.go
@@ -23,8 +23,8 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/thestormforge/konjure/pkg/konjure"
 	"github.com/thestormforge/optimize-controller/api/apps/v1alpha1"
+	"github.com/thestormforge/optimize-controller/internal/scan"
 	"sigs.k8s.io/kustomize/api/filesys"
 	"sigs.k8s.io/kustomize/api/provider"
 	"sigs.k8s.io/kustomize/api/resmap"
@@ -175,10 +175,13 @@ func (e *AmbiguousNameError) Error() string {
 // LoadResources loads all of the resources for an application, using the supplied file system
 // to load file based resources (if necessary).
 func LoadResources(app *v1alpha1.Application, _ filesys.FileSystem) (resmap.ResMap, error) {
+	kf := scan.NewKonjureFilter(nil)
+	kf.KeepStatus = false
+
 	var buf bytes.Buffer
 	err := kio.Pipeline{
 		Inputs:  []kio.Reader{app.Resources},
-		Filters: []kio.Filter{&konjure.Filter{Depth: 100}},
+		Filters: []kio.Filter{kf},
 		Outputs: []kio.Writer{&kio.ByteWriter{Writer: &buf}},
 	}.Execute()
 	if err != nil {

--- a/internal/application/documentation.go
+++ b/internal/application/documentation.go
@@ -107,7 +107,7 @@ func (f *DocumentationFilter) annotateApplication(app *yaml.RNode) error {
 
 	// Each key and value are elements in the content list, iterate over even indices
 	var content []*yaml.Node
-	for i := 0; i < len(n.Content); i = i + 2 {
+	for i := 0; i < len(n.Content); i = yaml.IncrementFieldIndex(i) {
 		n.Content[i].HeadComment = headComments[n.Content[i].Value]
 		content = append(content, missingRequiredContent(n.Content[i].Value, required)...)
 		content = append(content, n.Content[i], n.Content[i+1])

--- a/internal/application/documentation.go
+++ b/internal/application/documentation.go
@@ -102,6 +102,7 @@ func (f *DocumentationFilter) annotateApplication(app *yaml.RNode) error {
 		"parameters": "resources",
 		"scenarios":  "parameters",
 		"objectives": "scenarios",
+		"":           "objectives",
 	}
 
 	// Each key and value are elements in the content list, iterate over even indices
@@ -111,7 +112,9 @@ func (f *DocumentationFilter) annotateApplication(app *yaml.RNode) error {
 		content = append(content, missingRequiredContent(n.Content[i].Value, required)...)
 		content = append(content, n.Content[i], n.Content[i+1])
 	}
-	n.Content = content
+
+	// Make sure all the required content has been produced
+	n.Content = append(content, missingRequiredContent("", required)...)
 
 	return nil
 }

--- a/internal/application/documentation.go
+++ b/internal/application/documentation.go
@@ -29,28 +29,27 @@ import (
 var headComments = map[string]string{
 
 	"resources": `
-Resources define where you application's Kubernetes resources come from. These can be URL-like
-values such as file paths, HTTP URLs, or Git repository URLs. They can also be more complex
-definitions such references to in-cluster objects or Helm charts.
+Resources define where you application's Kubernetes resources come from. These
+can be URL-like values such as file paths, HTTP URLs, or Git repository URLs.
+They can also be more complex definitions such references to in-cluster objects
+or Helm charts.
 `,
 
 	"parameters": `
 Parameters control what parts of you application will be optimized.
-
 Reference: https://docs.stormforge.io/reference/application/v1alpha1/#parameters
 `,
 
 	"scenarios": `
-Scenarios determine how you application will be put under load during optimization.
-
+Scenarios determine how you application will be put under load during
+optimization.
 Reference: https://docs.stormforge.io/reference/application/v1alpha1/#scenario
 `,
 
 	"objectives": `
-Objectives are used to define what you are trying to optimize about your application. Most
-objectives correspond to metrics observed over the course of an observation trial, for
-example: "p95-latency".
-
+Objectives are used to define what you are trying to optimize about your
+application. Most objectives correspond to metrics observed over the course of
+an observation trial, for example: "p95-latency".
 Reference: https://docs.stormforge.io/reference/application/v1alpha1/#objective
 `,
 }
@@ -108,7 +107,7 @@ func (f *DocumentationFilter) annotateApplication(app *yaml.RNode) error {
 	// Each key and value are elements in the content list, iterate over even indices
 	var content []*yaml.Node
 	for i := 0; i < len(n.Content); i = i + 2 {
-		n.Content[i].HeadComment = softWrap(headComments[n.Content[i].Value], 80)
+		n.Content[i].HeadComment = headComments[n.Content[i].Value]
 		content = append(content, missingRequiredContent(n.Content[i].Value, required)...)
 		content = append(content, n.Content[i], n.Content[i+1])
 	}
@@ -145,7 +144,7 @@ func missingRequiredContent(key string, required map[string]string) []*yaml.Node
 		Kind:        yaml.ScalarNode,
 		Tag:         yaml.NodeTagString,
 		Value:       req,
-		HeadComment: softWrap(headComments[req], 80),
+		HeadComment: headComments[req],
 	})
 
 	// Add an empty value
@@ -166,35 +165,4 @@ func missingRequiredContent(key string, required map[string]string) []*yaml.Node
 	}
 
 	return result
-}
-
-// softWrap is a naive wrapper that really doesn't try very hard.
-func softWrap(comment string, width int) string {
-	if len(comment) <= width {
-		return comment
-	}
-
-	// Preserve leading newlines
-	var lines []string
-	if strings.HasPrefix(comment, "\n") {
-		lines = append(lines, "")
-	}
-
-	// Split the comment into "words" (simple English words) and re-join around the width
-	var words []string
-	for _, word := range strings.Fields(comment) {
-		if line := strings.Join(words, " "); len(line) >= width {
-			lines = append(lines, line)
-			words = nil
-		}
-
-		words = append(words, word)
-	}
-
-	// Don't leave anything behind
-	if len(words) > 0 {
-		lines = append(lines, strings.Join(words, " "))
-	}
-
-	return strings.Join(lines, "\n")
 }

--- a/internal/application/documentation.go
+++ b/internal/application/documentation.go
@@ -1,0 +1,191 @@
+/*
+Copyright 2021 GramLabs, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package application
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	redskyappsv1alpha1 "github.com/thestormforge/optimize-controller/api/apps/v1alpha1"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+// headComments is the mapping of field names to desired comments.
+var headComments = map[string]string{
+	"resources": `
+Resources define where you application's Kubernetes resources come from. These can be URL-like
+values such as file paths, HTTP URLs, or Git repository URLs. They can also be more complex
+definitions such references to in-cluster objects or Helm charts.
+`,
+	"parameters": `
+Parameters control what parts of you application will be optimized.
+
+Reference: https://docs.stormforge.io/reference/application/v1alpha1/#parameters
+`,
+	"scenarios": `
+Scenarios determine how you application will be put under load during optimization.
+
+Reference: https://docs.stormforge.io/reference/application/v1alpha1/#scenario
+`,
+	"objectives": `
+Objectives are used to define what you are trying to optimize about your application. Most
+objectives correspond to metrics observed over the course of an observation trial, for
+example: "p95-latency".
+
+Reference: https://docs.stormforge.io/reference/application/v1alpha1/#objective
+`,
+}
+
+// DocumentationFilter looks for Application instances and attempts to annotate them
+// with comments that might help people finish writing their app.yaml.
+type DocumentationFilter struct {
+	// Flag to completely disable documentation.
+	Disabled bool
+}
+
+// Filter applies documentation to any applications in the supplied node set.
+func (f *DocumentationFilter) Filter(nodes []*yaml.RNode) ([]*yaml.RNode, error) {
+	if f.Disabled {
+		return nodes, nil
+	}
+
+	for _, n := range nodes {
+		meta, err := n.GetMeta()
+		if err != nil {
+			continue
+		}
+
+		if meta.Kind != "Application" || meta.APIVersion != redskyappsv1alpha1.GroupVersion.String() {
+			continue
+		}
+
+		if err := f.annotateApplication(n); err != nil {
+			return nil, err
+		}
+	}
+
+	return nodes, nil
+}
+
+// annotateApplication documents a single application.
+func (f *DocumentationFilter) annotateApplication(app *yaml.RNode) error {
+	n := app.YNode()
+
+	// Reminder about how the file was generated
+	if len(os.Args) >= 3 && filepath.Base(os.Args[0]) == "redskyctl" {
+		n.HeadComment = strings.Join(os.Args, " ")
+	}
+
+	// Required is map of field name to required preceding field name
+	// This is used to ensure even empty (and otherwise omitted) fields can be
+	// included for documentation purposes.
+	required := map[string]string{
+		"resources":  "",
+		"parameters": "resources",
+		"scenarios":  "parameters",
+		"objectives": "scenarios",
+	}
+
+	// Each key and value are elements in the content list, iterate over even indices
+	var content []*yaml.Node
+	for i := 0; i < len(n.Content); i = i + 2 {
+		n.Content[i].HeadComment = softWrap(headComments[n.Content[i].Value], 80)
+		content = append(content, missingRequiredContent(n.Content[i].Value, required)...)
+		content = append(content, n.Content[i], n.Content[i+1])
+	}
+	n.Content = content
+
+	return nil
+}
+
+func missingRequiredContent(key string, required map[string]string) []*yaml.Node {
+	// As soon as we encounter a key, remove it so it does not get double added
+	for k, v := range required {
+		if v == key {
+			delete(required, k)
+		}
+	}
+
+	// Check if there is any required content for the key
+	req := required[key]
+	if req == "" {
+		return nil
+	}
+
+	// Recursively include missing content first
+	var result []*yaml.Node
+	result = append(result, missingRequiredContent(req, required)...)
+
+	// Add field name with the appropriate head comment
+	result = append(result, &yaml.Node{
+		Kind:        yaml.ScalarNode,
+		Tag:         yaml.NodeTagString,
+		Value:       req,
+		HeadComment: softWrap(headComments[req], 80),
+	})
+
+	// Add an empty value
+	switch req {
+	case "parameters":
+		result = append(result, &yaml.Node{
+			Kind:  yaml.MappingNode,
+			Style: yaml.FoldedStyle,
+			Tag:   yaml.NodeTagMap,
+		})
+
+	default:
+		result = append(result, &yaml.Node{
+			Kind:  yaml.SequenceNode,
+			Style: yaml.FoldedStyle,
+			Tag:   yaml.NodeTagSeq,
+		})
+	}
+
+	return result
+}
+
+// softWrap is a naive wrapper that really doesn't try very hard.
+func softWrap(comment string, width int) string {
+	if len(comment) <= width {
+		return comment
+	}
+
+	// Preserve leading newlines
+	var lines []string
+	if strings.HasPrefix(comment, "\n") {
+		lines = append(lines, "")
+	}
+
+	// Split the comment into "words" (simple English words) and re-join around the width
+	var words []string
+	for _, word := range strings.Fields(comment) {
+		if line := strings.Join(words, " "); len(line) >= width {
+			lines = append(lines, line)
+			words = nil
+		}
+
+		words = append(words, word)
+	}
+
+	// Don't leave anything behind
+	if len(words) > 0 {
+		lines = append(lines, strings.Join(words, " "))
+	}
+
+	return strings.Join(lines, "\n")
+}

--- a/internal/application/documentation.go
+++ b/internal/application/documentation.go
@@ -27,21 +27,25 @@ import (
 
 // headComments is the mapping of field names to desired comments.
 var headComments = map[string]string{
+
 	"resources": `
 Resources define where you application's Kubernetes resources come from. These can be URL-like
 values such as file paths, HTTP URLs, or Git repository URLs. They can also be more complex
 definitions such references to in-cluster objects or Helm charts.
 `,
+
 	"parameters": `
 Parameters control what parts of you application will be optimized.
 
 Reference: https://docs.stormforge.io/reference/application/v1alpha1/#parameters
 `,
+
 	"scenarios": `
 Scenarios determine how you application will be put under load during optimization.
 
 Reference: https://docs.stormforge.io/reference/application/v1alpha1/#scenario
 `,
+
 	"objectives": `
 Objectives are used to define what you are trying to optimize about your application. Most
 objectives correspond to metrics observed over the course of an observation trial, for
@@ -91,7 +95,7 @@ func (f *DocumentationFilter) annotateApplication(app *yaml.RNode) error {
 		n.HeadComment = strings.Join(os.Args, " ")
 	}
 
-	// Required is map of field name to required preceding field name
+	// Required is a map of field name to required preceding field name.
 	// This is used to ensure even empty (and otherwise omitted) fields can be
 	// included for documentation purposes.
 	required := map[string]string{
@@ -113,6 +117,11 @@ func (f *DocumentationFilter) annotateApplication(app *yaml.RNode) error {
 	return nil
 }
 
+// missingRequiredContent adds top level fields which may have been empty and therefore
+// emitted during the initial Go to YAML encoding process. The supplied map is used
+// to track which fields have already been encountered and which fields must precede
+// the current field (identified by "key"). The resulting list of nodes are suitable
+// for inclusion in the content of a mapping node.
 func missingRequiredContent(key string, required map[string]string) []*yaml.Node {
 	// As soon as we encounter a key, remove it so it does not get double added
 	for k, v := range required {

--- a/internal/application/generator.go
+++ b/internal/application/generator.go
@@ -42,11 +42,7 @@ func (g *Generator) Execute(output kio.Writer) error {
 	return kio.Pipeline{
 		Inputs: []kio.Reader{g.Resources},
 		Filters: []kio.Filter{
-			&konjure.Filter{
-				Depth:         100,
-				DefaultReader: g.DefaultReader,
-				KeepStatus:    true,
-			},
+			scan.NewKonjureFilter(g.DefaultReader),
 			&scan.Scanner{
 				Selectors:   []scan.Selector{g},
 				Transformer: g,

--- a/internal/application/generator.go
+++ b/internal/application/generator.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2021 GramLabs, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package application
+
+import (
+	"io"
+
+	"github.com/thestormforge/konjure/pkg/konjure"
+	redskyappsv1alpha1 "github.com/thestormforge/optimize-controller/api/apps/v1alpha1"
+	"github.com/thestormforge/optimize-controller/internal/scan"
+	"sigs.k8s.io/kustomize/kyaml/kio"
+	"sigs.k8s.io/kustomize/kyaml/kio/filters"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+type Generator struct {
+	Name          string
+	Resources     konjure.Resources
+	Objectives    []string
+	DefaultReader io.Reader
+}
+
+func (g *Generator) Execute(output kio.Writer) error {
+	return kio.Pipeline{
+		Inputs: []kio.Reader{g.Resources},
+		Filters: []kio.Filter{
+			&konjure.Filter{
+				Depth:         100,
+				DefaultReader: g.DefaultReader,
+				KeepStatus:    true,
+			},
+			&scan.Scanner{
+				Selectors:   []scan.Selector{g},
+				Transformer: g,
+			},
+			kio.FilterAll(yaml.Clear("status")),
+			&filters.FormatFilter{UseSchema: true},
+		},
+		Outputs:               []kio.Writer{output},
+		ContinueOnEmptyResult: true,
+	}.Execute()
+}
+
+// Select keeps all of the input resources.
+func (g *Generator) Select(nodes []*yaml.RNode) ([]*yaml.RNode, error) {
+	// TODO Should we limit this only to types we can actually get information from?
+	return nodes, nil
+}
+
+func (g *Generator) Map(node *yaml.RNode, meta yaml.ResourceMeta) ([]interface{}, error) {
+	return nil, nil
+}
+
+func (g *Generator) Transform(_ []*yaml.RNode, selected []interface{}) ([]*yaml.RNode, error) {
+	result := scan.ObjectSlice{}
+
+	app := &redskyappsv1alpha1.Application{
+		Resources: g.Resources,
+	}
+
+	for _, o := range g.Objectives {
+		app.Objectives = append(app.Objectives, redskyappsv1alpha1.Objective{Name: o})
+	}
+
+	if g.Name != "" {
+		app.Name = g.Name
+	}
+
+	result = append(result, app)
+	return result.Read()
+}

--- a/internal/application/generator.go
+++ b/internal/application/generator.go
@@ -34,6 +34,7 @@ type Generator struct {
 	Name          string
 	Resources     konjure.Resources
 	Objectives    []string
+	Documentation DocumentationFilter
 	DefaultReader io.Reader
 }
 
@@ -51,8 +52,8 @@ func (g *Generator) Execute(output kio.Writer) error {
 				Transformer: g,
 			},
 			kio.FilterAll(yaml.Clear("status")),
-			// TODO We should have an optional filter that annotates the application with comments
 			&filters.FormatFilter{UseSchema: true},
+			&g.Documentation, // Documentation is added last so everything is sorted
 		},
 		Outputs:               []kio.Writer{output},
 		ContinueOnEmptyResult: true,

--- a/internal/experiment/generation/transformer.go
+++ b/internal/experiment/generation/transformer.go
@@ -72,7 +72,7 @@ type Transformer struct {
 
 var _ scan.Transformer = &Transformer{}
 
-func (t *Transformer) Filter(nodes []*yaml.RNode, selected []interface{}) ([]*yaml.RNode, error) {
+func (t *Transformer) Transform(nodes []*yaml.RNode, selected []interface{}) ([]*yaml.RNode, error) {
 	var result []*yaml.RNode
 
 	// Parameter names need to be computed based on what resources were selected by the scan

--- a/internal/experiment/generator.go
+++ b/internal/experiment/generator.go
@@ -19,7 +19,6 @@ package experiment
 import (
 	"io"
 
-	"github.com/thestormforge/konjure/pkg/konjure"
 	redskyappsv1alpha1 "github.com/thestormforge/optimize-controller/api/apps/v1alpha1"
 	"github.com/thestormforge/optimize-controller/internal/application"
 	"github.com/thestormforge/optimize-controller/internal/experiment/generation"
@@ -108,11 +107,7 @@ func (g *Generator) Execute(output kio.Writer) error {
 			g.Application.Resources,
 		},
 		Filters: []kio.Filter{
-			&konjure.Filter{
-				Depth:         100,
-				DefaultReader: g.DefaultReader,
-				KeepStatus:    true,
-			},
+			scan.NewKonjureFilter(g.DefaultReader),
 			g.newScannerFilter(),
 			&generation.ApplicationFilter{Application: &g.Application},
 			kio.FilterAll(yaml.Clear("status")),

--- a/internal/scan/filter.go
+++ b/internal/scan/filter.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2021 GramLabs, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scan
+
+import (
+	"io"
+	"os/exec"
+
+	"github.com/thestormforge/konjure/pkg/konjure"
+	"sigs.k8s.io/kustomize/api/filesys"
+	"sigs.k8s.io/kustomize/api/konfig"
+	"sigs.k8s.io/kustomize/api/krusty"
+	"sigs.k8s.io/kustomize/api/types"
+)
+
+// NewKonjureFilter creates a new Konjure filter with the default settings
+// for this project. The supplied default reader is used when the "-" is requested.
+func NewKonjureFilter(defaultReader io.Reader) *konjure.Filter {
+	return &konjure.Filter{
+		Depth:         100,
+		DefaultReader: defaultReader,
+		KeepStatus:    true,
+
+		// Override the default behaviors for execution
+		KubectlExecutor:   kubectl,
+		KustomizeExecutor: kustomize,
+	}
+}
+
+func kubectl(cmd *exec.Cmd) ([]byte, error) {
+	// TODO We can use the Kube API to handle `kubectl get`, we may need pflags to help
+	return cmd.Output()
+}
+
+func kustomize(cmd *exec.Cmd) ([]byte, error) {
+	// If the command path is absolute, it was found by LookPath. In this
+	// case we will just fork so the embedded version of Kustomize does not
+	// becoming a limiting factor.
+
+	// We are only handling the very specific case of `kustomize build X`
+	if len(cmd.Args) != 3 || cmd.Path != "kustomize" || cmd.Args[1] != "build" {
+		return cmd.Output()
+	}
+
+	// Restrict to disk access to be consistent with the flow when we fork
+	fs := filesys.MakeFsOnDisk()
+
+	// Create Krusty options: be sure to disable KYAML as we don't want to accidentally
+	// invoke code paths in which we have created problems due to dependencies
+	opts := &krusty.Options{
+		UseKyaml:         false,
+		LoadRestrictions: types.LoadRestrictionsNone,
+		PluginConfig:     konfig.DisabledPluginConfig(),
+	}
+
+	// Run the Kustomization in process
+	rm, err := krusty.MakeKustomizer(fs, opts).Run(cmd.Args[1])
+	if err != nil {
+		return nil, err
+	}
+
+	return rm.AsYaml()
+}

--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -32,7 +32,7 @@ type Selector interface {
 // turns them back into resource nodes. The original resource nodes used
 // to generate the inputs are also made available.
 type Transformer interface {
-	Filter(nodes []*yaml.RNode, selected []interface{}) ([]*yaml.RNode, error)
+	Transform(nodes []*yaml.RNode, selected []interface{}) ([]*yaml.RNode, error)
 }
 
 // Scanner is used to map resource nodes to an intermediate type and back to
@@ -74,5 +74,5 @@ func (s *Scanner) Filter(nodes []*yaml.RNode) ([]*yaml.RNode, error) {
 		}
 	}
 
-	return s.Transformer.Filter(nodes, selected)
+	return s.Transformer.Transform(nodes, selected)
 }

--- a/redskyctl/internal/commands/generate/application.go
+++ b/redskyctl/internal/commands/generate/application.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2021 GramLabs, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generate
+
+import (
+	"github.com/spf13/cobra"
+	konjurev1beta2 "github.com/thestormforge/konjure/pkg/api/core/v1beta2"
+	"github.com/thestormforge/konjure/pkg/konjure"
+	"github.com/thestormforge/optimize-controller/internal/application"
+	"github.com/thestormforge/optimize-controller/redskyctl/internal/commander"
+	"github.com/thestormforge/optimize-go/pkg/config"
+	"sigs.k8s.io/kustomize/kyaml/kio"
+)
+
+type ApplicationOptions struct {
+	// Config is the Red Sky Configuration used to generate the application
+	Config *config.RedSkyConfig
+	// IOStreams are used to access the standard process streams
+	commander.IOStreams
+
+	Generator       application.Generator
+	Resources       []string
+	DefaultResource konjurev1beta2.Kubernetes
+}
+
+func NewApplicationCommand(o *ApplicationOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "application",
+		Short: "Generate an application",
+		Long:  "Generate an application descriptor",
+
+		PreRun: func(cmd *cobra.Command, args []string) {
+			commander.SetStreams(&o.IOStreams, cmd)
+			o.Generator.DefaultReader = cmd.InOrStdin()
+		},
+		RunE: commander.WithoutArgsE(o.generate),
+	}
+
+	cmd.Flags().StringVar(&o.Generator.Name, "name", "", "set the application `name`")
+	cmd.Flags().StringSliceVar(&o.Generator.Objectives, "objectives", []string{"p95-latency", "cost"}, "specify the application optimization `obj`ectives")
+	cmd.Flags().StringArrayVarP(&o.Resources, "resources", "r", nil, "additional resources to consider")
+	cmd.Flags().StringArrayVar(&o.DefaultResource.Namespaces, "namespace", nil, "select resources from a specific namespace")
+	cmd.Flags().StringVar(&o.DefaultResource.NamespaceSelector, "ns-selector", "", "`sel`ect resources from labeled namespaces")
+	cmd.Flags().StringVarP(&o.DefaultResource.LabelSelector, "selector", "l", "", "`sel`ect only labeled resources")
+
+	return cmd
+}
+
+func (o *ApplicationOptions) generate() error {
+	if len(o.Resources) > 0 {
+		// Add explicitly requested resources
+		o.Generator.Resources = append(o.Generator.Resources, konjure.NewResource(o.Resources...))
+	} else if o.DefaultResource.LabelSelector == "" && o.Generator.Name != "" {
+		// Add a default the label selector based on the name
+		o.DefaultResource.LabelSelector = "app.kubernetes.io/name=" + o.Generator.Name
+	}
+
+	// Only include the default resource if it has values
+	if !o.isDefaultResourceEmpty() {
+		o.Generator.Resources = append(o.Generator.Resources, konjure.Resource{Kubernetes: &o.DefaultResource})
+	}
+
+	// Generate the application
+	return o.Generator.Execute(&kio.ByteWriter{Writer: o.Out})
+}
+
+func (o *ApplicationOptions) isDefaultResourceEmpty() bool {
+	// TODO Should we check that `kubectl` is available and can return something meaningful?
+	return len(o.DefaultResource.Namespaces) == 0 &&
+		o.DefaultResource.NamespaceSelector == "" &&
+		len(o.DefaultResource.Types) == 0 &&
+		o.DefaultResource.LabelSelector == ""
+}

--- a/redskyctl/internal/commands/generate/application.go
+++ b/redskyctl/internal/commands/generate/application.go
@@ -17,6 +17,13 @@ limitations under the License.
 package generate
 
 import (
+	"bufio"
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
 	"github.com/spf13/cobra"
 	konjurev1beta2 "github.com/thestormforge/konjure/pkg/api/core/v1beta2"
 	"github.com/thestormforge/konjure/pkg/konjure"
@@ -75,6 +82,10 @@ func (o *ApplicationOptions) generate() error {
 		o.Generator.Resources = append(o.Generator.Resources, konjure.Resource{Kubernetes: &o.DefaultResource})
 	}
 
+	// Prefer Git resources if possible, this will make the resulting application more portable
+	// Note that using Git will be slower then if we just referenced the file system directly
+	o.preferGit()
+
 	// Generate the application
 	return o.Generator.Execute(&kio.ByteWriter{Writer: o.Out})
 }
@@ -85,4 +96,86 @@ func (o *ApplicationOptions) isDefaultResourceEmpty() bool {
 		o.DefaultResource.NamespaceSelector == "" &&
 		len(o.DefaultResource.Types) == 0 &&
 		o.DefaultResource.LabelSelector == ""
+}
+
+func (o *ApplicationOptions) preferGit() {
+	var resources []konjure.Resource
+	for _, r := range o.Generator.Resources {
+		switch {
+		case r.Resource != nil:
+			var resourceSpecs []string
+			for _, rr := range r.Resource.Resources {
+				if gr := o.asGitResource(rr); gr != nil {
+					resources = append(resources, konjure.Resource{Git: gr})
+					continue
+				}
+
+				resourceSpecs = append(resourceSpecs, rr)
+			}
+			if len(resourceSpecs) > 0 {
+				r.Resource.Resources = resourceSpecs
+				resources = append(resources, r)
+			}
+
+		default:
+			resources = append(resources, r)
+		}
+
+	}
+	o.Generator.Resources = resources
+}
+
+// asGitResource tests to see if the supplied path points to a Git resource. Git reference
+// will be more portable when recorded in an app.yaml file because they are not specific to
+// the current workstation.
+func (o *ApplicationOptions) asGitResource(path string) *konjurev1beta2.Git {
+	// These will fail in stat, may as well just save the call
+	for _, prefix := range []string{"http://", "https://", "git::", "git@"} {
+		if strings.HasPrefix(path, prefix) {
+			return nil
+		}
+	}
+
+	var dir, file = path, ""
+	if fi, err := os.Stat(dir); err != nil {
+		return nil
+	} else if !fi.IsDir() {
+		dir, file = filepath.Split(dir)
+	}
+
+	// Assume we only want this to work with origin
+	remote := runGit(dir, "remote", "get-url", "origin")
+	if len(remote) != 1 {
+		return nil
+	}
+
+	revParse := runGit(dir, "rev-parse", "--show-prefix", "--abbrev-ref", "HEAD")
+	if len(revParse) != 2 {
+		return nil
+	}
+	if revParse[1] == "master" {
+		revParse[1] = ""
+	}
+
+	return &konjurev1beta2.Git{
+		Repository: remote[0],
+		Refspec:    revParse[1],
+		Context:    revParse[0] + file,
+	}
+}
+
+func runGit(dir string, args ...string) []string {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		return nil
+	}
+
+	var lines []string
+	scanner := bufio.NewScanner(bytes.NewReader(out))
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+	return lines
 }

--- a/redskyctl/internal/commands/generate/application.go
+++ b/redskyctl/internal/commands/generate/application.go
@@ -52,6 +52,7 @@ func NewApplicationCommand(o *ApplicationOptions) *cobra.Command {
 
 	cmd.Flags().StringVar(&o.Generator.Name, "name", "", "set the application `name`")
 	cmd.Flags().StringSliceVar(&o.Generator.Objectives, "objectives", []string{"p95-latency", "cost"}, "specify the application optimization `obj`ectives")
+	cmd.Flags().BoolVar(&o.Generator.Documentation.Disabled, "no-comments", false, "suppress documentation comments on output")
 	cmd.Flags().StringArrayVarP(&o.Resources, "resources", "r", nil, "additional resources to consider")
 	cmd.Flags().StringArrayVar(&o.DefaultResource.Namespaces, "namespace", nil, "select resources from a specific namespace")
 	cmd.Flags().StringVar(&o.DefaultResource.NamespaceSelector, "ns-selector", "", "`sel`ect resources from labeled namespaces")

--- a/redskyctl/internal/commands/generate/experiment.go
+++ b/redskyctl/internal/commands/generate/experiment.go
@@ -29,7 +29,9 @@ import (
 	"github.com/thestormforge/optimize-controller/internal/experiment"
 	"github.com/thestormforge/optimize-controller/redskyctl/internal/commander"
 	"github.com/thestormforge/optimize-go/pkg/config"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/kustomize/kyaml/kio"
+	"sigs.k8s.io/kustomize/kyaml/kio/kioutil"
 )
 
 type ExperimentOptions struct {
@@ -92,6 +94,8 @@ func (o *ExperimentOptions) generate() error {
 		if err := rr.ReadInto(r, &o.Generator.Application); err != nil {
 			return err
 		}
+
+		metav1.SetMetaDataAnnotation(&o.Generator.Application.ObjectMeta, kioutil.PathAnnotation, o.Filename)
 	}
 
 	if err := o.filterResources(&o.Generator.Application); err != nil {

--- a/redskyctl/internal/commands/generate/generate.go
+++ b/redskyctl/internal/commands/generate/generate.go
@@ -42,6 +42,7 @@ func NewCommand(o *Options) *cobra.Command {
 	cmd.AddCommand(authorize_cluster.NewGeneratorCommand(&authorize_cluster.GeneratorOptions{Config: o.Config}))
 	cmd.AddCommand(grant_permissions.NewGeneratorCommand(&grant_permissions.GeneratorOptions{Config: o.Config}))
 	cmd.AddCommand(NewRBACCommand(&RBACOptions{Config: o.Config, ClusterRole: true, ClusterRoleBinding: true}))
+	cmd.AddCommand(NewApplicationCommand(&ApplicationOptions{Config: o.Config}))
 	cmd.AddCommand(NewExperimentCommand(&ExperimentOptions{Config: o.Config}))
 	cmd.AddCommand(NewTrialCommand(&TrialOptions{}))
 


### PR DESCRIPTION
This code adds a minimal "new application" command for scaffolding an app.yaml from the CLI.

At this point, the command really just helps populating the "resources" section. I think we can improve it to so it adds YAML comments to the output and maybe a few other nice to haves. This generator does take a pass over the actual resources so we may be able to get some additional information.