### PR TITLE
Handle missing baseline in generate experiment

### DIFF
--- a/internal/experiment/generation/containerresources.go
+++ b/internal/experiment/generation/containerresources.go
@@ -52,8 +52,11 @@ func (s *ContainerResourcesSelector) Map(node *yaml.RNode, meta yaml.ResourceMet
 		yaml.FilterFunc(func(node *yaml.RNode) (*yaml.RNode, error) {
 			return nil, node.VisitElements(func(node *yaml.RNode) error {
 				rl := node.Field("resources")
-				if rl == nil && !s.CreateIfNotPresent {
-					return nil
+				if rl == nil {
+					if !s.CreateIfNotPresent {
+						return nil
+					}
+					rl = &yaml.MapNode{Value: yaml.NewMapRNode(nil)}
 				}
 
 				name := node.Field("name").Value.YNode().Value
@@ -64,10 +67,8 @@ func (s *ContainerResourcesSelector) Map(node *yaml.RNode, meta yaml.ResourceMet
 				p := containerResourcesParameter{pnode{
 					meta:      meta,
 					fieldPath: append(path, "[name="+name+"]", "resources"),
+					value:     rl.Value.YNode(),
 				}}
-				if rl != nil {
-					p.value = rl.Value.YNode()
-				}
 
 				result = append(result, &p)
 				return nil

--- a/internal/experiment/generator.go
+++ b/internal/experiment/generator.go
@@ -178,14 +178,14 @@ func (g *Generator) Execute(output kio.Writer) error {
 func (g *Generator) selectors() []scan.Selector {
 	var result []scan.Selector
 
-	// Container resource selectors look for resource requests/limits
-	for i := range g.ContainerResourcesSelectors {
-		result = append(result, &g.ContainerResourcesSelectors[i])
-	}
-
 	// Replica selectors look for horizontally scalable resources
 	for i := range g.ReplicaSelectors {
 		result = append(result, &g.ReplicaSelectors[i])
+	}
+
+	// Container resource selectors look for resource requests/limits
+	for i := range g.ContainerResourcesSelectors {
+		result = append(result, &g.ContainerResourcesSelectors[i])
 	}
 
 	// TODO EnvVarSelector


### PR DESCRIPTION
Fixes a panic when no baseline is specified in the scanned manifest.

I also put replicas ahead of container resources, it makes the patches easier to read.