### PR TITLE
Adjust StormForger generation to account for multiple organization authorization

### DIFF
--- a/api/apps/v1alpha1/application_defaults.go
+++ b/api/apps/v1alpha1/application_defaults.go
@@ -31,8 +31,7 @@ func init() {
 }
 
 const (
-	StormForgerAccessTokenSecretName = "stormforger-service-account"
-	StormForgerAccessTokenSecretKey  = "accessToken"
+	StormForgerAccessTokenSecretName = "stormforger-service-accounts"
 	defaultName                      = "default"
 )
 
@@ -51,8 +50,6 @@ func (in *Application) Default() {
 		in.Objectives[i].Default()
 	}
 
-	in.StormForger.Default()
-
 	// Count the number of objectives, this is necessary to accurately compute experiment names
 	in.InitialObjectiveCount = len(in.Objectives)
 }
@@ -66,33 +63,6 @@ func (in *Scenario) Default() {
 			in.Name = defaultScenarioName(in.Locust.Locustfile)
 		default:
 			in.Name = defaultName
-		}
-	}
-}
-
-func (in *StormForger) Default() {
-	if in == nil {
-		return
-	}
-
-	in.AccessToken.Default()
-}
-
-func (in *StormForgerAccessToken) Default() {
-	if in == nil {
-		return
-	}
-
-	if in.File == "" && in.Literal == "" && in.SecretKeyRef == nil {
-		in.SecretKeyRef = &corev1.SecretKeySelector{}
-	}
-
-	if in.SecretKeyRef != nil {
-		if in.SecretKeyRef.Name == "" {
-			in.SecretKeyRef.Name = StormForgerAccessTokenSecretName
-		}
-		if in.SecretKeyRef.Key == "" {
-			in.SecretKeyRef.Key = StormForgerAccessTokenSecretKey
 		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/thestormforge/optimize-controller
 go 1.16
 
 require (
-	github.com/BurntSushi/toml v0.3.1
 	github.com/Masterminds/goutils v1.1.0 // indirect
 	github.com/Masterminds/semver v1.4.2 // indirect
 	github.com/Masterminds/sprig v2.20.0+incompatible
@@ -14,6 +13,7 @@ require (
 	github.com/imdario/mergo v0.3.7 // indirect
 	github.com/lestrrat-go/jwx v1.0.6
 	github.com/mdp/qrterminal/v3 v3.0.0
+	github.com/pelletier/go-toml v1.2.0
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	github.com/prometheus/client_golang v1.0.0
 	github.com/prometheus/common v0.4.1

--- a/go.sum
+++ b/go.sum
@@ -496,6 +496,7 @@ github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQ
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/paulmach/orb v0.1.3/go.mod h1:VFlX/8C+IQ1p6FTRRKzKoOPJnvEtA5G0Veuqwbu//Vk=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
+github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=


### PR DESCRIPTION
This PR consists of a few changes/fixes:

The primary change is making it possible to source the value for `STORMFORGER_JWT` from an organization specific location (in this case, a section of the TOML file). This change is largely in anticipation of running the experiment generation in an environment where multiple organizations are in use. Since a service account is tied to the organization, we must pick a token based on the org name. Note that this only affects the fallback behavior when the credentials are not specified in the `app.yaml`.

Previous versions of experiment generation can produce a trial whose pod spec references a secret that does not exist. This would be the case if you did not have `forge` logged in and did not specify credentials in your `app.yaml`. Instead of creating the invalid spec, the new behavior is to recognize the error and fail experiment generation.

An edge case where specifying your test case file as a URL instead of a file path lead to an invalid ConfigMap definition has also been addressed (instead of `filepath.Base(testCaseFile)` we now use `testCase + ".js"` in the container).

It appears that `github.com/BurntSushi/toml` is no longer supported so I switched out the TOML parser for one that was already an indirect dependency.