### PR TITLE
Create paused experiments

### DIFF
--- a/api/v1beta1/experiment_types.go
+++ b/api/v1beta1/experiment_types.go
@@ -212,6 +212,8 @@ type TrialTemplateSpec struct {
 type ExperimentConditionType string
 
 const (
+	// ExperimentComplete is a condition that indicates the experiment completed successfully
+	ExperimentComplete ExperimentConditionType = "redskyops.dev/experiment-complete"
 	// ExperimentFailed is a condition that indicates an experiment failed
 	ExperimentFailed ExperimentConditionType = "redskyops.dev/experiment-failed"
 )

--- a/controllers/server_controller.go
+++ b/controllers/server_controller.go
@@ -74,10 +74,8 @@ func (r *ServerReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	}
 
 	// Create the experiment on the server
-	if exp.GetAnnotations()[redskyv1beta1.AnnotationExperimentURL] == "" && exp.Replicas() > 0 {
-		if result, err := r.createExperiment(ctx, log, exp); result != nil {
-			return *result, err
-		}
+	if result, err := r.createExperiment(ctx, log, exp); result != nil {
+		return *result, err
 	}
 
 	// Get the current list of trials
@@ -215,6 +213,16 @@ func (r *ServerReconciler) listTrials(ctx context.Context, trialList *redskyv1be
 // createExperiment will create a new experiment on the server using the cluster state; any default values from the
 // server will be copied back into cluster along with the URLs needed for future interactions with server.
 func (r *ServerReconciler) createExperiment(ctx context.Context, log logr.Logger, exp *redskyv1beta1.Experiment) (*ctrl.Result, error) {
+	// If the server finalizer is already present, do not try to recreate the experiment on the server
+	if meta.HasFinalizer(exp, server.Finalizer) {
+		return nil, nil
+	}
+
+	// Rely on the status to prevent re-running an already run experiment
+	if experiment.IsFinished(exp) {
+		return nil, nil
+	}
+
 	// Convert the cluster state into a server representation
 	n, e, b, err := server.FromCluster(exp)
 	if err != nil {
@@ -226,6 +234,7 @@ func (r *ServerReconciler) createExperiment(ctx context.Context, log logr.Logger
 	}
 
 	// Create the experiment remotely
+	// TODO This should check for an existing URL annotation before using the name (needs a new version of optimize-go)
 	ee, err := r.ExperimentsAPI.CreateExperiment(ctx, n, *e)
 	if err != nil {
 		if server.FailExperiment(exp, "ServerCreateFailed", err) {

--- a/controllers/server_controller.go
+++ b/controllers/server_controller.go
@@ -274,6 +274,8 @@ func (r *ServerReconciler) unlinkExperiment(ctx context.Context, log logr.Logger
 	delete(exp.GetAnnotations(), redskyv1beta1.AnnotationExperimentURL)
 	delete(exp.GetAnnotations(), redskyv1beta1.AnnotationNextTrialURL)
 
+	experiment.ApplyCondition(&exp.Status, redskyv1beta1.ExperimentComplete, corev1.ConditionTrue, "", "", nil)
+
 	// Update the experiment
 	if err := r.Update(ctx, exp); err != nil {
 		return controller.RequeueConflict(err)

--- a/internal/experiment/experiment.go
+++ b/internal/experiment/experiment.go
@@ -122,6 +122,17 @@ func summarize(exp *redskyv1beta1.Experiment, activeTrials int32, totalTrials in
 	return PhaseIdle
 }
 
+func IsFinished(exp *redskyv1beta1.Experiment) bool {
+	for _, c := range exp.Status.Conditions {
+		if c.Status == corev1.ConditionTrue {
+			if c.Type == redskyv1beta1.ExperimentComplete || c.Type == redskyv1beta1.ExperimentFailed {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func ApplyCondition(status *redskyv1beta1.ExperimentStatus, conditionType redskyv1beta1.ExperimentConditionType, conditionStatus corev1.ConditionStatus, reason, message string, time *metav1.Time) {
 	if time == nil {
 		now := metav1.Now()

--- a/internal/experiment/experiment.go
+++ b/internal/experiment/experiment.go
@@ -19,8 +19,6 @@ package experiment
 import (
 	redskyv1beta1 "github.com/thestormforge/optimize-controller/api/v1beta1"
 	"github.com/thestormforge/optimize-controller/internal/controller"
-	"github.com/thestormforge/optimize-controller/internal/meta"
-	"github.com/thestormforge/optimize-controller/internal/server"
 	"github.com/thestormforge/optimize-controller/internal/trial"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -113,7 +111,7 @@ func summarize(exp *redskyv1beta1.Experiment, activeTrials int32, totalTrials in
 	}
 
 	if totalTrials == 0 {
-		if meta.HasFinalizer(exp, server.Finalizer) {
+		if exp.Annotations[redskyv1beta1.AnnotationExperimentURL] != "" {
 			return PhaseCreated
 		}
 		return PhaseEmpty

--- a/internal/experiment/experiment_test.go
+++ b/internal/experiment/experiment_test.go
@@ -121,6 +121,14 @@ func TestSummarize(t *testing.T) {
 				Spec: redsky.ExperimentSpec{
 					Replicas: &zeroReplicas,
 				},
+				Status: redsky.ExperimentStatus{
+					Conditions: []redsky.ExperimentCondition{
+						{
+							Type:   redsky.ExperimentComplete,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
 			},
 			expectedPhase: PhaseCompleted,
 		},


### PR DESCRIPTION
This PR includes two related changes:

First, when a remote experiment runs out of trials, we now add a "completed" condition to the status (this is useful as records the time at which the controller believes the experiment is no longer running). We also leverage this status for the "is finished" test that is required for the next change.

Second, we no longer rely on the combination of the remote URL and replicas value to determine if the cluster state needs to be synced, instead we leverage the server finalizer and the (new) "is finished" test.

The is-finished test is necessary to ensure we do not get in a loop recreating the experiment on the server: for example, when we hit the end of the experiment and "unlink" it (removing the server finalizer), it would otherwise appear to be a new experiment ready to be run on the next reconciliation. However: we are not reliant on the status (consistent with best practices), only because re-creating the experiment on the server will be a no-op (the definition already exists and the `PUT` won't conflict) and the next attempt to get a trial will result in the server telling us that there are no more trials (re-triggering the unlink without attempting to run more trials).

I left a `TODO` in the code that will need to be addressed after the next `optimize-go` release, it is possible to have a mismatched server URL annotation and experiment name going into creation and we end up ignoring the URL.