### PR TITLE
Fix relative paths

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1
-	github.com/thestormforge/konjure v0.3.0-beta.5
+	github.com/thestormforge/konjure v0.3.0-beta.6
 	github.com/thestormforge/optimize-go v0.0.8
 	github.com/yujunz/go-getter v1.5.1-lite.0.20201201013212-6d9c071adddf
 	github.com/zorkian/go-datadog-api v2.24.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -588,8 +588,8 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
-github.com/thestormforge/konjure v0.3.0-beta.5 h1:WHZECa4ea9Y86BIjsk0kqqNXlFZOxeOTx5sljYM8xks=
-github.com/thestormforge/konjure v0.3.0-beta.5/go.mod h1:8gIqMRKShWB7ejEA+JCN8DUeeDe9CTIc3eXyniFdNj8=
+github.com/thestormforge/konjure v0.3.0-beta.6 h1:0wVQ7Ms5BfXwY+DIFv2VA1w0wvAqndYby6I8T41sbm0=
+github.com/thestormforge/konjure v0.3.0-beta.6/go.mod h1:8gIqMRKShWB7ejEA+JCN8DUeeDe9CTIc3eXyniFdNj8=
 github.com/thestormforge/optimize-go v0.0.8 h1:nIdz5pSz00eHzBS8Ueti3xmNP9MB9l15/NTob6k6Whg=
 github.com/thestormforge/optimize-go v0.0.8/go.mod h1:ZWRi49lIlw4g3JyP9Aog+zQI/rb7+81HOyHcccVqnfU=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=

--- a/internal/application/application.go
+++ b/internal/application/application.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/thestormforge/optimize-controller/api/apps/v1alpha1"
+	redskyappsv1alpha1 "github.com/thestormforge/optimize-controller/api/apps/v1alpha1"
 	"github.com/thestormforge/optimize-controller/internal/scan"
 	"sigs.k8s.io/kustomize/api/filesys"
 	"sigs.k8s.io/kustomize/api/provider"
@@ -34,7 +34,7 @@ import (
 // FilterScenarios retains only the named scenario on the supplied application. Removing unused
 // scenarios may be useful for some types of application operations. If the requested scenario
 // cannot be found, an error is returned.
-func FilterScenarios(app *v1alpha1.Application, scenario string) error {
+func FilterScenarios(app *redskyappsv1alpha1.Application, scenario string) error {
 	if scenario == "" {
 		if len(app.Scenarios) > 1 {
 			names := make([]string, 0, len(app.Scenarios))
@@ -75,14 +75,14 @@ func FilterScenarios(app *v1alpha1.Application, scenario string) error {
 // FilterObjectives retains and re-orders the named scenarios on the supplied application. Removing
 // unused objectives may be useful for some types of application operations. If the requested
 // objectives cannot be found, an error is returned.
-func FilterObjectives(app *v1alpha1.Application, objectives []string) error {
+func FilterObjectives(app *redskyappsv1alpha1.Application, objectives []string) error {
 	// No filter, keep all objectives
 	if len(objectives) == 0 {
 		return nil
 	}
 
 	// Keep will have the same explicit order as the requested objectives
-	keep := make([]v1alpha1.Objective, 0, len(objectives))
+	keep := make([]redskyappsv1alpha1.Objective, 0, len(objectives))
 	unknown := make([]string, 0, len(objectives))
 
 FOUND:
@@ -106,7 +106,7 @@ FOUND:
 
 // ExperimentName returns the name of an experiment corresponding to the application state. Before
 // passing an application, be sure to filter scenarios and objectives.
-func ExperimentName(application *v1alpha1.Application) string {
+func ExperimentName(application *redskyappsv1alpha1.Application) string {
 	// Default the application to avoid empty names (deep copy first so we don't impact the caller)
 	app := application.DeepCopy()
 	app.Default()
@@ -133,7 +133,7 @@ func ExperimentName(application *v1alpha1.Application) string {
 // application name is "a", there are scenarios named "s" and "s-s" and objectives named
 // "s-o" and "o" then the experiment name "a-s-s-o" could be "s" and "s-o" OR "s-s" and "o".
 // Callers should have a back up plan for invoking `Filter*` methods independently.
-func FilterByExperimentName(app *v1alpha1.Application, name string) error {
+func FilterByExperimentName(app *redskyappsv1alpha1.Application, name string) error {
 	e := newLexer(app, name)
 
 	// Eat the application name at the start (it will error if they don't match)
@@ -174,7 +174,7 @@ func (e *AmbiguousNameError) Error() string {
 
 // LoadResources loads all of the resources for an application, using the supplied file system
 // to load file based resources (if necessary).
-func LoadResources(app *v1alpha1.Application, _ filesys.FileSystem) (resmap.ResMap, error) {
+func LoadResources(app *redskyappsv1alpha1.Application, _ filesys.FileSystem) (resmap.ResMap, error) {
 	kf := scan.NewKonjureFilter(nil)
 	kf.KeepStatus = false
 
@@ -218,7 +218,7 @@ type experimentNameLexer struct {
 
 var errEos = errors.New("eos")
 
-func newLexer(application *v1alpha1.Application, name string) *experimentNameLexer {
+func newLexer(application *redskyappsv1alpha1.Application, name string) *experimentNameLexer {
 	// Build the token library from the defaulted application
 	app := application.DeepCopy()
 	app.Default()

--- a/internal/application/generator.go
+++ b/internal/application/generator.go
@@ -32,18 +32,19 @@ import (
 )
 
 type Generator struct {
-	Name          string
-	Resources     konjure.Resources
-	Objectives    []string
-	Documentation DocumentationFilter
-	DefaultReader io.Reader
+	Name             string
+	Resources        konjure.Resources
+	Objectives       []string
+	Documentation    DocumentationFilter
+	WorkingDirectory string
+	DefaultReader    io.Reader
 }
 
 func (g *Generator) Execute(output kio.Writer) error {
 	return kio.Pipeline{
 		Inputs: []kio.Reader{g.Resources},
 		Filters: []kio.Filter{
-			scan.NewKonjureFilter(g.DefaultReader),
+			scan.NewKonjureFilter(g.WorkingDirectory, g.DefaultReader),
 			&scan.Scanner{
 				Selectors:   []scan.Selector{g},
 				Transformer: g,

--- a/internal/experiment/generation/generation.go
+++ b/internal/experiment/generation/generation.go
@@ -27,9 +27,9 @@ import (
 
 	redskyappsv1alpha1 "github.com/thestormforge/optimize-controller/api/apps/v1alpha1"
 	redskyv1beta1 "github.com/thestormforge/optimize-controller/api/v1beta1"
+	"github.com/thestormforge/optimize-controller/internal/application"
 	"github.com/yujunz/go-getter"
 	"sigs.k8s.io/kustomize/api/types"
-	"sigs.k8s.io/kustomize/kyaml/kio/kioutil"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
@@ -96,17 +96,15 @@ func loadApplicationData(app *redskyappsv1alpha1.Application, src string) ([]byt
 	dst := filepath.Join(os.TempDir(), fmt.Sprintf("load-application-data-%x", md5.Sum([]byte(src))))
 	defer os.Remove(dst)
 
-	var opts []getter.ClientOption
-
 	// Only set the working directory to directory of the file the app.yaml was loaded from,
 	// we MUST NOT set this to the process working directory or relative paths in the app.yaml
 	// will be dependent on what directory you run the process from. If the path annotation is
 	// not present on the application, we MUST fail to load relative paths.
-	if path := app.Annotations[kioutil.PathAnnotation]; path != "" {
-		opts = append(opts, func(c *getter.Client) error {
-			c.Pwd = filepath.Dir(path)
+	opts := []getter.ClientOption{
+		func(c *getter.Client) error {
+			c.Pwd = application.WorkingDirectory(app)
 			return nil
-		})
+		},
 	}
 
 	if err := getter.GetFile(dst, src, opts...); err != nil {

--- a/internal/experiment/generator.go
+++ b/internal/experiment/generator.go
@@ -102,12 +102,13 @@ func (g *Generator) SetDefaultSelectors() {
 
 // Execute the experiment generation pipeline, sending the results to the supplied writer.
 func (g *Generator) Execute(output kio.Writer) error {
+	pwd := application.WorkingDirectory(&g.Application)
 	return kio.Pipeline{
 		Inputs: []kio.Reader{
 			g.Application.Resources,
 		},
 		Filters: []kio.Filter{
-			scan.NewKonjureFilter(g.DefaultReader),
+			scan.NewKonjureFilter(pwd, g.DefaultReader),
 			g.newScannerFilter(),
 			&generation.ApplicationFilter{Application: &g.Application},
 			kio.FilterAll(yaml.Clear("status")),

--- a/internal/scan/filter.go
+++ b/internal/scan/filter.go
@@ -29,7 +29,7 @@ import (
 
 // NewKonjureFilter creates a new Konjure filter with the default settings
 // for this project. The supplied default reader is used when the "-" is requested.
-func NewKonjureFilter(defaultReader io.Reader) *konjure.Filter {
+func NewKonjureFilter(workingDir string, defaultReader io.Reader) *konjure.Filter {
 	return &konjure.Filter{
 		Depth:         100,
 		DefaultReader: defaultReader,

--- a/internal/scan/filter.go
+++ b/internal/scan/filter.go
@@ -31,11 +31,10 @@ import (
 // for this project. The supplied default reader is used when the "-" is requested.
 func NewKonjureFilter(workingDir string, defaultReader io.Reader) *konjure.Filter {
 	return &konjure.Filter{
-		Depth:         100,
-		DefaultReader: defaultReader,
-		KeepStatus:    true,
-
-		// Override the default behaviors for execution
+		Depth:             100,
+		DefaultReader:     defaultReader,
+		KeepStatus:        true,
+		WorkingDirectory:  workingDir,
 		KubectlExecutor:   kubectl,
 		KustomizeExecutor: kustomize,
 	}

--- a/redskyctl/internal/commander/commander.go
+++ b/redskyctl/internal/commander/commander.go
@@ -33,6 +33,9 @@ import (
 	"golang.org/x/oauth2"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/kustomize/kyaml/kio"
+	"sigs.k8s.io/kustomize/kyaml/kio/filters"
+	"sigs.k8s.io/kustomize/kyaml/kio/kioutil"
 )
 
 // TODO Terminal type for commands whose produce character level interactions (as opposed to byte level implied by the direct streams)
@@ -59,6 +62,18 @@ func (s *IOStreams) OpenFile(filename string) (io.ReadCloser, error) {
 		return ioutil.NopCloser(s.In), nil
 	}
 	return os.Open(filename)
+}
+
+// YAMLWriter returns a resource node writer for the current output stream. The writer
+// is configured to strip common annotations used during pipeline processing.
+func (s *IOStreams) YAMLWriter() kio.Writer {
+	return &kio.ByteWriter{
+		Writer: s.Out,
+		ClearAnnotations: []string{
+			kioutil.PathAnnotation,
+			filters.FmtAnnotation,
+		},
+	}
 }
 
 // SetStreams updates the streams using the supplied command

--- a/redskyctl/internal/commands/export/export.go
+++ b/redskyctl/internal/commands/export/export.go
@@ -142,10 +142,15 @@ func (o *Options) readInput() error {
 			return err
 		}
 
+		path, err := filepath.Abs(filename)
+		if err != nil {
+			return err
+		}
+
 		kioInputs = append(kioInputs, &kio.ByteReader{
 			Reader: bytes.NewReader(data),
 			SetAnnotations: map[string]string{
-				kioutil.PathAnnotation: filename,
+				kioutil.PathAnnotation: path,
 			},
 		})
 

--- a/redskyctl/internal/commands/export/export.go
+++ b/redskyctl/internal/commands/export/export.go
@@ -359,10 +359,7 @@ func (o *Options) runner(ctx context.Context) error {
 	output := kio.Pipeline{
 		Inputs:  []kio.Reader{&kio.ByteReader{Reader: bytes.NewReader(yamls)}},
 		Filters: []kio.Filter{kio.FilterFunc(filterPatch(patches))},
-		Outputs: []kio.Writer{kio.ByteWriter{
-			Writer:           o.Out,
-			ClearAnnotations: []string{kioutil.PathAnnotation},
-		}},
+		Outputs: []kio.Writer{o.YAMLWriter()},
 	}
 	if err := output.Execute(); err != nil {
 		return err

--- a/redskyctl/internal/commands/generate/application.go
+++ b/redskyctl/internal/commands/generate/application.go
@@ -17,6 +17,8 @@ limitations under the License.
 package generate
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 	konjurev1beta2 "github.com/thestormforge/konjure/pkg/api/core/v1beta2"
 	"github.com/thestormforge/konjure/pkg/konjure"
@@ -43,9 +45,11 @@ func NewApplicationCommand(o *ApplicationOptions) *cobra.Command {
 		Short: "Generate an application",
 		Long:  "Generate an application descriptor",
 
-		PreRun: func(cmd *cobra.Command, args []string) {
+		PreRunE: func(cmd *cobra.Command, args []string) (err error) {
 			commander.SetStreams(&o.IOStreams, cmd)
 			o.Generator.DefaultReader = cmd.InOrStdin()
+			o.Generator.WorkingDirectory, err = os.Getwd()
+			return
 		},
 		RunE: commander.WithoutArgsE(o.generate),
 	}

--- a/redskyctl/internal/commands/generate/experiment.go
+++ b/redskyctl/internal/commands/generate/experiment.go
@@ -18,7 +18,6 @@ package generate
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"strings"
 	"unicode"
@@ -143,17 +142,18 @@ func (o *ExperimentOptions) filterResources(app *redskyappsv1alpha1.Application)
 	return nil
 }
 
-func (o *ExperimentOptions) setPath() error {
+func (o *ExperimentOptions) setPath() (err error) {
 	path := o.Filename
 	if path == "" || path == "-" || filepath.Dir(path) == "/dev/fd" {
-		pwd, err := os.Getwd()
-		if err != nil {
-			return err
-		}
-
 		// The filename here could be anything, the important part is the directory so
 		// when you do not supply `-f`, relative paths resolve against the working directory
-		path = filepath.Join(pwd, "app.yaml")
+		path = "app.yaml"
+	}
+
+	// Ensure the path is absolute, relative to the current working directory
+	path, err = filepath.Abs(path)
+	if err != nil {
+		return err
 	}
 
 	metav1.SetMetaDataAnnotation(&o.Generator.Application.ObjectMeta, kioutil.PathAnnotation, path)

--- a/redskyctl/internal/commands/generate/experiment.go
+++ b/redskyctl/internal/commands/generate/experiment.go
@@ -30,7 +30,6 @@ import (
 	"github.com/thestormforge/optimize-controller/redskyctl/internal/commander"
 	"github.com/thestormforge/optimize-go/pkg/config"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/kustomize/kyaml/kio"
 	"sigs.k8s.io/kustomize/kyaml/kio/kioutil"
 )
 
@@ -125,7 +124,7 @@ func (o *ExperimentOptions) generate() error {
 	o.Generator.SetDefaultSelectors()
 
 	// Generate the experiment
-	return o.Generator.Execute(&kio.ByteWriter{Writer: o.Out})
+	return o.Generator.Execute(o.YAMLWriter())
 }
 
 func (o *ExperimentOptions) filterResources(app *redskyappsv1alpha1.Application) error {


### PR DESCRIPTION
The bulk of this PR is to ensure that path annotations are properly set to absolute paths on resources and that those paths are use appropriately to load relative paths encountered during generation.