### PR TITLE
Add a "redskyops.dev/server-sync" annotation

### DIFF
--- a/api/v1beta1/well_known_labels.go
+++ b/api/v1beta1/well_known_labels.go
@@ -25,6 +25,8 @@ const (
 	AnnotationNextTrialURL = "redskyops.dev/next-trial-url"
 	// AnnotationReportTrialURL is the URL used to report trial observations
 	AnnotationReportTrialURL = "redskyops.dev/report-trial-url"
+	// AnnotationServerSync controls additional behavior around synchronizing the experiment remotely
+	AnnotationServerSync = "redskyops.dev/server-sync"
 
 	// LabelExperiment is the name of the experiment associated with an object
 	LabelExperiment = "redskyops.dev/experiment"

--- a/controllers/server_controller.go
+++ b/controllers/server_controller.go
@@ -74,7 +74,7 @@ func (r *ServerReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	}
 
 	// Check to see if the experiment is exempt from server operations
-	if server.IsServerSyncDisabled(exp) {
+	if !server.IsServerSyncEnabled(exp) {
 		return ctrl.Result{}, nil
 	}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -303,15 +303,13 @@ func FailExperiment(exp *redskyv1beta1.Experiment, reason string, err error) boo
 	return true
 }
 
-// IsServerSyncDisabled checks to see if server synchronization should be disabled.
-func IsServerSyncDisabled(exp *redskyv1beta1.Experiment) bool {
+// IsServerSyncEnabled checks to see if server synchronization is enabled.
+func IsServerSyncEnabled(exp *redskyv1beta1.Experiment) bool {
 	switch strings.ToLower(exp.GetAnnotations()[redskyv1beta1.AnnotationServerSync]) {
 	case "disabled", "false":
-		// DO NOT perform server synchronization
-		return true
-	default:
-		// Server sync IS NOT disabled, allow server sync
 		return false
+	default:
+		return true
 	}
 }
 
@@ -328,7 +326,7 @@ func DeleteServerExperiment(exp *redskyv1beta1.Experiment) bool {
 	// As a special case, check to see if synchronization is disabled. This would
 	// be the case if someone tried disabling server synchronization mid-run,
 	// presumably with the intent of not having the server experiment at the end.
-	if IsServerSyncDisabled(exp) {
+	if !IsServerSyncEnabled(exp) {
 		return true
 	}
 


### PR DESCRIPTION
The value can be "disabled" or "delete-completed" to entirely skip server synchronization or to delete server experiments on completion respectively.