### PR TITLE
Do not require kubectl to resolve Konjure resources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
 	k8s.io/api v0.17.2
 	k8s.io/apimachinery v0.17.2
+	k8s.io/cli-runtime v0.17.2
 	k8s.io/client-go v0.17.2
 	k8s.io/kubectl v0.17.2
 	k8s.io/metrics v0.17.2

--- a/internal/application/generator.go
+++ b/internal/application/generator.go
@@ -17,7 +17,6 @@ limitations under the License.
 package application
 
 import (
-	"io"
 	"path/filepath"
 	"time"
 
@@ -45,15 +44,15 @@ type Generator struct {
 	Documentation DocumentationFilter
 	// An explicit working directory used to relativize file paths.
 	WorkingDirectory string
-	// Override for the stdin stream.
-	DefaultReader io.Reader
+	// Configure the filter options.
+	scan.FilterOptions
 }
 
 func (g *Generator) Execute(output kio.Writer) error {
 	return kio.Pipeline{
 		Inputs: []kio.Reader{g.Resources},
 		Filters: []kio.Filter{
-			scan.NewKonjureFilter(g.WorkingDirectory, g.DefaultReader),
+			g.FilterOptions.NewFilter(g.WorkingDirectory),
 			&scan.Scanner{
 				Selectors:   []scan.Selector{g},
 				Transformer: g,

--- a/internal/experiment/generator.go
+++ b/internal/experiment/generator.go
@@ -18,7 +18,6 @@ package experiment
 
 import (
 	"fmt"
-	"io"
 
 	redskyappsv1alpha1 "github.com/thestormforge/optimize-controller/api/apps/v1alpha1"
 	"github.com/thestormforge/optimize-controller/internal/application"
@@ -45,8 +44,8 @@ type Generator struct {
 	ReplicaSelectors []generation.ReplicaSelector
 	// IncludeApplicationResources is a flag indicating that the application resources should be included in the output.
 	IncludeApplicationResources bool
-	// Default reader to use instead of stdin.
-	DefaultReader io.Reader
+	// Configure the filter options.
+	scan.FilterOptions
 }
 
 // SetDefaultSelectors adds the default selectors to the generator, this requires that the application
@@ -139,7 +138,7 @@ func (g *Generator) Execute(output kio.Writer) error {
 		},
 		Filters: []kio.Filter{
 			// Expand resource references using Konjure
-			scan.NewKonjureFilter(application.WorkingDirectory(&g.Application), g.DefaultReader),
+			g.FilterOptions.NewFilter(application.WorkingDirectory(&g.Application)),
 
 			// Scan the resources and transform them into an experiment (and it's supporting resources)
 			&scan.Scanner{

--- a/internal/scan/filter.go
+++ b/internal/scan/filter.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"os/exec"
 
+	"github.com/spf13/pflag"
 	"github.com/thestormforge/konjure/pkg/konjure"
 	"sigs.k8s.io/kustomize/api/filesys"
 	"sigs.k8s.io/kustomize/api/konfig"
@@ -41,8 +42,33 @@ func NewKonjureFilter(workingDir string, defaultReader io.Reader) *konjure.Filte
 }
 
 func kubectl(cmd *exec.Cmd) ([]byte, error) {
-	// TODO We can use the Kube API to handle `kubectl get`, we may need pflags to help
-	return cmd.Output()
+	// If LookPath found the kubectl binary, it is safer to just use it. That
+	// way the cluster version doesn't need to be in the compatibility range of
+	// whatever client-go we were compiled with.
+	if cmd.Path != "kubectl" {
+		return cmd.Output()
+	}
+
+	// Kustomize has a clown. We have minikubectl.
+	k := newMinikubectl()
+
+	// Create and populate a new flag set
+	flags := pflag.NewFlagSet("minikubectl", pflag.ContinueOnError)
+	k.AddFlags(flags)
+
+	// Parse the arguments on exec.Cmd (ignoring arg[0] which is "kubectl")
+	if err := flags.Parse(cmd.Args[1:]); err != nil {
+		return nil, err
+	}
+
+	// If complete fails, assume it was because we asked too much of minikubectl
+	// and we should just run the real thing in a subprocess
+	if err := k.Complete(flags.Args()); err != nil {
+		return cmd.Output()
+	}
+
+	// Run minikubectl with the remaining arguments
+	return k.Run(flags.Args())
 }
 
 func kustomize(cmd *exec.Cmd) ([]byte, error) {

--- a/internal/scan/filter.go
+++ b/internal/scan/filter.go
@@ -71,8 +71,7 @@ func (factoryFn KubectlExecutor) Output(cmd *exec.Cmd) ([]byte, error) {
 		return cmd.Output()
 	}
 
-	// Run minikubectl with the remaining arguments
-	return k.Run(flags.Args())
+	return k.Run()
 }
 
 // KustomizeExecutor runs kustomize commands using Krusty.

--- a/internal/scan/minikubectl.go
+++ b/internal/scan/minikubectl.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2021 GramLabs, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scan
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/spf13/pflag"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/resource"
+)
+
+// minikubectl is just a miniature in-process kubectl for us to use to avoid
+// a binary dependency on the tool itself.
+type minikubectl struct {
+	*genericclioptions.ConfigFlags
+	*genericclioptions.ResourceBuilderFlags
+	*genericclioptions.PrintFlags
+	IgnoreNotFound bool
+}
+
+// newMinikubectl creates a new minikubectl, the empty state is not usable.
+func newMinikubectl() *minikubectl {
+	outputFormat := ""
+	return &minikubectl{
+		ConfigFlags: genericclioptions.NewConfigFlags(false),
+		ResourceBuilderFlags: genericclioptions.NewResourceBuilderFlags().
+			WithLabelSelector("").
+			WithAll(true).
+			WithLatest(),
+		PrintFlags: &genericclioptions.PrintFlags{
+			JSONYamlPrintFlags: genericclioptions.NewJSONYamlPrintFlags(),
+			OutputFormat:       &outputFormat,
+		},
+	}
+}
+
+// AddFlags configures the supplied flag set with the recognized flags.
+func (k *minikubectl) AddFlags(flags *pflag.FlagSet) {
+	k.ConfigFlags.AddFlags(flags)
+	k.ResourceBuilderFlags.AddFlags(flags)
+
+	// PrintFlags somehow is tied to Cobra...
+	flags.StringVarP(k.PrintFlags.OutputFormat, "output", "o", *k.PrintFlags.OutputFormat, "")
+
+	// Don't bother with usage strings here, we aren't showing help to anyone
+	flags.BoolVar(&k.IgnoreNotFound, "ignore-not-found", k.IgnoreNotFound, "")
+}
+
+// Complete validates we can execute against the supplied arguments.
+func (k *minikubectl) Complete(args []string) error {
+	if len(args) == 0 || args[0] != "get" {
+		return fmt.Errorf("minikubectl only supports get")
+	}
+
+	return nil
+}
+
+// Run executes the supplied arguments and returns the output as bytes.
+func (k *minikubectl) Run(args []string) ([]byte, error) {
+	v := k.ResourceBuilderFlags.ToBuilder(k.ConfigFlags, args[1:]).Do()
+
+	// Create a printer to dump the objects
+	printer, err := k.PrintFlags.ToPrinter()
+	if err != nil {
+		return nil, err
+	}
+
+	// Use the printer to render everything into a byte buffer
+	var b bytes.Buffer
+	err = v.Visit(func(info *resource.Info, err error) error {
+		if err != nil {
+			if k.IgnoreNotFound && apierrors.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+
+		return printer.PrintObj(info.Object, &b)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return b.Bytes(), nil
+}

--- a/internal/scan/minikubectl.go
+++ b/internal/scan/minikubectl.go
@@ -26,19 +26,19 @@ import (
 	"k8s.io/cli-runtime/pkg/resource"
 )
 
-// minikubectl is just a miniature in-process kubectl for us to use to avoid
+// Minikubectl is just a miniature in-process kubectl for us to use to avoid
 // a binary dependency on the tool itself.
-type minikubectl struct {
+type Minikubectl struct {
 	*genericclioptions.ConfigFlags
 	*genericclioptions.ResourceBuilderFlags
 	*genericclioptions.PrintFlags
 	IgnoreNotFound bool
 }
 
-// newMinikubectl creates a new minikubectl, the empty state is not usable.
-func newMinikubectl() *minikubectl {
+// NewMinikubectl creates a new minikubectl, the empty state is not usable.
+func NewMinikubectl() *Minikubectl {
 	outputFormat := ""
-	return &minikubectl{
+	return &Minikubectl{
 		ConfigFlags: genericclioptions.NewConfigFlags(false),
 		ResourceBuilderFlags: genericclioptions.NewResourceBuilderFlags().
 			WithLabelSelector("").
@@ -52,7 +52,7 @@ func newMinikubectl() *minikubectl {
 }
 
 // AddFlags configures the supplied flag set with the recognized flags.
-func (k *minikubectl) AddFlags(flags *pflag.FlagSet) {
+func (k *Minikubectl) AddFlags(flags *pflag.FlagSet) {
 	k.ConfigFlags.AddFlags(flags)
 	k.ResourceBuilderFlags.AddFlags(flags)
 
@@ -64,7 +64,7 @@ func (k *minikubectl) AddFlags(flags *pflag.FlagSet) {
 }
 
 // Complete validates we can execute against the supplied arguments.
-func (k *minikubectl) Complete(args []string) error {
+func (k *Minikubectl) Complete(args []string) error {
 	if len(args) == 0 || args[0] != "get" {
 		return fmt.Errorf("minikubectl only supports get")
 	}
@@ -73,7 +73,7 @@ func (k *minikubectl) Complete(args []string) error {
 }
 
 // Run executes the supplied arguments and returns the output as bytes.
-func (k *minikubectl) Run(args []string) ([]byte, error) {
+func (k *Minikubectl) Run(args []string) ([]byte, error) {
 	v := k.ResourceBuilderFlags.ToBuilder(k.ConfigFlags, args[1:]).Do()
 
 	// Create a printer to dump the objects

--- a/internal/scan/minikubectl.go
+++ b/internal/scan/minikubectl.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/pflag"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
 )
 
@@ -33,6 +34,9 @@ type Minikubectl struct {
 	*genericclioptions.ResourceBuilderFlags
 	*genericclioptions.PrintFlags
 	IgnoreNotFound bool
+
+	genericclioptions.ResourceFinder
+	printers.ResourcePrinter
 }
 
 // NewMinikubectl creates a new minikubectl, the empty state is not usable.
@@ -64,27 +68,35 @@ func (k *Minikubectl) AddFlags(flags *pflag.FlagSet) {
 }
 
 // Complete validates we can execute against the supplied arguments.
-func (k *Minikubectl) Complete(args []string) error {
+func (k *Minikubectl) Complete(args []string) (err error) {
+	// Verify we are only being asked to do a get
 	if len(args) == 0 || args[0] != "get" {
 		return fmt.Errorf("minikubectl only supports get")
 	}
 
-	return nil
+	// Get a resource finder
+	if k.ResourceFinder == nil {
+		k.ResourceFinder = k.ResourceBuilderFlags.ToBuilder(k.ConfigFlags, args[1:])
+	}
+
+	// Get a resource printer
+	if k.ResourcePrinter == nil {
+		k.ResourcePrinter, err = k.PrintFlags.ToPrinter()
+		if err != nil {
+			return err
+		}
+	}
+
+	return
 }
 
 // Run executes the supplied arguments and returns the output as bytes.
-func (k *Minikubectl) Run(args []string) ([]byte, error) {
-	v := k.ResourceBuilderFlags.ToBuilder(k.ConfigFlags, args[1:]).Do()
-
-	// Create a printer to dump the objects
-	printer, err := k.PrintFlags.ToPrinter()
-	if err != nil {
-		return nil, err
-	}
+func (k *Minikubectl) Run() ([]byte, error) {
+	v := k.ResourceFinder.Do()
 
 	// Use the printer to render everything into a byte buffer
 	var b bytes.Buffer
-	err = v.Visit(func(info *resource.Info, err error) error {
+	err := v.Visit(func(info *resource.Info, err error) error {
 		if err != nil {
 			if k.IgnoreNotFound && apierrors.IsNotFound(err) {
 				return nil
@@ -92,7 +104,7 @@ func (k *Minikubectl) Run(args []string) ([]byte, error) {
 			return err
 		}
 
-		return printer.PrintObj(info.Object, &b)
+		return k.ResourcePrinter.PrintObj(info.Object, &b)
 	})
 	if err != nil {
 		return nil, err

--- a/redskyctl/internal/commands/export/export.go
+++ b/redskyctl/internal/commands/export/export.go
@@ -375,12 +375,16 @@ func (o *Options) runner(ctx context.Context) error {
 func (o *Options) generateExperiment(trial *trialDetails) error {
 	list := &corev1.List{}
 
+	opts := scan.FilterOptions{
+		DefaultReader: o.In,
+	}
+
 	gen := experiment.Generator{
 		Application:    *o.application,
 		ExperimentName: trial.Experiment,
 		Scenario:       trial.Scenario,
 		Objective:      trial.Objective,
-		DefaultReader:  o.In,
+		FilterOptions:  opts,
 	}
 
 	gen.SetDefaultSelectors()
@@ -419,7 +423,7 @@ func (o *Options) generateExperiment(trial *trialDetails) error {
 	var buf bytes.Buffer
 	err := kio.Pipeline{
 		Inputs:  []kio.Reader{o.application.Resources},
-		Filters: []kio.Filter{scan.NewKonjureFilter(apppkg.WorkingDirectory(o.application), o.In)},
+		Filters: []kio.Filter{opts.NewFilter(apppkg.WorkingDirectory(o.application))},
 		Outputs: []kio.Writer{&kio.ByteWriter{
 			Writer: &buf,
 		}},


### PR DESCRIPTION
This PR updates the Konjure filter so we do not need `kubectl` on the `PATH` to resolve in-cluster resources.

The approach I finally settled on leverages the `cli-runtime` (which we were pulling in indirectly); it isn't a perfect match to the `kubectl get` behavior, but it is definitely closer than I originally thought I would get.