### PR TITLE
Fix default version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ GOBIN=$(shell go env GOBIN)
 endif
 
 # Collect version information
-VERSION ?= $(shell git ls-remote --tags --refs origin 'v*' | tail -1 | awk -F/ '{ print $$3 }')-next
+VERSION ?= $(shell git ls-remote --tags --refs origin 'v*' | awk -F/ '{ print $$3 }' | sort -V | tail -1)-next
 BUILD_METADATA ?=
 GIT_COMMIT ?= $(shell git rev-parse HEAD)
 


### PR DESCRIPTION
This has been broken since 1.10 I guess. In CI it is set explicitly, but local builds show up as 1.9.x.