### PR TITLE
Eliminate ApplicationFilter

### DIFF
--- a/internal/experiment/generation/filter.go
+++ b/internal/experiment/generation/filter.go
@@ -20,95 +20,69 @@ import (
 	"crypto/sha256"
 	"fmt"
 
-	redskyappsv1alpha1 "github.com/thestormforge/optimize-controller/api/apps/v1alpha1"
 	redskyv1beta1 "github.com/thestormforge/optimize-controller/api/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	"sigs.k8s.io/kustomize/kyaml/kio"
 	"sigs.k8s.io/kustomize/kyaml/openapi"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
-type ApplicationFilter struct {
-	Application *redskyappsv1alpha1.Application
-}
-
-var _ kio.Filter = &ApplicationFilter{}
-
-func (f *ApplicationFilter) Filter(nodes []*yaml.RNode) ([]*yaml.RNode, error) {
-	var fs []yaml.Filter
-
-	// TODO The first filter should make sure we only apply things to resources we generated
-
-	for i := range f.Application.Objectives {
-		if !f.Application.Objectives[i].Implemented {
-			return nil, fmt.Errorf("generated experiment cannot optimize objective: %s", f.Application.Objectives[i].Name)
+// SetExperimentLabel is a filter that sets a label on an experiment object.
+func SetExperimentLabel(key, value string) yaml.Filter {
+	return yaml.FilterFunc(func(node *yaml.RNode) (*yaml.RNode, error) {
+		if value == "" {
+			return node, nil
 		}
-	}
 
-	if f.Application.Name != "" {
-		setLabel := yaml.SetLabel(redskyappsv1alpha1.LabelApplication, f.Application.Name)
-		fs = append(fs, yaml.Tee(
-			yaml.Tee(setLabel),
-			isExperiment(),
-			yaml.Lookup("spec", "trialTemplate"), yaml.Tee(setLabel),
-			yaml.Lookup("spec", "jobTemplate"), yaml.Tee(setLabel),
-			yaml.Lookup("spec", "template"), yaml.Tee(setLabel),
-		))
-	}
-
-	if f.Application.Namespace != "" {
-		fs = append(fs, yaml.Tee(
-			isNamespaceScoped(),
-			yaml.SetK8sNamespace(f.Application.Namespace),
-		))
-
-		fs = append(fs, yaml.Tee(
-			isClusterRoleOrBinding(),
-			yaml.Get("subjects"),
-			yaml.GetElementByKey("name"),
-			&yaml.FieldMatcher{Name: "namespace", Create: yaml.NewScalarRNode(f.Application.Namespace)},
-		))
-	}
-
-	if len(f.Application.Scenarios) == 1 {
-		setLabel := yaml.SetLabel(redskyappsv1alpha1.LabelScenario, f.Application.Scenarios[0].Name)
-		fs = append(fs, yaml.Tee(
+		setLabel := yaml.SetLabel(key, value)
+		return node.Pipe(yaml.Tee(
 			isExperiment(),
 			yaml.Tee(setLabel),
 			yaml.Lookup("spec", "trialTemplate"), yaml.Tee(setLabel),
 			yaml.Lookup("spec", "jobTemplate"), yaml.Tee(setLabel),
 			yaml.Lookup("spec", "template"), yaml.Tee(setLabel),
 		))
-	}
-
-	// Get the experiment name and add it as a suffix
-	experimentName := getExperimentName(nodes)
-	if experimentName != "" {
-		suffix := &yaml.SuffixSetter{Value: fmt.Sprintf("-%x", sha256.Sum256([]byte(experimentName)))[0:7]}
-		fs = append(fs, yaml.Tee(
-			isClusterRoleOrBinding(),
-			yaml.Tee(yaml.Lookup(yaml.MetadataField, yaml.NameField), suffix),
-			yaml.Tee(yaml.Lookup("roleRef", yaml.NameField), suffix),
-		))
-	}
-
-	for i := range nodes {
-		if err := nodes[i].PipeE(fs...); err != nil {
-			return nil, err
-		}
-	}
-
-	return nodes, nil
+	})
 }
 
-func getExperimentName(nodes []*yaml.RNode) string {
-	var experimentName string
-	_, _ = kio.FilterAll(yaml.Tee(
-		isExperiment(), yaml.Lookup("metadata", "name"), yaml.FilterFunc(func(object *yaml.RNode) (*yaml.RNode, error) {
-			experimentName = object.YNode().Value
-			return nil, fmt.Errorf("ignore this error, just stop iterating")
-		}))).Filter(nodes)
-	return experimentName
+// SetNamespace sets the namespace on a resource (if necessary).
+func SetNamespace(namespace string) yaml.Filter {
+	return yaml.FilterFunc(func(node *yaml.RNode) (*yaml.RNode, error) {
+		if namespace == "" {
+			return node, nil
+		}
+
+		return node.Pipe(yaml.Tee(
+			yaml.Tee(
+				isNamespaceScoped(),
+				yaml.SetK8sNamespace(namespace),
+			),
+			yaml.Tee(
+				isClusterRoleOrBinding(),
+				yaml.Get("subjects"),
+				yaml.GetElementByKey("name"),
+				&yaml.FieldMatcher{Name: "namespace", Create: yaml.NewScalarRNode(namespace)},
+			),
+		))
+	})
+}
+
+// SetExperimentName sets the name on the experiment. In addition, the experiment name is set as a
+// suffix on any generated cluster roles or cluster role bindings.
+func SetExperimentName(name string) yaml.Filter {
+	return yaml.FilterFunc(func(node *yaml.RNode) (*yaml.RNode, error) {
+		suffix := &yaml.SuffixSetter{Value: fmt.Sprintf("-%x", sha256.Sum256([]byte(name)))[0:7]}
+		return node.Pipe(
+			yaml.Tee(
+				isExperiment(),
+				yaml.SetK8sName(name),
+			),
+			yaml.Tee(
+				isClusterRoleOrBinding(),
+				yaml.Tee(yaml.Lookup(yaml.MetadataField, yaml.NameField), suffix),
+				yaml.Tee(yaml.Lookup("roleRef", yaml.NameField), suffix),
+			),
+		)
+	})
 }
 
 func isExperiment() yaml.Filter {

--- a/internal/experiment/generator.go
+++ b/internal/experiment/generator.go
@@ -116,6 +116,7 @@ func (g *Generator) Execute(output kio.Writer) error {
 			&scan.Scanner{
 				Transformer: &generation.Transformer{
 					IncludeApplicationResources: g.IncludeApplicationResources,
+					MergeGenerated:              len(g.Application.Scenarios) > 1,
 				},
 				Selectors: g.selectors(),
 			},


### PR DESCRIPTION
This is more of cleanup to make a few things easier going forward. The `ApplicationFilter` type was a single filter that was performing multiple roles (and confusingly was not in `application.go`). The new code defines 3 more general purpose YAML filters and leans a little more on the `experiment.Generator` type to orchestrate things. This also makes debugging a little easier in practice.

These changes will be used to improve generated experiment naming in a subsequent PR.