### PR TITLE
Environment variable scanning

### DIFF
--- a/api/apps/v1alpha1/application_types.go
+++ b/api/apps/v1alpha1/application_types.go
@@ -59,6 +59,8 @@ type Parameter struct {
 	ContainerResources *ContainerResources `json:"containerResources,omitempty"`
 	// Information related to the discovery of replica parameters.
 	Replicas *Replicas `json:"replicas,omitempty"`
+	// Information related to the discovery of environment variables.
+	EnvironmentVariable *EnvironmentVariable `json:"environmentVariable,omitempty"`
 }
 
 // ContainerResources specifies which resources in the application should have their container
@@ -74,6 +76,20 @@ type ContainerResources struct {
 type Replicas struct {
 	// Label selector of Kubernetes objects to consider when generating replica patches.
 	Selector string `json:"selector,omitempty"`
+}
+
+// EnvironmentVariable specifies which environment variables in the application should have their value optimized.
+type EnvironmentVariable struct {
+	// Label selector of Kubernetes objects to consider when looking for environment variables.
+	Selector string `json:"selector,omitempty"`
+	// The name of the environment variable to optimize.
+	Name string `json:"name,omitempty"`
+	// The prefix of the value to use when setting the environment variable.
+	Prefix string `json:"prefix,omitempty"`
+	// The suffix of the value to use when setting the environment variable.
+	Suffix string `json:"suffix,omitempty"`
+	// The discrete values of the environment variable.
+	Values []string `json:"values,omitempty"`
 }
 
 // Ingress describes the point of ingress to the application.

--- a/internal/experiment/generation/environmentvariables.go
+++ b/internal/experiment/generation/environmentvariables.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2021 GramLabs, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generation
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	redskyv1beta1 "github.com/thestormforge/optimize-controller/api/v1beta1"
+	"github.com/thestormforge/optimize-controller/internal/scan"
+	"github.com/thestormforge/optimize-controller/internal/sfio"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+// EnvironmentVariablesSelector scans for environment variables.
+type EnvironmentVariablesSelector struct {
+	scan.GenericSelector
+	// Regular expression matching the container name.
+	ContainerName string `json:"containerName,omitempty"`
+	// Name of the environment variable to match.
+	VariableName string `json:"variableName,omitempty"`
+	// Path to the environment variable's value.
+	Path string `json:"path,omitempty"`
+	// Prefix that appears before the value.
+	ValuePrefix string `json:"valuePrefix,omitempty"`
+	// Suffix that appears after the value.
+	ValueSuffix string `json:"valueSuffix,omitempty"`
+	// Allowed values for categorical parameters.
+	Values []string `json:"values,omitempty"`
+}
+
+var _ scan.Selector = &EnvironmentVariablesSelector{}
+
+func (s *EnvironmentVariablesSelector) Default() {
+	if s.Kind == "" {
+		s.Group = "apps|extensions"
+		s.Kind = "Deployment|StatefulSet"
+		s.Path = "/spec/template/spec/containers/[name={ .ContainerName }]/env/[name={ .VariableName }]/value"
+	}
+}
+
+func (s *EnvironmentVariablesSelector) Map(node *yaml.RNode, meta yaml.ResourceMeta) ([]interface{}, error) {
+	var result []interface{}
+
+	path, err := sfio.FieldPath(s.Path, map[string]string{
+		"ContainerName": s.ContainerName,
+		"VariableName":  regexp.QuoteMeta(s.VariableName), // Quoting here ensures variable name is an exact match
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return result, node.PipeE(sfio.TeeMatched(
+		yaml.PathMatcher{Path: path},
+		yaml.FilterFunc(func(node *yaml.RNode) (*yaml.RNode, error) {
+			result = append(result, &environmentVariablesParameter{
+				pnode: pnode{
+					meta:      meta,
+					fieldPath: node.FieldPath(),
+					value:     node.YNode(),
+				},
+				prefix: s.ValuePrefix,
+				suffix: s.ValueSuffix,
+				values: s.Values,
+			})
+			return node, nil
+		}),
+	))
+}
+
+// environmentVariablesParameter is used to record the position of an environment variable specification
+// found by the selector during scanning.
+type environmentVariablesParameter struct {
+	pnode
+	prefix string
+	suffix string
+	values []string
+}
+
+var _ PatchSource = &environmentVariablesParameter{}
+var _ ParameterSource = &environmentVariablesParameter{}
+
+func (p *environmentVariablesParameter) Patch(name ParameterNamer) (yaml.Filter, error) {
+	// Since the field path will contain a "[name=ENV_VAR]" we can just leave the name blank
+	parameterName := name(p.meta, p.fieldPath, "")
+	patch := fmt.Sprintf("%s{{ .Values.%s }}%s", p.prefix, parameterName, p.suffix)
+	value := yaml.NewScalarRNode(patch)
+
+	return yaml.Tee(
+		&yaml.PathGetter{Path: p.fieldPath, Create: yaml.ScalarNode},
+		yaml.FieldSetter{Value: value, OverrideStyle: true},
+	), nil
+}
+
+func (p *environmentVariablesParameter) Parameters(name ParameterNamer) ([]redskyv1beta1.Parameter, error) {
+	param := redskyv1beta1.Parameter{
+		Name:     name(p.meta, p.fieldPath, ""),
+		Baseline: new(intstr.IntOrString),
+	}
+
+	value := strings.TrimPrefix(strings.TrimSuffix(p.value.Value, p.suffix), p.prefix)
+	if len(p.values) > 0 {
+		if value == "" {
+			value = p.values[0]
+		}
+		*param.Baseline = intstr.FromString(value)
+		param.Values = appendMissing(p.values, value)
+	} else if baseline, err := strconv.Atoi(value); err == nil {
+		*param.Baseline = intstr.FromInt(baseline)
+		param.Min = int32(baseline / 2)
+		param.Max = int32(baseline * 2)
+	} else {
+		param.Baseline = nil
+		param.Min = 100
+		param.Max = 4000
+	}
+
+	return []redskyv1beta1.Parameter{param}, nil
+}
+
+func appendMissing(slice []string, elem string) []string {
+	for _, s := range slice {
+		if s == elem {
+			return slice
+		}
+	}
+	return append(slice, elem)
+}

--- a/internal/experiment/generation/transformer.go
+++ b/internal/experiment/generation/transformer.go
@@ -262,21 +262,36 @@ func parameterNamer(selected []interface{}) ParameterNamer {
 
 	return func(meta yaml.ResourceMeta, path []string, name string) string {
 		var parts []string
+
 		if needsKind {
-			parts = append(parts, strings.ToLower(meta.Kind))
+			parts = append(parts, meta.Kind)
 		}
+
 		if needsName {
-			parts = append(parts, strings.Split(meta.Name, "-")...)
+			parts = append(parts, meta.Name)
 		}
+
 		if needsPath[meta.Kind][meta.Name] > 1 {
 			for _, p := range path {
 				if yaml.IsListIndex(p) {
 					if _, value, _ := yaml.SplitIndexNameValue(p); value != "" {
-						parts = append(parts, strings.Split(value, "-")...)
+						parts = append(parts, value)
 					}
 				}
 			}
 		}
-		return strings.Join(append(parts, name), "_")
+
+		if name != "" {
+			parts = append(parts, name)
+		}
+
+		// Explainer: Parameter names are used in Go Templates which are executed
+		// against Go structs, if the template parser encounters a token that is
+		// not a valid Go field name, parsing fails (e.g. "bad character U+002D '-'").
+
+		parameterName := strings.Join(parts, "_")
+		parameterName = strings.ReplaceAll(parameterName, "-", "_")
+		parameterName = strings.ToLower(parameterName)
+		return parameterName
 	}
 }

--- a/internal/experiment/generator.go
+++ b/internal/experiment/generator.go
@@ -135,6 +135,17 @@ func (g *Generator) selectors() []scan.Selector {
 				},
 				CreateIfNotPresent: true,
 			})
+
+		case g.Application.Parameters[i].EnvironmentVariable != nil:
+			result = append(result, &generation.EnvironmentVariablesSelector{
+				GenericSelector: scan.GenericSelector{
+					LabelSelector: g.Application.Parameters[i].EnvironmentVariable.Selector,
+				},
+				VariableName: g.Application.Parameters[i].EnvironmentVariable.Name,
+				ValuePrefix:  g.Application.Parameters[i].EnvironmentVariable.Prefix,
+				ValueSuffix:  g.Application.Parameters[i].EnvironmentVariable.Suffix,
+				Values:       g.Application.Parameters[i].EnvironmentVariable.Values,
+			})
 		}
 
 	}


### PR DESCRIPTION
This PR extends the app.yaml syntax to support discovery and tuning of environment variables. Like container resource scanning, the current implementation only exposes the functionality for deployments and stateful sets.

Environment variables can be added to the existing `parameters` section, you specify an environment variable name and the label selector matching the deployments/statefulsets you want to search on. Only environment variables with an explicit value can be tuned (i.e. no `valueFrom` support). Scanning can recognize a fixed prefix and/or suffix on the value: for example if an environment variable is defined as `value: '--mem 128mb'` you can supply a prefix of `'--mem '` and a suffix of `'mb'` to isolate and optimize on the numeric value `128`. Finally, you can specify a list categorical values to optimize over (the baseline will be added to this list implicitly and the prefix and suffix are still allowed).

Examples:
```
parameters:
# Look for the FOO_BAR environment variable and strip the "x" suffix
- environmentVariable:
    name: FOO_BAR
    suffix: x
# Optimize ALPHABET over the values "a", "b", "c"
- environmentVariable:
    name: ALPHABET
    values:
    - a
    - b
    - c
# Only consider deployments/stateful sets with `app=env` labels
- environmentVariable:
    name: NOT_ALL_RESOURCES
    selector: app=env
```