### PR TITLE
Perform experiment and application name validation on export

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -53,7 +53,8 @@ func FromCluster(in *redskyv1beta1.Experiment) (redskyapi.ExperimentName, *redsk
 	if l := len(in.ObjectMeta.Labels); l > 0 {
 		out.Labels = make(map[string]string, l)
 		for k, v := range in.ObjectMeta.Labels {
-			out.Labels[strings.TrimPrefix(k, "redskyops.dev/")] = v
+			k = strings.TrimPrefix(k, "redskyops.dev/")
+			out.Labels[k] = v
 		}
 	}
 

--- a/redskyctl/internal/commands/export/export_api_test.go
+++ b/redskyctl/internal/commands/export/export_api_test.go
@@ -62,6 +62,10 @@ func (f *fakeRedSkyServer) GetExperimentByName(ctx context.Context, name experim
 			TrialsURL: "http://sometrial",
 		},
 		DisplayName: "postgres-example",
+		Labels: map[string]string{
+			// NOTE: If the application label is not present, we will accept any application
+			"application": "sampleApplication",
+		},
 		Metrics: []experimentsapi.Metric{
 			{
 				Name:     "cost",


### PR DESCRIPTION
This PR makes a few changes to export:
* The logic for fetching a trial is adjusted so that it uses the `SplitTrialName` from `optimize-go`. Additionally, we now capture the experiment labels when fetching the trials (the functions `getTrialByID` and `getTrials` have been consolidated into `getTrialDetails`).
* We now completely skip application generation if an experiment is present in the resources nodes.
* The experiment name and application name are now used when filtering the resource nodes (this is an extreme edge case, e.g. someone included multiple experiment definitions in the input).

As with previous PRs, this is a building block: the `FilterByExperimentName` function is not sustainable, these changes will ultimately allow us to recover the scenario and objective from the API to use as inputs to generation.