### PR TITLE
Fix command

### DIFF
--- a/internal/application/generator.go
+++ b/internal/application/generator.go
@@ -23,6 +23,7 @@ import (
 	"github.com/thestormforge/konjure/pkg/konjure"
 	redskyappsv1alpha1 "github.com/thestormforge/optimize-controller/api/apps/v1alpha1"
 	"github.com/thestormforge/optimize-controller/internal/scan"
+	"github.com/thestormforge/optimize-controller/internal/sfio"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/json"
 	"sigs.k8s.io/kustomize/kyaml/kio"
@@ -97,7 +98,7 @@ func (g *Generator) Map(node *yaml.RNode, meta yaml.ResourceMeta) ([]interface{}
 
 // Transform converts the scan information into an application definition.
 func (g *Generator) Transform(_ []*yaml.RNode, selected []interface{}) ([]*yaml.RNode, error) {
-	result := scan.ObjectSlice{}
+	result := sfio.ObjectSlice{}
 
 	app := &redskyappsv1alpha1.Application{}
 	for _, sel := range selected {

--- a/internal/experiment/generation/containerresources.go
+++ b/internal/experiment/generation/containerresources.go
@@ -24,6 +24,7 @@ import (
 	"github.com/thestormforge/konjure/pkg/filters"
 	redskyv1beta1 "github.com/thestormforge/optimize-controller/api/v1beta1"
 	"github.com/thestormforge/optimize-controller/internal/scan"
+	"github.com/thestormforge/optimize-controller/internal/sfio"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -160,7 +161,7 @@ func (s *ContainerResourcesSelector) saveContainerLimitRange(namespace string, n
 	}
 
 	lri := corev1.LimitRangeItem{}
-	if err := scan.DecodeYAMLToJSON(lriNode, &lri); err != nil {
+	if err := sfio.DecodeYAMLToJSON(lriNode, &lri); err != nil {
 		return err
 	}
 
@@ -203,7 +204,7 @@ func (p *containerResourcesParameter) Patch(name ParameterNamer) (yaml.Filter, e
 func (p *containerResourcesParameter) Parameters(name ParameterNamer) ([]redskyv1beta1.Parameter, error) {
 	// ResourceList (actually, Quantities) won't unmarshal as YAML so we need to round trip through JSON
 	r := corev1.ResourceRequirements{}
-	if err := scan.DecodeYAMLToJSON(yaml.NewRNode(p.value), &r); err != nil {
+	if err := sfio.DecodeYAMLToJSON(yaml.NewRNode(p.value), &r); err != nil {
 		return nil, err
 	}
 

--- a/internal/experiment/generation/generation.go
+++ b/internal/experiment/generation/generation.go
@@ -22,8 +22,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"reflect"
-	"strings"
 
 	redskyappsv1alpha1 "github.com/thestormforge/optimize-controller/api/apps/v1alpha1"
 	redskyv1beta1 "github.com/thestormforge/optimize-controller/api/v1beta1"
@@ -32,31 +30,7 @@ import (
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/kustomize/api/types"
-	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
-
-func init() {
-	// Hack the sort order used by the format filter to make experiments sort more naturally
-	addFieldOrder := func(obj interface{}, order int) {
-		t := reflect.Indirect(reflect.ValueOf(obj)).Type()
-		for i := 0; i < t.NumField(); i++ {
-			if tag := strings.Split(t.Field(i).Tag.Get("json"), ",")[0]; tag != "" {
-				if _, ok := yaml.FieldOrder[tag]; !ok {
-					yaml.FieldOrder[tag] = order
-				}
-				order++
-			}
-		}
-	}
-
-	addFieldOrder(&redskyv1beta1.ExperimentSpec{}, 200)
-	addFieldOrder(&redskyv1beta1.Parameter{}, 300)
-	addFieldOrder(&redskyv1beta1.PatchTemplate{}, 400)
-	addFieldOrder(&redskyv1beta1.Metric{}, 500)
-
-	// TODO We should probably move this code to a more generic YAML package
-	addFieldOrder(&redskyappsv1alpha1.Application{}, 600)
-}
 
 // newGoalMetric creates a new metric for the supplied goal with most fields pre-filled.
 func newGoalMetric(obj *redskyappsv1alpha1.Goal, query string) redskyv1beta1.Metric {

--- a/internal/experiment/generation/locust.go
+++ b/internal/experiment/generation/locust.go
@@ -21,7 +21,7 @@ import (
 
 	redskyappsv1alpha1 "github.com/thestormforge/optimize-controller/api/apps/v1alpha1"
 	redskyv1beta1 "github.com/thestormforge/optimize-controller/api/v1beta1"
-	"github.com/thestormforge/optimize-controller/internal/scan"
+	"github.com/thestormforge/optimize-controller/internal/sfio"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
@@ -85,7 +85,7 @@ func (s *LocustSource) Update(exp *redskyv1beta1.Experiment) error {
 }
 
 func (s *LocustSource) Read() ([]*yaml.RNode, error) {
-	result := scan.ObjectSlice{}
+	result := sfio.ObjectSlice{}
 
 	if s.Scenario.Locust.Locustfile != "" {
 		data, err := loadApplicationData(s.Application, s.Scenario.Locust.Locustfile)

--- a/internal/experiment/generation/prometheus.go
+++ b/internal/experiment/generation/prometheus.go
@@ -19,7 +19,7 @@ package generation
 import (
 	redskyappsv1alpha1 "github.com/thestormforge/optimize-controller/api/apps/v1alpha1"
 	redskyv1beta1 "github.com/thestormforge/optimize-controller/api/v1beta1"
-	"github.com/thestormforge/optimize-controller/internal/scan"
+	"github.com/thestormforge/optimize-controller/internal/sfio"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -52,7 +52,7 @@ type BuiltInPrometheus struct {
 	ServiceAccountName     string
 	ClusterRoleBindingName string
 
-	scan.ObjectSlice
+	sfio.ObjectSlice
 }
 
 var _ ExperimentSource = &BuiltInPrometheus{} // Service Account name and Setup Task

--- a/internal/experiment/generation/stormforger.go
+++ b/internal/experiment/generation/stormforger.go
@@ -25,7 +25,7 @@ import (
 	"github.com/pelletier/go-toml"
 	redskyappsv1alpha1 "github.com/thestormforge/optimize-controller/api/apps/v1alpha1"
 	redskyv1beta1 "github.com/thestormforge/optimize-controller/api/v1beta1"
-	"github.com/thestormforge/optimize-controller/internal/scan"
+	"github.com/thestormforge/optimize-controller/internal/sfio"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
@@ -125,7 +125,7 @@ func (s *StormForgerSource) Update(exp *redskyv1beta1.Experiment) error {
 }
 
 func (s *StormForgerSource) Read() ([]*yaml.RNode, error) {
-	result := scan.ObjectSlice{}
+	result := sfio.ObjectSlice{}
 
 	org, tc := s.stormForgerTestCase()
 

--- a/internal/experiment/generation/transformer.go
+++ b/internal/experiment/generation/transformer.go
@@ -24,6 +24,7 @@ import (
 
 	redskyv1beta1 "github.com/thestormforge/optimize-controller/api/v1beta1"
 	"github.com/thestormforge/optimize-controller/internal/scan"
+	"github.com/thestormforge/optimize-controller/internal/sfio"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 	"sigs.k8s.io/kustomize/kyaml/kio/filters"
@@ -134,7 +135,7 @@ func (t *Transformer) Transform(nodes []*yaml.RNode, selected []interface{}) ([]
 	}
 
 	// Serialize the experiment as a YAML node
-	if expNode, err := (scan.ObjectSlice{&exp}).Read(); err != nil {
+	if expNode, err := (sfio.ObjectSlice{&exp}).Read(); err != nil {
 		return nil, err
 	} else {
 		result = append(expNode, result...) // Put the experiment at the front

--- a/internal/sfio/fns.go
+++ b/internal/sfio/fns.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2021 GramLabs, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sfio
+
+import (
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+func RenameField(from, to string) FieldRenamer {
+	return FieldRenamer{From: from, To: to}
+}
+
+type FieldRenamer struct {
+	From string
+	To   string
+}
+
+func (f FieldRenamer) Filter(rn *yaml.RNode) (*yaml.RNode, error) {
+	if err := yaml.ErrorIfInvalid(rn, yaml.MappingNode); err != nil {
+		return nil, err
+	}
+
+	// TODO This doesn't account for when the "To" field already exists...
+
+	for i := 0; i < len(rn.Content()); i = yaml.IncrementFieldIndex(i) {
+		if rn.Content()[i].Value == f.From {
+			rn.Content()[i].Value = f.To
+			return yaml.Get(f.To).Filter(rn)
+		}
+	}
+
+	return nil, nil
+}
+
+func ClearFieldComment(name string, comments ...string) CommentClearer {
+	cc := CommentClearer{Name: name}
+	if len(comments) > 0 {
+		cc.Comments.LineComment = comments[0]
+	}
+	if len(comments) > 1 {
+		cc.Comments.HeadComment = comments[1]
+	}
+	if len(comments) > 2 {
+		cc.Comments.FootComment = comments[2]
+	}
+	return cc
+}
+
+type CommentClearer struct {
+	Name string
+	yaml.Comments
+}
+
+func (f CommentClearer) Filter(rn *yaml.RNode) (*yaml.RNode, error) {
+	if err := yaml.ErrorIfInvalid(rn, yaml.MappingNode); err != nil {
+		return nil, err
+	}
+
+	for i := 0; i < len(rn.Content()); i = yaml.IncrementFieldIndex(i) {
+		c := rn.Content()[i]
+		if c.Value == f.Name {
+			if c.LineComment == f.Comments.LineComment {
+				c.LineComment = ""
+			}
+			if c.HeadComment == f.Comments.HeadComment {
+				c.HeadComment = ""
+			}
+			if c.FootComment == f.Comments.FootComment {
+				c.FootComment = ""
+			}
+			return yaml.Get(f.Name).Filter(rn)
+		}
+	}
+
+	return rn, nil
+}
+
+// Has works like `yaml.Tee` except that is also preserves a nil filter result.
+func Has(filters ...yaml.Filter) HasFilter {
+	return HasFilter{Filters: filters}
+}
+
+type HasFilter struct {
+	Filters []yaml.Filter
+}
+
+func (f HasFilter) Filter(rn *yaml.RNode) (*yaml.RNode, error) {
+	n, err := rn.Pipe(f.Filters...)
+	if err != nil {
+		return nil, err
+	}
+	if yaml.IsMissingOrNull(n) {
+		return nil, nil
+	}
+	return rn, nil
+}

--- a/internal/sfio/migrate.go
+++ b/internal/sfio/migrate.go
@@ -1,0 +1,212 @@
+/*
+Copyright 2021 GramLabs, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sfio
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/thestormforge/konjure/pkg/filters"
+	redskyv1alpha1 "github.com/thestormforge/optimize-controller/api/v1alpha1"
+	redskyv1beta1 "github.com/thestormforge/optimize-controller/api/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+// ExperimentMigrationFilter is a KYAML filter for perform experiment migration.
+type ExperimentMigrationFilter struct {
+}
+
+// Filter applies migration changes to all recognized experiment nodes in the supplied list.
+func (f *ExperimentMigrationFilter) Filter(node *yaml.RNode) (*yaml.RNode, error) {
+	return node.Pipe(
+		yaml.Tee(
+			filters.FilterOne(&filters.ResourceMetaFilter{
+				Group:   redskyv1alpha1.GroupVersion.Group,
+				Version: redskyv1alpha1.GroupVersion.Version,
+				Kind:    "Experiment",
+			}),
+			yaml.FilterFunc(f.MigrateExperimentV1alpha1),
+		),
+
+		yaml.Tee(
+			filters.FilterOne(&filters.ResourceMetaFilter{
+				Group:   redskyv1beta1.GroupVersion.Group,
+				Version: redskyv1beta1.GroupVersion.Version,
+				Kind:    "Experiment",
+			}),
+			yaml.FilterFunc(f.MigrateExperimentV1beta1),
+		),
+	)
+}
+
+// MigrateExperimentV1beta1 converts a resource node from a v1beta1 Experiment to the latest format.
+func (f *ExperimentMigrationFilter) MigrateExperimentV1beta1(node *yaml.RNode) (*yaml.RNode, error) {
+	return node.Pipe()
+}
+
+// MigrateExperimentV1alpha1 converts a resource node from a v1alpha1 Experiment to a v1beta1 Experiment.
+func (f *ExperimentMigrationFilter) MigrateExperimentV1alpha1(node *yaml.RNode) (*yaml.RNode, error) {
+	return node.Pipe(
+		// Remove the "# trial", "# job", "# pod" comments if present
+		yaml.Tee(
+			yaml.Lookup("spec"), ClearFieldComment("template", "# trial"),
+			yaml.Lookup("spec"), ClearFieldComment("template", "# job"),
+			yaml.Lookup("spec"), ClearFieldComment("template", "# pod"),
+		),
+
+		// Rename the template fields
+		yaml.Tee(
+			yaml.Lookup("spec"), RenameField("template", "trialTemplate"),
+			yaml.Lookup("spec"), RenameField("template", "jobTemplate"),
+		),
+
+		// Migrate the parameters
+		yaml.Tee(
+			yaml.Lookup("spec", "parameters"), yaml.FilterFunc(f.migrateParametersV1alpha1),
+		),
+
+		// Migrate the metrics
+		yaml.Tee(
+			yaml.Lookup("spec", "metrics"), yaml.FilterFunc(f.migrateMetricsV1alpha1),
+		),
+
+		// Finally, set the apiVersion
+		yaml.Tee(
+			yaml.SetField("apiVersion", yaml.NewStringRNode(redskyv1beta1.GroupVersion.String())),
+		),
+	)
+}
+
+func (f *ExperimentMigrationFilter) migrateParametersV1alpha1(node *yaml.RNode) (*yaml.RNode, error) {
+	elements, err := node.Elements()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, e := range elements {
+		err := e.PipeE(
+			// If values is non-empty, remove min/max
+			yaml.Tee(
+				Has(yaml.Lookup("values", "-")),
+				yaml.Tee(yaml.Clear("min")),
+				yaml.Tee(yaml.Clear("max")),
+			),
+		)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return node, nil
+}
+
+func (f *ExperimentMigrationFilter) migrateMetricsV1alpha1(node *yaml.RNode) (*yaml.RNode, error) {
+	elements, err := node.Elements()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, e := range elements {
+		m := metric{}
+		if err := e.YNode().Decode(&m); err != nil {
+			return nil, err
+		}
+
+		err := e.PipeE(
+			// Change metric type "local" to "kubernetes"
+			yaml.Tee(
+				yaml.MatchField("type", "local"),
+				yaml.Set(yaml.NewStringRNode(string(redskyv1beta1.MetricKubernetes))),
+			),
+
+			// Change type "pods" to "" and add "target: { kind: PodList }"
+			yaml.Tee(
+				Has(
+					yaml.MatchField("type", "pods"),
+					yaml.Set(yaml.NewStringRNode("")),
+				),
+				yaml.SetField("target", yaml.NewMapRNode(&map[string]string{
+					"kind": "PodList",
+				})),
+			),
+
+			// Set or clear the URL field
+			yaml.Tee(
+				m.setURLField("url"),
+			),
+
+			// Rename the selector to target (must happen AFTER setting the "url" field because we unmarshal it)
+			yaml.Tee(
+				RenameField("selector", "target"),
+			),
+		)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return node, nil
+}
+
+// metric represents the parts of a v1alpha1 metric required for producing a v1beta1 metric URL.
+type metric struct {
+	Type     string                `yaml:"type"`
+	Scheme   string                `yaml:"scheme"`
+	Selector *metav1.LabelSelector `yaml:"selector"`
+	Port     intstr.IntOrString    `yaml:"port"`
+	Path     string                `yaml:"path"`
+}
+
+// setURLField returns a filter that will set the named field with the metric URL.
+func (m *metric) setURLField(name string) yaml.Filter {
+	switch m.Type {
+	case "prometheus":
+		if m.Selector == nil || (len(m.Selector.MatchLabels) == 1 && m.Selector.MatchLabels["app"] == "prometheus") {
+			return yaml.Clear(name)
+		}
+	case "datadog":
+		u := url.URL{RawQuery: url.Values{"aggregator": []string{m.Scheme}}.Encode()}
+		return yaml.SetField(name, yaml.NewStringRNode(u.String()))
+	case "jsonpath":
+		// Don't return empty
+	default:
+		return yaml.Clear(name)
+	}
+
+	u := url.URL{
+		Scheme: m.Scheme,
+		Host:   redskyv1alpha1.LegacyHostnamePlaceholder,
+		Path:   m.Path,
+	}
+
+	if u.Scheme == "" {
+		u.Scheme = "http"
+	}
+
+	if m.Port.IntValue() > 0 {
+		u.Host += ":" + m.Port.String()
+	}
+
+	if p := strings.SplitN(m.Path, "?", 2); len(p) > 1 {
+		u.Path = p[0]
+		u.RawQuery = p[1]
+	}
+
+	return yaml.SetField(name, yaml.NewStringRNode(u.String()))
+}

--- a/internal/sfio/order.go
+++ b/internal/sfio/order.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2021 GramLabs, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sfio
+
+import (
+	"reflect"
+	"strings"
+
+	redskyappsv1alpha1 "github.com/thestormforge/optimize-controller/api/apps/v1alpha1"
+	redskyv1beta1 "github.com/thestormforge/optimize-controller/api/v1beta1"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+func init() {
+	addFieldOrder(&redskyv1beta1.ExperimentSpec{}, 200)
+	addFieldOrder(&redskyv1beta1.Parameter{}, 300)
+	addFieldOrder(&redskyv1beta1.PatchTemplate{}, 400)
+	addFieldOrder(&redskyv1beta1.Metric{}, 500)
+	addFieldOrder(&redskyappsv1alpha1.Application{}, 600)
+}
+
+// addFieldOrder use reflection to try and make the YAML sort order match the Go struct field order.
+func addFieldOrder(obj interface{}, order int) {
+	t := reflect.Indirect(reflect.ValueOf(obj)).Type()
+	for i := 0; i < t.NumField(); i++ {
+		if tag := strings.Split(t.Field(i).Tag.Get("json"), ",")[0]; tag != "" {
+			if _, ok := yaml.FieldOrder[tag]; !ok {
+				yaml.FieldOrder[tag] = order
+			}
+			order++
+		}
+	}
+}

--- a/internal/sfio/runtime.go
+++ b/internal/sfio/runtime.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package scan
+package sfio
 
 import (
 	redskyappsv1alpha1 "github.com/thestormforge/optimize-controller/api/apps/v1alpha1"

--- a/redskyctl/internal/commands/commands.go
+++ b/redskyctl/internal/commands/commands.go
@@ -34,6 +34,7 @@ import (
 	"github.com/thestormforge/optimize-controller/redskyctl/internal/commands/docs"
 	"github.com/thestormforge/optimize-controller/redskyctl/internal/commands/experiments"
 	"github.com/thestormforge/optimize-controller/redskyctl/internal/commands/export"
+	"github.com/thestormforge/optimize-controller/redskyctl/internal/commands/fix"
 	"github.com/thestormforge/optimize-controller/redskyctl/internal/commands/generate"
 	"github.com/thestormforge/optimize-controller/redskyctl/internal/commands/grant_permissions"
 	"github.com/thestormforge/optimize-controller/redskyctl/internal/commands/initialize"
@@ -71,6 +72,7 @@ func NewRedskyctlCommand() *cobra.Command {
 	rootCmd.AddCommand(grant_permissions.NewCommand(&grant_permissions.Options{GeneratorOptions: grant_permissions.GeneratorOptions{Config: cfg}}))
 	rootCmd.AddCommand(authorize_cluster.NewCommand(&authorize_cluster.Options{GeneratorOptions: authorize_cluster.GeneratorOptions{Config: cfg}}))
 	rootCmd.AddCommand(generate.NewCommand(&generate.Options{Config: cfg}))
+	rootCmd.AddCommand(fix.NewCommand(&fix.Options{}))
 	rootCmd.AddCommand(export.NewCommand(&export.Options{Config: cfg}))
 	rootCmd.AddCommand(run.NewCommand(&run.Options{Config: cfg}))
 

--- a/redskyctl/internal/commands/export/export.go
+++ b/redskyctl/internal/commands/export/export.go
@@ -34,6 +34,7 @@ import (
 	"github.com/thestormforge/optimize-controller/internal/patch"
 	"github.com/thestormforge/optimize-controller/internal/scan"
 	"github.com/thestormforge/optimize-controller/internal/server"
+	"github.com/thestormforge/optimize-controller/internal/sfio"
 	"github.com/thestormforge/optimize-controller/internal/template"
 	"github.com/thestormforge/optimize-controller/redskyctl/internal/commander"
 	"github.com/thestormforge/optimize-controller/redskyctl/internal/kustomize"
@@ -371,7 +372,7 @@ func (o *Options) generateExperiment(trial *trialDetails) error {
 		gen.Scenario, gen.Objective = apppkg.GuessScenarioAndObjective(&gen.Application, gen.ExperimentName)
 	}
 
-	if err := gen.Execute((*scan.ObjectList)(list)); err != nil {
+	if err := gen.Execute((*sfio.ObjectList)(list)); err != nil {
 		return err
 	}
 

--- a/redskyctl/internal/commands/fix/fix.go
+++ b/redskyctl/internal/commands/fix/fix.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2021 GramLabs, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fix
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/thestormforge/optimize-controller/internal/sfio"
+	"github.com/thestormforge/optimize-controller/redskyctl/internal/commander"
+	"sigs.k8s.io/kustomize/kyaml/kio"
+	"sigs.k8s.io/kustomize/kyaml/kio/filters"
+)
+
+type Options struct {
+	commander.IOStreams
+	Filenames []string
+}
+
+func NewCommand(o *Options) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "fix",
+		Short: "Fix manifests",
+
+		PreRun: commander.StreamsPreRun(&o.IOStreams),
+		RunE:   commander.WithoutArgsE(o.Fix),
+	}
+
+	cmd.Flags().StringArrayVarP(&o.Filenames, "filename", "f", nil, "manifest `file` to fix")
+
+	_ = cmd.MarkFlagFilename("filename", "yml", "yaml")
+	_ = cmd.MarkFlagRequired("filename")
+
+	return cmd
+}
+
+func (o *Options) Fix() error {
+	p := kio.Pipeline{
+		Filters: []kio.Filter{
+			kio.FilterAll(&sfio.ExperimentMigrationFilter{}),
+			filters.FormatFilter{},
+		},
+		Outputs: []kio.Writer{o.YAMLWriter()},
+	}
+
+	for _, filename := range o.Filenames {
+		p.Inputs = append(p.Inputs, o.YAMLReader(filename))
+	}
+
+	return p.Execute()
+}

--- a/redskyctl/internal/commands/run/model.go
+++ b/redskyctl/internal/commands/run/model.go
@@ -22,7 +22,7 @@ import (
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	redskyv1beta1 "github.com/thestormforge/optimize-controller/api/v1beta1"
-	"github.com/thestormforge/optimize-controller/internal/scan"
+	"github.com/thestormforge/optimize-controller/internal/sfio"
 	"github.com/thestormforge/optimize-controller/redskyctl/internal/commands/run/form"
 	"github.com/thestormforge/optimize-controller/redskyctl/internal/commands/run/internal"
 	"sigs.k8s.io/kustomize/kyaml/kio"
@@ -258,7 +258,7 @@ func (m previewModel) Update(msg tea.Msg) (previewModel, tea.Cmd) {
 
 	case internal.ExperimentMsg:
 		// Extract the experiment definition from the YAML to make it easier to pull values from
-		obj := scan.ObjectList{}
+		obj := sfio.ObjectList{}
 		if err := obj.Write(msg); err != nil {
 			return m, internal.Error(err)
 		}


### PR DESCRIPTION
This PR adds a `redskyctl fix -f experiment.yaml` command. The goal of this command is to provide something to aid in the eventual migration away from the `redskyops.dev` group name. The current implementation handles all of the v1alpha1 -> v1beta1 Experiment object migrations.

Note that this migration path is one way (sequenced as migrations from version N-1 to N) and is performed directly on the YAML (not the Go structures). It does not handle migration of trial data. This tool is intended to be used on stored experiment files outside of the cluster. Although it solves a different problem, when we move away from redskyops.dev the current scheme based migration code will become obsolete and will be removed (i.e. this will be the only way to get from a v1alpha1 to where ever we end up).