### PR TITLE
Container resource scanning maths

### DIFF
--- a/internal/experiment/generation/containerresources.go
+++ b/internal/experiment/generation/containerresources.go
@@ -51,7 +51,7 @@ func (s *ContainerResourcesSelector) Default() {
 	if s.Kind == "" {
 		s.Group = "apps|extensions"
 		s.Kind = "Deployment|StatefulSet"
-		s.Path = "/spec/template/spec/containers/[name={{ .ContainerName }}]/resources"
+		s.Path = "/spec/template/spec/containers/[name={ .ContainerName }]/resources"
 	}
 
 	if len(s.Resources) == 0 {

--- a/internal/experiment/generation/generation.go
+++ b/internal/experiment/generation/generation.go
@@ -29,7 +29,6 @@ import (
 	"github.com/yujunz/go-getter"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/kustomize/api/types"
 )
 
 // newGoalMetric creates a new metric for the supplied goal with most fields pre-filled.
@@ -52,12 +51,6 @@ func ensureTrialJobPod(exp *redskyv1beta1.Experiment) *corev1.PodTemplateSpec {
 		exp.Spec.TrialTemplate.Spec.JobTemplate = &batchv1beta1.JobTemplateSpec{}
 	}
 	return &exp.Spec.TrialTemplate.Spec.JobTemplate.Spec.Template
-}
-
-// splitPath splits a string based path, honoring backslash escaped slashes.
-func splitPath(p string) []string {
-	// TODO This is using the Kustomize API, refactor it out
-	return (&types.FieldSpec{Path: p}).PathSlice()
 }
 
 // trialJobImage returns the image name for a type of job.

--- a/internal/experiment/generation/replicas.go
+++ b/internal/experiment/generation/replicas.go
@@ -19,6 +19,7 @@ package generation
 import (
 	redskyv1beta1 "github.com/thestormforge/optimize-controller/api/v1beta1"
 	"github.com/thestormforge/optimize-controller/internal/scan"
+	"github.com/thestormforge/optimize-controller/internal/sfio"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
@@ -47,8 +48,12 @@ func (s *ReplicaSelector) Default() {
 func (s *ReplicaSelector) Map(node *yaml.RNode, meta yaml.ResourceMeta) ([]interface{}, error) {
 	var result []interface{}
 
-	path := splitPath(s.Path)
-	err := node.PipeE(
+	path, err := sfio.FieldPath(s.Path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, node.PipeE(
 		&yaml.PathGetter{Path: path, Create: yaml.ScalarNode},
 		yaml.FilterFunc(func(node *yaml.RNode) (*yaml.RNode, error) {
 			value := node.YNode()
@@ -67,12 +72,6 @@ func (s *ReplicaSelector) Map(node *yaml.RNode, meta yaml.ResourceMeta) ([]inter
 
 			return node, nil
 		}))
-
-	if err != nil {
-		return nil, err
-	}
-
-	return result, nil
 }
 
 type replicaParameter struct {

--- a/internal/experiment/generator.go
+++ b/internal/experiment/generator.go
@@ -105,7 +105,7 @@ func (g *Generator) Execute(output kio.Writer) error {
 			kio.FilterAll(yaml.Clear("status")),
 		},
 		Outputs: []kio.Writer{
-			// Validate the resulting resources before sending them to the supplier writer
+			// Validate the resulting resources before sending them to the supplied writer
 			kio.WriterFunc(g.validate),
 			output,
 		},


### PR DESCRIPTION
This PR reworks a large section of the contain resource scanning. There are two primary issues:
1. A lot of code was written that already existed in KYAML (namely `PathMatcher`)
2. Correctness: scanning produces unpredictable results because of the rounding and changes number bases.

First there is the clean up to leverage the `PathMatcher`: the initial implementation implemented the extra YAML traversal code that already existed in KYAML (e.g. the container name matching). This was cleaned up, as a result the `Path` value now references all the way down to the `resources` field which makes a lot more sense.

The second problem was how scanning was forcing `Quantity` values to round during min/max and even baseline computations. For example, the old code would take a base 2 ("binary") quantity like `2Gi`, scale it base 10, then round it on 10^6 giving you 2148. The new code is sensitive to the original format (binary or decimal) and scales appropriately so when we see a baseline of `2Gi` we end up with a baseline of `2048Mi` or if we see `2G` we end up with a baseline of `2000M`.