### PR TITLE
Update the Optimize Common library to pickup a round of StormForge updates

### DIFF
--- a/controllers/server_controller.go
+++ b/controllers/server_controller.go
@@ -54,7 +54,7 @@ var (
 // default (and minimum allowed) rate is 1 trial per second.
 func trialCreationRateLimit(log logr.Logger) rate.Limit {
 	// NOTE: If we are changing this to a lot of different values, it should be moved to the configuration
-	trialCreationInterval, ok := os.LookupEnv("REDSKY_TRIAL_CREATION_INTERVAL")
+	trialCreationInterval, ok := os.LookupEnv("STORMFORGE_TRIAL_CREATION_INTERVAL")
 	if !ok {
 		return rate.Every(time.Second)
 	}

--- a/controllers/server_controller.go
+++ b/controllers/server_controller.go
@@ -260,7 +260,7 @@ func (r *ServerReconciler) createExperiment(ctx context.Context, log logr.Logger
 
 	// Create the experiment remotely
 	// TODO This should check for an existing URL annotation before using the name (needs a new version of optimize-go)
-	ee, err := r.ExperimentsAPI.CreateExperiment(ctx, n, *e)
+	ee, err := r.ExperimentsAPI.CreateExperimentByName(ctx, n, *e)
 	if err != nil {
 		if server.FailExperiment(exp, "ServerCreateFailed", err) {
 			err := r.Update(ctx, exp)

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
 	github.com/thestormforge/konjure v0.3.0
-	github.com/thestormforge/optimize-go v0.0.8
+	github.com/thestormforge/optimize-go v0.0.9
 	github.com/yujunz/go-getter v1.5.1-lite.0.20201201013212-6d9c071adddf
 	github.com/zorkian/go-datadog-api v2.24.0+incompatible
 	go.uber.org/zap v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -632,8 +632,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/thestormforge/konjure v0.3.0 h1:VOUX6te9lbdk8dYJLQpJsvZfuhvwp8+DJMhB1VR46RM=
 github.com/thestormforge/konjure v0.3.0/go.mod h1:8gIqMRKShWB7ejEA+JCN8DUeeDe9CTIc3eXyniFdNj8=
-github.com/thestormforge/optimize-go v0.0.8 h1:nIdz5pSz00eHzBS8Ueti3xmNP9MB9l15/NTob6k6Whg=
-github.com/thestormforge/optimize-go v0.0.8/go.mod h1:ZWRi49lIlw4g3JyP9Aog+zQI/rb7+81HOyHcccVqnfU=
+github.com/thestormforge/optimize-go v0.0.9 h1:Ialq4lN0B5zVF5ViBzxeT+RLBk71KHTCPLSxeK9rffI=
+github.com/thestormforge/optimize-go v0.0.9/go.mod h1:ZWRi49lIlw4g3JyP9Aog+zQI/rb7+81HOyHcccVqnfU=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/timakin/bodyclose v0.0.0-20190930140734-f7f2e9bca95e/go.mod h1:Qimiffbc6q9tBWlVV6x0P9sat/ao1xEkREYPPj9hphk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/redskyctl/internal/commands/authorize_cluster/generator.go
+++ b/redskyctl/internal/commands/authorize_cluster/generator.go
@@ -152,8 +152,8 @@ func (o *GeneratorOptions) generate(ctx context.Context) error {
 	}
 
 	// Overwrite the client credentials in the secret
-	mergeString(secret.Data, "REDSKY_AUTHORIZATION_CLIENT_ID", info.ClientID)
-	mergeString(secret.Data, "REDSKY_AUTHORIZATION_CLIENT_SECRET", info.ClientSecret)
+	mergeString(secret.Data, "STORMFORGE_AUTHORIZATION_CLIENT_ID", info.ClientID)
+	mergeString(secret.Data, "STORMFORGE_AUTHORIZATION_CLIENT_SECRET", info.ClientSecret)
 
 	return o.Printer.PrintObj(secret, o.Out)
 }
@@ -236,9 +236,9 @@ func localClientInformation(ctrl *config.Controller) *registration.ClientInforma
 	}
 	for _, v := range ctrl.Env {
 		switch v.Name {
-		case "REDSKY_AUTHORIZATION_CLIENT_ID":
+		case "STORMFORGE_AUTHORIZATION_CLIENT_ID":
 			resp.ClientID = v.Value
-		case "REDSKY_AUTHORIZATION_CLIENT_SECRET":
+		case "STORMFORGE_AUTHORIZATION_CLIENT_SECRET":
 			resp.ClientSecret = v.Value
 		}
 	}
@@ -259,10 +259,10 @@ func printHelmValues(obj interface{}, w io.Writer) error {
 	vals := map[string]interface{}{
 		"remoteServer": map[string]interface{}{
 			"enabled":      true,
-			"identifier":   string(secret.Data["REDSKY_SERVER_IDENTIFIER"]),
-			"issuer":       string(secret.Data["REDSKY_SERVER_ISSUER"]),
-			"clientID":     string(secret.Data["REDSKY_AUTHORIZATION_CLIENT_ID"]),
-			"clientSecret": string(secret.Data["REDSKY_AUTHORIZATION_CLIENT_SECRET"]),
+			"identifier":   string(secret.Data["STORMFORGE_SERVER_IDENTIFIER"]),
+			"issuer":       string(secret.Data["STORMFORGE_SERVER_ISSUER"]),
+			"clientID":     string(secret.Data["STORMFORGE_AUTHORIZATION_CLIENT_ID"]),
+			"clientSecret": string(secret.Data["STORMFORGE_AUTHORIZATION_CLIENT_SECRET"]),
 		},
 	}
 

--- a/redskyctl/internal/commands/export/export_api_test.go
+++ b/redskyctl/internal/commands/export/export_api_test.go
@@ -106,7 +106,11 @@ func (f *fakeRedSkyServer) GetExperiment(ctx context.Context, name string) (expe
 	return experimentsapi.Experiment{}, nil
 }
 
-func (f *fakeRedSkyServer) CreateExperiment(ctx context.Context, name experimentsapi.ExperimentName, exp experimentsapi.Experiment) (experimentsapi.Experiment, error) {
+func (f *fakeRedSkyServer) CreateExperimentByName(ctx context.Context, name experimentsapi.ExperimentName, experiment experimentsapi.Experiment) (experimentsapi.Experiment, error) {
+	return experimentsapi.Experiment{}, nil
+}
+
+func (f *fakeRedSkyServer) CreateExperiment(ctx context.Context, s string, experiment experimentsapi.Experiment) (experimentsapi.Experiment, error) {
 	return experimentsapi.Experiment{}, nil
 }
 


### PR DESCRIPTION
There will be another release of optimize-go to pick up the latest refactorings (i.e. the rename of the configuration), but we aren't even on the current release of optimize-go yet.

Also note that I am targeting a long running v2 branch for this work. There are a lot of changes that are needed for the renaming so I'm going to break them up so we can just merge the v2 branch all at once.