### PR TITLE
Consider the scrape interval when moving the scrape time back

### DIFF
--- a/internal/metric/prometheus.go
+++ b/internal/metric/prometheus.go
@@ -114,8 +114,9 @@ func checkReady(ctx context.Context, api promv1.API, t time.Time) (time.Time, er
 			return t, &CaptureError{RetryAfter: 5 * time.Second}
 		}
 
-		if target.LastScrape.After(lastScrape) {
-			lastScrape = target.LastScrape
+		// TODO This should use `target.LastScrapeDuration` once it is available
+		if ls := target.LastScrape.Add(3 * time.Second); ls.After(lastScrape) {
+			lastScrape = ls
 		}
 	}
 


### PR DESCRIPTION
As of v1.9.0 the Prometheus client does not expose the `LastScrapeDuration` field so we are using the`scrapeTimeout` of the built-in Prometheus as a stand in (the hard-coded 3s).