### PR TITLE
Allow trial creation rate limit to be configured

### DIFF
--- a/controllers/server_controller.go
+++ b/controllers/server_controller.go
@@ -56,13 +56,13 @@ func trialCreationRateLimit(log logr.Logger) rate.Limit {
 	// NOTE: If we are changing this to a lot of different values, it should be moved to the configuration
 	trialCreationInterval, ok := os.LookupEnv("REDSKY_TRIAL_CREATION_INTERVAL")
 	if !ok {
-		return rate.Limit(1)
+		return rate.Every(time.Second)
 	}
 
 	d, err := time.ParseDuration(trialCreationInterval)
 	if err != nil || d < time.Second {
 		log.Info("Ignoring invalid custom trial creation interval", "trialCreationInterval", trialCreationInterval)
-		return rate.Limit(1)
+		return rate.Every(time.Second)
 	}
 
 	log.Info("Using custom trial creation interval", "trialCreationInterval", trialCreationInterval)


### PR DESCRIPTION
This change makes it possible to decrease the trial creation rate, this may be necessary if the API server is unable to report the existence of new trials with sub-second accuracy.

Configuration is done with the `REDSKY_TRIAL_CREATION_INTERVAL` environment variable, this variable is a duration representing the maximum amount of time required to synchronize the creation of a new trial through the API server. The default value is `1s` (this is also the minimum allowed value). To ensure only one attempt is made to create a trial every 5 seconds, set `REDSKY_TRIAL_CREATION_INTERVAL=5s`.

It is possible to configure controller environment variables by putting them in your configuration and running the `redskyctl init` command. For example in your configuration file you should have something like this:
```
controllers:
- name: default
  controller:
    env:
    - name: REDSKY_TRIAL_CREATION_INTERVAL
      value: 5s
```

Additionally, this PR improves handling of an edge case that should never happen: if a reservation fails outright the old behavior was to continue with trial creation, the new behavior is to log the failure and skip the creation. However, because we hard code the burst size of the limiter to 1, the `Reserve` function (with it's effective token count of 1) should never fail.