### PR TITLE
Allow metrics to select information from the trial job

### DIFF
--- a/api/v1beta1/experiment_types.go
+++ b/api/v1beta1/experiment_types.go
@@ -41,6 +41,11 @@ type ResourceTarget struct {
 	*metav1.LabelSelector `json:",inline"`
 }
 
+// SetGroupVersionKind overwrites the GVK for the target reference.
+func (r *ResourceTarget) SetGroupVersionKind(gvk schema.GroupVersionKind) {
+	r.APIVersion, r.Kind = gvk.ToAPIVersionAndKind()
+}
+
 // GroupVersionKind returns the GVK for the target reference.
 func (r *ResourceTarget) GroupVersionKind() schema.GroupVersionKind {
 	// NOTE: schema.FromAPIVersionAndKind is discouraged and neglects the default "v1" case


### PR DESCRIPTION
This PR allows metrics to query the trial job in a similar to fashion to what we support for patches. This is useful because the trial job may have state (such as individual container timings) that are relevant as metrics. The change uses the same `IsTrialJobReference` test that the patching code uses.