### PR TITLE
Add "exp" short name for Experiment CRD

### DIFF
--- a/api/v1beta1/experiment_types.go
+++ b/api/v1beta1/experiment_types.go
@@ -278,6 +278,7 @@ type ExperimentStatus struct {
 // +kubebuilder:storageversion
 
 // Experiment is the Schema for the experiments API
+// +kubebuilder:resource:shortName=exp
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.phase",description="Experiment status"
 type Experiment struct {
 	metav1.TypeMeta `json:",inline"`

--- a/config/crd/bases/redskyops.dev_experiments.yaml
+++ b/config/crd/bases/redskyops.dev_experiments.yaml
@@ -16,8 +16,10 @@ spec:
     kind: Experiment
     listKind: ExperimentList
     plural: experiments
+    shortNames:
+    - exp
     singular: experiment
-  scope: ""
+  scope: Namespaced
   subresources: {}
   version: v1alpha1
   versions:


### PR DESCRIPTION
This brings parity to `kubectl` and `redskyctl` in terms of using `exp` as a short name for the type.

Note, the addition of `// +kubebuilder:resource` directive seems to have forced what was otherwise a default value on the scope. I am interested to see what this does when it hits the matrix builds for older versions, hopefully it won't matter.