### PR TITLE
GoReleaser should tidy, not download

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,7 @@
 project_name: redskyctl
 before:
   hooks:
-    - go mod download
+    - go mod tidy
 builds:
   - dir: redskyctl
     env:


### PR DESCRIPTION
[Source](https://goreleaser.com/customization/build/#go-modules). I noticed my `go.sum` file was dirty after every `make tool`, not entirely sure why, but it looks like we are doing it wrong and fixing it fixes my `go.sum` problem.