### PR TITLE
Allow Prometheus queries to skip the `scalar(...)`

### DIFF
--- a/controllers/metric_controller.go
+++ b/controllers/metric_controller.go
@@ -155,8 +155,14 @@ func (r *MetricReconciler) collectMetrics(ctx context.Context, t *redskyv1beta1.
 		metrics[exp.Spec.Metrics[i].Name] = exp.Spec.Metrics[i].DeepCopy()
 	}
 
+	// Add more context to the log to help with debugging
+	log := r.Log.WithValues(
+		"trial", fmt.Sprintf("%s/%s", t.Namespace, t.Name),
+		"startTime", t.Status.StartTime.Time,
+		"completionTime", t.Status.CompletionTime.Time,
+	)
+
 	// Iterate over the metric values, looking for remaining attempts
-	log := r.Log.WithValues("trial", fmt.Sprintf("%s/%s", t.Namespace, t.Name))
 	for i := range t.Spec.Values {
 		v := &t.Spec.Values[i]
 		if v.AttemptsRemaining <= 0 {
@@ -231,7 +237,7 @@ func (r *MetricReconciler) collectionAttempt(ctx context.Context, log logr.Logge
 
 		// Metric errors contain additional information which should be logged for debugging
 		if merr, ok := err.(*metric.CaptureError); ok {
-			log.Error(merr, "Metric collection failed", "address", merr.Address, "query", merr.Query, "completionTime", merr.CompletionTime)
+			log.Error(merr, "Metric collection failed", "address", merr.Address, "query", merr.Query)
 		}
 	}
 


### PR DESCRIPTION
This PR makes the `scalar(...)` optional, if we get a vector we apply the same unwrapping `scalar(...)` would have.

Additionally, I made two minor changes:
* The name of the "lastScrapeTime" variable is now "lastScrapeEndTime" to be clear it is different from "lastScrapeTime"
* I realized that the log could be updated in the controller and we wouldn't need to pass so much information around