### PR TITLE
SFIO improvements

### DIFF
--- a/internal/experiment/generation/quantity.go
+++ b/internal/experiment/generation/quantity.go
@@ -42,30 +42,30 @@ func AsScaledInt(q resource.Quantity, scale resource.Scale) int32 {
 	return int32(v)
 }
 
-type suffixList []string
-
-func (l suffixList) lookup(scale resource.Scale) string {
-	i := int(scale)/3 + 3
-	if int(scale)%3 != 0 || i < 0 || i >= len(l) {
-		return ""
-	}
-	return l[i]
-}
-
 var (
-	binarySuffix  = suffixList{"", "", "", "", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei"}
-	decimalSuffix = suffixList{"n", "u", "m", "", "k", "M", "G", "T", "P", "E"}
+	binarySuffix  = []string{"", "", "", "", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei"}
+	decimalSuffix = []string{"n", "u", "m", "", "k", "M", "G", "T", "P", "E"}
 )
 
 // QuantitySuffix returns the suffix for a quantity or an empty string if it is
 // known. Note that although scale is just an int, you should only use the
 // predefined constants (or variables populated from them) when calling.
 func QuantitySuffix(scale resource.Scale, format resource.Format) string {
+	index := func(suffixes []string, scale resource.Scale) string {
+		// Adjust the Scale (Nano=-9 ... Exa=18) to match the index in the suffix arrays
+		i := int(scale-resource.Nano) / 3
+		// Suffixes only exist if the scale is divisible by 3 (i.e. powers of 1000)
+		if int(scale)%3 != 0 || i < 0 || i >= len(suffixes) {
+			return ""
+		}
+		return suffixes[i]
+	}
+
 	switch format {
 	case resource.BinarySI:
-		return binarySuffix.lookup(scale)
+		return index(binarySuffix, scale)
 	case resource.DecimalSI:
-		return decimalSuffix.lookup(scale)
+		return index(decimalSuffix, scale)
 	default:
 		return ""
 	}

--- a/internal/experiment/generation/quantity.go
+++ b/internal/experiment/generation/quantity.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2021 GramLabs, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generation
+
+import (
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// AsScaledInt scales the quantity to the appropriate scale, honoring the base
+// as determined by the format of the supplied quantity. For example,
+// AsScaledInt(NewQuantity(1, BinarySI), Milli) returns 1024.
+func AsScaledInt(q resource.Quantity, scale resource.Scale) int32 {
+	// ScaledValue works fine for base 10
+	if q.Format != resource.BinarySI {
+		return int32(q.ScaledValue(scale))
+	}
+
+	v := q.Value()
+	if scale > 0 {
+		for e := int(scale) / 3; e > 0; e-- {
+			v /= 1024
+		}
+	} else {
+		for e := int(scale) / 3; e < 0; e++ {
+			v *= 1024
+		}
+	}
+	return int32(v)
+}
+
+type suffixList []string
+
+func (l suffixList) lookup(scale resource.Scale) string {
+	i := int(scale)/3 + 3
+	if int(scale)%3 != 0 || i < 0 || i >= len(l) {
+		return ""
+	}
+	return l[i]
+}
+
+var (
+	binarySuffix  = suffixList{"", "", "", "", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei"}
+	decimalSuffix = suffixList{"n", "u", "m", "", "k", "M", "G", "T", "P", "E"}
+)
+
+// QuantitySuffix returns the suffix for a quantity or an empty string if it is
+// known. Note that although scale is just an int, you should only use the
+// predefined constants (or variables populated from them) when calling.
+func QuantitySuffix(scale resource.Scale, format resource.Format) string {
+	switch format {
+	case resource.BinarySI:
+		return binarySuffix.lookup(scale)
+	case resource.DecimalSI:
+		return decimalSuffix.lookup(scale)
+	default:
+		return ""
+	}
+}

--- a/internal/experiment/generation/quantity_test.go
+++ b/internal/experiment/generation/quantity_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2021 GramLabs, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generation
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestAsScaledInt(t *testing.T) {
+	cases := []struct {
+		q        resource.Quantity
+		scale    resource.Scale
+		expected int32
+	}{
+		// AsScaledInt vs ScaledValue
+		{
+			q:        *resource.NewQuantity(1, resource.BinarySI),
+			scale:    resource.Milli,
+			expected: 1024,
+		},
+		{
+			q:        *resource.NewQuantity(1, resource.DecimalSI),
+			scale:    resource.Milli,
+			expected: 1000,
+		},
+
+		// Binary Mega
+		{
+			q:        resource.MustParse("2Gi"),
+			scale:    resource.Mega,
+			expected: 2048,
+		},
+		{
+			q:        resource.MustParse("2Mi"),
+			scale:    resource.Mega,
+			expected: 2,
+		},
+		{
+			q:        resource.MustParse("2048Ki"),
+			scale:    resource.Mega,
+			expected: 2,
+		},
+
+		// Decimal Mega
+		{
+			q:        resource.MustParse("2G"),
+			scale:    resource.Mega,
+			expected: 2000,
+		},
+		{
+			q:        resource.MustParse("2M"),
+			scale:    resource.Mega,
+			expected: 2,
+		},
+		{
+			q:        resource.MustParse("2000k"),
+			scale:    resource.Mega,
+			expected: 2,
+		},
+
+		// Decimal Milli
+		{
+			q:        resource.MustParse("2.0"),
+			scale:    resource.Milli,
+			expected: 2000,
+		},
+		{
+			q:        resource.MustParse("2000m"),
+			scale:    resource.Milli,
+			expected: 2000,
+		},
+		{
+			q:        resource.MustParse("2000000u"),
+			scale:    resource.Milli,
+			expected: 2000,
+		},
+	}
+	for _, c := range cases {
+		t.Run(desc(c.q.String(), c.scale), func(t *testing.T) {
+			assert.Equal(t, c.expected, AsScaledInt(c.q, c.scale))
+		})
+	}
+}
+
+func TestQuantitySuffix(t *testing.T) {
+	cases := []struct {
+		scale    resource.Scale
+		format   resource.Format
+		expected string
+	}{
+		{expected: "Mi", scale: resource.Mega, format: resource.BinarySI},
+		{expected: "", scale: resource.Nano, format: resource.BinarySI},
+		{expected: "", scale: resource.Scale(-96), format: resource.BinarySI},
+		{expected: "n", scale: resource.Nano, format: resource.DecimalSI},
+		{expected: "E", scale: resource.Exa, format: resource.DecimalSI},
+		{expected: "", scale: resource.Exa + 1, format: resource.DecimalSI},
+		{expected: "", scale: resource.Exa + 3, format: resource.DecimalSI},
+	}
+	for _, c := range cases {
+		t.Run(desc(string(c.format), c.scale), func(t *testing.T) {
+			assert.Equal(t, c.expected, QuantitySuffix(c.scale, c.format))
+		})
+	}
+}
+
+func desc(str string, scale resource.Scale) string {
+	scaleString := fmt.Sprintf("Pow10(%d)", scale)
+	i := scale/3 + 3
+	if scale%3 == 0 && i >= 0 && i < 9 {
+		scaleString = []string{"Nano", "Micro", "Milli", "", "Kilo", "Mega", "Giga", "Tera", "Peta", "Exa"}[i]
+	}
+
+	return fmt.Sprintf("%s_%s", str, scaleString)
+}

--- a/internal/sfio/fieldpath.go
+++ b/internal/sfio/fieldpath.go
@@ -16,7 +16,45 @@ limitations under the License.
 
 package sfio
 
-import "sigs.k8s.io/kustomize/kyaml/yaml"
+import (
+	"strings"
+	"text/template"
+
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+// FieldPath evaluates a path template using the supplied context and then
+// splits it into individual path segments (honoring escaped slashes).
+func FieldPath(p string, data map[string]string) ([]string, error) {
+	// Evaluate the path as a Go Template
+	t, err := template.New("path").
+		Delims("{", "}").
+		Option("missingkey=zero").
+		Parse(p)
+	if err != nil {
+		return nil, err
+	}
+	var pathBuf strings.Builder
+	if err := t.Execute(&pathBuf, data); err != nil {
+		return nil, err
+	}
+
+	// Remove the leading slash to prevent empty elements
+	path := strings.TrimLeft(pathBuf.String(), "/")
+	if path == "" {
+		return nil, nil
+	} else if !strings.Contains(path, `\/`) {
+		return strings.Split(path, "/"), nil
+	}
+
+	// Handle escaped slashes using a temporary placeholder
+	// NOTE: This just mimics the logic of the equivalent code in the Kustomize FieldPath
+	var result []string
+	for _, pp := range strings.Split(strings.ReplaceAll(path, `\/`, `???`), "/") {
+		result = append(result, strings.ReplaceAll(pp, `???`, `/`))
+	}
+	return result, nil
+}
 
 // PreserveFieldMatcherPath wraps a field matcher so the resulting nodes have
 // their field path set accordingly (incoming path + field name).

--- a/internal/sfio/fieldpath.go
+++ b/internal/sfio/fieldpath.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2021 GramLabs, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sfio
+
+import "sigs.k8s.io/kustomize/kyaml/yaml"
+
+// PreserveFieldMatcherPath wraps a field matcher so the resulting nodes have
+// their field path set accordingly (incoming path + field name).
+func PreserveFieldMatcherPath(fieldMatcher yaml.FieldMatcher) yaml.Filter {
+	return yaml.FilterFunc(func(node *yaml.RNode) (*yaml.RNode, error) {
+		result, err := fieldMatcher.Filter(node)
+		if err != nil {
+			return nil, err
+		}
+
+		result.AppendToFieldPath(node.FieldPath()...)
+		result.AppendToFieldPath(fieldMatcher.Name)
+		return result, nil
+	})
+}

--- a/internal/sfio/fieldpath_test.go
+++ b/internal/sfio/fieldpath_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2021 GramLabs, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sfio
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFieldPath(t *testing.T) {
+	cases := []struct {
+		desc     string
+		path     string
+		data     map[string]string
+		expected []string
+	}{
+		{
+			desc: "empty",
+		},
+		{
+			desc: "tricky empty",
+			path: `/{ .ItsATrap }`,
+			data: map[string]string{"ItsATrap": "/"},
+		},
+		{
+			desc:     "simple",
+			path:     `/spec/replicas`,
+			expected: []string{"spec", "replicas"},
+		},
+		{
+			desc:     "label",
+			path:     `/metadata/labels/app.kubernetes.io\/name`,
+			expected: []string{"metadata", "labels", "app.kubernetes.io/name"},
+		},
+		{
+			desc:     "parameter",
+			path:     `/spec/containers/[name={.ContainerName}]/image`,
+			data:     map[string]string{"ContainerName": "testing"},
+			expected: []string{"spec", "containers", "[name=testing]", "image"},
+		},
+		{
+			desc:     "leading slash is optional",
+			path:     `spec/replicas`,
+			expected: []string{"spec", "replicas"},
+		},
+		{
+			desc:     "run of leading slashes",
+			path:     `//spec/replicas`,
+			expected: []string{"spec", "replicas"},
+		},
+		{
+			desc:     "no data",
+			path:     `/spec/{ .WhichWayDidHeGo }`,
+			expected: []string{"spec", ""},
+		},
+		{
+			desc:     "consistent with Kustomize",
+			path:     `/a\/b/c???d`,
+			expected: []string{"a/b", "c/d"}, // Should be {"a/b", "c???d"}
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			actual, err := FieldPath(c.path, c.data)
+			if assert.NoError(t, err) {
+				assert.Equal(t, c.expected, actual)
+			}
+		})
+	}
+}

--- a/internal/sfio/fns.go
+++ b/internal/sfio/fns.go
@@ -17,6 +17,8 @@ limitations under the License.
 package sfio
 
 import (
+	"fmt"
+
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
@@ -126,4 +128,51 @@ func (f HasFilter) Filter(rn *yaml.RNode) (*yaml.RNode, error) {
 		return nil, nil
 	}
 	return rn, nil
+}
+
+// TeeMatched acts as a "tee" filter for nodes matched by the supplied path matcher:
+// each matched node is processed by the supplied filters and the result of the
+// entire operation is the initial node (or an error).
+func TeeMatched(pathMatcher yaml.PathMatcher, filters ...yaml.Filter) TeeMatchedFilter {
+	return TeeMatchedFilter{
+		PathMatcher: pathMatcher,
+		Filters:     filters,
+	}
+}
+
+// TeeMatchedFilter is a filter that applies a set of filters to the nodes
+// matched by a path matcher.
+type TeeMatchedFilter struct {
+	PathMatcher yaml.PathMatcher
+	Filters     []yaml.Filter
+}
+
+// Filter always returns the supplied node, however all matching nodes will have
+// been processed by the configured filters.
+func (f TeeMatchedFilter) Filter(rn *yaml.RNode) (*yaml.RNode, error) {
+	matches, err := f.PathMatcher.Filter(rn)
+	if err != nil {
+		return nil, err
+	}
+	if err := matches.VisitElements(f.visitMatched); err != nil {
+		return nil, err
+	}
+	return rn, nil
+}
+
+// visitMatched is used internally to preserve the field path and apply the
+// configured filters.
+func (f TeeMatchedFilter) visitMatched(node *yaml.RNode) error {
+	matches := f.PathMatcher.Matches[node.YNode()]
+	matchIndex := 0
+	for _, p := range f.PathMatcher.Path {
+		if yaml.IsListIndex(p) && matchIndex < len(matches) {
+			name, _, _ := yaml.SplitIndexNameValue(p)
+			p = fmt.Sprintf("[%s=%s]", name, matches[matchIndex])
+			matchIndex++
+		}
+		node.AppendToFieldPath(p)
+	}
+
+	return node.PipeE(f.Filters...)
 }

--- a/internal/sfio/fns.go
+++ b/internal/sfio/fns.go
@@ -65,18 +65,8 @@ func (f FieldRenamer) Filter(rn *yaml.RNode) (*yaml.RNode, error) {
 
 // ClearFieldComment returns a filter which will clear matching line comments
 // from a named field.
-func ClearFieldComment(name string, comments ...string) CommentClearer {
-	cc := CommentClearer{Name: name}
-	if len(comments) > 0 {
-		cc.Comments.LineComment = comments[0]
-	}
-	if len(comments) > 1 {
-		cc.Comments.HeadComment = comments[1]
-	}
-	if len(comments) > 2 {
-		cc.Comments.FootComment = comments[2]
-	}
-	return cc
+func ClearFieldComment(name string, lineComment string) CommentClearer {
+	return CommentClearer{Name: name, Comments: yaml.Comments{LineComment: lineComment}}
 }
 
 // CommentClearer is filter for clearing specific comments.


### PR DESCRIPTION
This PR cleans up some of the recent SFIO additions (comments); and adds a few bits of new functionality:
1. There is a replacement for the Kustomize `types.FieldPath` parser that also supports placeholders
2. Offers the ability to preserve the `RNode.fieldPath` through a `yaml.FieldMatcher`
3. Adds a `TeeMatchedFilter` to make `yaml.PathMatcher` usable in a pipeline (also preserving `RNode.fieldPath`)

Note that I am working on some fixes to the `ContainResourceSelector` which will be the first consumer for the new stuff, that isn't quite ready.