### PR TITLE
Remove Generator.SetDefaultSelectors

### DIFF
--- a/internal/experiment/generation/replicas.go
+++ b/internal/experiment/generation/replicas.go
@@ -34,6 +34,16 @@ type ReplicaSelector struct {
 
 var _ scan.Selector = &ReplicaSelector{}
 
+func (s *ReplicaSelector) Default() {
+	if s.Kind == "" {
+		s.Group = "apps|extensions"
+		s.Kind = "Deployment|StatefulSet"
+	}
+	if s.Path == "" {
+		s.Path = "/spec/replicas"
+	}
+}
+
 func (s *ReplicaSelector) Map(node *yaml.RNode, meta yaml.ResourceMeta) ([]interface{}, error) {
 	var result []interface{}
 

--- a/redskyctl/internal/commands/export/export.go
+++ b/redskyctl/internal/commands/export/export.go
@@ -367,7 +367,6 @@ func (o *Options) generateExperiment(trial *trialDetails) error {
 		FilterOptions:  opts,
 	}
 
-	gen.SetDefaultSelectors()
 	if gen.Scenario == "" && gen.Objective == "" {
 		gen.Scenario, gen.Objective = apppkg.GuessScenarioAndObjective(&gen.Application, gen.ExperimentName)
 	}

--- a/redskyctl/internal/commands/generate/experiment.go
+++ b/redskyctl/internal/commands/generate/experiment.go
@@ -111,9 +111,6 @@ func (o *ExperimentOptions) generate() error {
 		o.Generator.Application.Name = o.defaultName()
 	}
 
-	// Configure how we filter the application resources when looking for requests/limits
-	o.Generator.SetDefaultSelectors()
-
 	// Generate the experiment
 	return o.Generator.Execute(o.YAMLWriter())
 }

--- a/redskyctl/internal/commands/run/command.go
+++ b/redskyctl/internal/commands/run/command.go
@@ -215,7 +215,6 @@ func (o *Options) generateExperiment() tea.Msg {
 	msg := internal.ExperimentMsg{}
 
 	o.Generator.Application.Default()
-	o.Generator.SetDefaultSelectors()
 
 	if err := o.Generator.Execute(&msg); err != nil {
 		return err


### PR DESCRIPTION
Currently the selectors are configured on the generator independently of application state, remembering to call `SetDefaultSelectors` is error prone, and the default values are separated from the implementations. This PR addresses those issues by eliminating the `SetDefaultSelectors` function (and the corresponding generator specific configuration fields) and instead generating the selectors base on the application state as needed.

I changed the ordering on some of the CRS fields and made the limit range map exported just make things line up nicely: the plan going forward is to add more fields to the Application API versions of these resources (but for various reasons the fields won't ever quite match up so it still makes sense to have multiple representations; e.g. "selectors" -> "labelSelectors" where the field names were chosen for consistency in both contexts).

The behavior for defaulting the replica selector is a little different then the contain resources selector because the path for the replicas field is common across a broader set of resources.