### PR TITLE
Minor improvements

### DIFF
--- a/internal/experiment/generation/transformer.go
+++ b/internal/experiment/generation/transformer.go
@@ -146,7 +146,7 @@ func (t *Transformer) Transform(nodes []*yaml.RNode, selected []interface{}) ([]
 		if err != nil {
 			return nil, err
 		}
-		result = append(result, appResources...)
+		result = append(appResources, result...)
 	}
 
 	return result, nil

--- a/redskyctl/internal/commands/experiments/experiments.go
+++ b/redskyctl/internal/commands/experiments/experiments.go
@@ -117,6 +117,14 @@ func (n *name) trialNumber() int64 {
 	return n.Number
 }
 
+// String returns the joined name and number.
+func (n *name) String() string {
+	if n.Name == "" || n.Type == typeExperiment || n.Number < 0 {
+		return n.Name
+	}
+	return fmt.Sprintf("%s/%d", n.Name, n.Number)
+}
+
 // parseNames parses a list of arguments into structured names
 func parseNames(args []string) ([]name, error) {
 	names := make([]name, 0, len(args))


### PR DESCRIPTION
This PR includes a few minor improvements:
1. Generated experiments produce parameters in the correct order, this prevents the first trial from looking different in the the `kubectl get trials` output.
2. When using `--include-resources`, the application resources are emitted first: this is more consistent with the kustomize output in the examples.
3. When using auto-complete, we no longer re-suggest duplicate values.

The first two are very minor, but the third one needed a little refactoring to get all the information in the right places.