### PR TITLE
Comments, Usage Strings, and User Agents, Oh my.

### DIFF
--- a/internal/controller/errors_test.go
+++ b/internal/controller/errors_test.go
@@ -47,14 +47,14 @@ func TestIgnoreNotFound(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
-			desc: "redskyapi error experiment not found",
+			desc: "api error experiment not found",
 			in: &redskyapi.Error{
 				Type: redskyapi.ErrExperimentNotFound,
 			},
 			expectedErr: nil,
 		},
 		{
-			desc: "redskyapi error trial not found",
+			desc: "api error trial not found",
 			in: &redskyapi.Error{
 				Type: redskyapi.ErrTrialNotFound,
 			},

--- a/internal/version/useragent.go
+++ b/internal/version/useragent.go
@@ -32,7 +32,7 @@ func UserAgent(product, comment string, transport http.RoundTripper) http.RoundT
 
 // Transport sets the `User-Agent` header
 type Transport struct {
-	// UserAgent string to use, defaults to "RedSky/{version}" if unset
+	// UserAgent string to use, defaults to "Optimize/{version}" if unset
 	UserAgent string
 	// Base transport to use, uses the system default if nil
 	Base http.RoundTripper
@@ -49,7 +49,7 @@ func (t *Transport) userAgent() string {
 		return t.UserAgent
 	}
 	// TODO We probably don't want to be doing this every time...
-	return userAgentString("RedSky", "")
+	return userAgentString("Optimize", "")
 }
 
 func (t *Transport) base() http.RoundTripper {

--- a/internal/version/useragent_test.go
+++ b/internal/version/useragent_test.go
@@ -34,7 +34,7 @@ func TestUserAgent(t *testing.T) {
 			desc:     "default",
 			product:  "",
 			comment:  "",
-			expected: "RedSky/0.0.0-source",
+			expected: "Optimize/0.0.0-source",
 		},
 		{
 			desc:    "version",
@@ -43,7 +43,7 @@ func TestUserAgent(t *testing.T) {
 			versionInfo: &Info{
 				Version: "v1.2.3",
 			},
-			expected: "RedSky/1.2.3",
+			expected: "Optimize/1.2.3",
 		},
 		{
 			desc:     "product",

--- a/main.go
+++ b/main.go
@@ -69,7 +69,7 @@ func main() {
 	}))
 
 	v := version.GetInfo()
-	setupLog.Info("Red Sky Ops Controller", "version", v.String(), "gitCommit", v.GitCommit)
+	setupLog.Info("StormForge Optimize Controller", "version", v.String(), "gitCommit", v.GitCommit)
 
 	mgr, err := ctrl.NewManager(controller.WithConversion(ctrl.GetConfigOrDie(), scheme), ctrl.Options{
 		Scheme:             scheme,

--- a/redskyctl/internal/commands/authorize_cluster/authorize_cluster.go
+++ b/redskyctl/internal/commands/authorize_cluster/authorize_cluster.go
@@ -39,7 +39,7 @@ func NewCommand(o *Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "authorize-cluster",
 		Short: "Authorize a cluster",
-		Long:  "Authorize Red Sky Ops in a cluster",
+		Long:  "Authorize StormForge Optimize in a cluster",
 
 		PreRun: commander.StreamsPreRun(&o.IOStreams),
 		RunE:   commander.WithContextE(o.authorizeCluster),
@@ -106,7 +106,7 @@ func (o *Options) generateSecret(out io.Writer, secretName, secretHash *string) 
 	return nil
 }
 
-// patchDeployment patches the Red Sky Controller deployment to reflect the state of the secret; any changes to the
+// patchDeployment patches the Optimize Controller deployment to reflect the state of the secret; any changes to the
 // will cause the controller to be re-deployed.
 func (o *Options) patchDeployment(ctx context.Context, secretName, secretHash string) error {
 	ctrl, err := config.CurrentController(o.Config.Reader())

--- a/redskyctl/internal/commands/authorize_cluster/generator.go
+++ b/redskyctl/internal/commands/authorize_cluster/generator.go
@@ -43,7 +43,7 @@ import (
 
 // GeneratorOptions are the configuration options for generating the cluster authorization secret
 type GeneratorOptions struct {
-	// Config is the Red Sky Configuration used to generate the authorization secret
+	// Config is the Optimize Configuration used to generate the authorization secret
 	Config *config.RedSkyConfig
 	// Printer is the resource printer used to render generated objects
 	Printer commander.ResourcePrinter
@@ -62,8 +62,8 @@ type GeneratorOptions struct {
 func NewGeneratorCommand(o *GeneratorOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "secret",
-		Short: "Generate Red Sky Ops authorization",
-		Long:  "Generate authorization secret for Red Sky Ops",
+		Short: "Generate Optimize authorization",
+		Long:  "Generate authorization secret for StormForge Optimize",
 
 		Annotations: map[string]string{
 			commander.PrinterAllowedFormats: "json,yaml,helm",

--- a/redskyctl/internal/commands/check/check.go
+++ b/redskyctl/internal/commands/check/check.go
@@ -23,7 +23,7 @@ import (
 
 // Options includes the configuration for the subcommands
 type Options struct {
-	// Config is the Red Sky Configuration
+	// Config is the Optimize Configuration
 	Config *config.RedSkyConfig
 }
 
@@ -32,7 +32,7 @@ func NewCommand(o *Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "check",
 		Short: "Run a consistency check",
-		Long:  "Run a consistency check on Red Sky Ops components",
+		Long:  "Run a consistency check on StormForge Optimize components",
 	}
 
 	cmd.AddCommand(NewConfigCommand(&ConfigOptions{Config: o.Config}))

--- a/redskyctl/internal/commands/check/config.go
+++ b/redskyctl/internal/commands/check/config.go
@@ -28,11 +28,11 @@ import (
 	"github.com/thestormforge/optimize-go/pkg/config"
 )
 
-// ConfigOptions are the options for checking a Red Sky Configuration
+// ConfigOptions are the options for checking an Optimize Configuration
 type ConfigOptions struct {
-	// Config is the Red Sky Configuration to check
+	// Config is the Optimize Configuration to check
 	Config *config.RedSkyConfig
-	// ExperimentsAPI is used to interact with the Red Sky Experiments API
+	// ExperimentsAPI is used to interact with the Optimize Experiments API
 	ExperimentsAPI experimentsv1alpha1.API
 	// IOStreams are used to access the standard process streams
 	commander.IOStreams
@@ -40,12 +40,12 @@ type ConfigOptions struct {
 	// TODO Verbose? Skip server check?
 }
 
-// NewConfigCommand creates a new command for checking the Red Sky Configuration
+// NewConfigCommand creates a new command for checking the Optimize Configuration
 func NewConfigCommand(o *ConfigOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "config",
 		Short: "Check the configuration",
-		Long:  "Check the Red Sky Configuration",
+		Long:  "Check the StormForge Optimize Configuration",
 
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			// TODO We should have an option to overwrite the configuration using stdin (e.g. to test connections using the controller config)

--- a/redskyctl/internal/commands/check/controller.go
+++ b/redskyctl/internal/commands/check/controller.go
@@ -31,9 +31,9 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-// ControllerOptions are the options for checking a Red Sky controller
+// ControllerOptions are the options for checking an Optimize controller
 type ControllerOptions struct {
-	// Config is the Red Sky Configuration for connecting to the cluster
+	// Config is the Optimize Configuration for connecting to the cluster
 	Config *config.RedSkyConfig
 	// IOStreams are used to access the standard process streams
 	commander.IOStreams
@@ -42,12 +42,12 @@ type ControllerOptions struct {
 	Wait bool
 }
 
-// NewControllerCommand creates a new command for checking a Red Sky controller
+// NewControllerCommand creates a new command for checking an Optimize controller
 func NewControllerCommand(o *ControllerOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "controller",
 		Short: "Check the controller",
-		Long:  "Check the Red Sky controller",
+		Long:  "Check the Optimize controller",
 
 		PreRun: commander.StreamsPreRun(&o.IOStreams),
 		RunE:   commander.WithContextE(o.CheckController),

--- a/redskyctl/internal/commands/check/version.go
+++ b/redskyctl/internal/commands/check/version.go
@@ -90,7 +90,7 @@ func (o *VersionOptions) checkVersion(ctx context.Context) error {
 }
 
 func getJSON(ctx context.Context, url string, obj interface{}) error {
-	client := &http.Client{Transport: version.UserAgent("RedSkyOps", "", nil)}
+	client := &http.Client{Transport: version.UserAgent("StormForgeOptimize", "", nil)}
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return err

--- a/redskyctl/internal/commands/configure/configure.go
+++ b/redskyctl/internal/commands/configure/configure.go
@@ -23,7 +23,7 @@ import (
 
 // Options includes the configuration for the subcommands
 type Options struct {
-	// Config is the Red Sky Configuration
+	// Config is the Optimize Configuration
 	Config *config.RedSkyConfig
 }
 
@@ -32,7 +32,7 @@ func NewCommand(o *Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "config",
 		Short: "Work with the configuration file",
-		Long:  "Modify or view the Red Sky Configuration file",
+		Long:  "Modify or view the StormForge Optimize Configuration file",
 	}
 
 	cmd.AddCommand(NewCurrentContextCommand(&CurrentContextOptions{Config: o.Config}))

--- a/redskyctl/internal/commands/configure/currentcontext.go
+++ b/redskyctl/internal/commands/configure/currentcontext.go
@@ -26,7 +26,7 @@ import (
 
 // CurrentContextOptions are the options for viewing the current context
 type CurrentContextOptions struct {
-	// Config is the Red Sky Configuration to view
+	// Config is the Optimize Configuration to view
 	Config *config.RedSkyConfig
 	// IOStreams are used to access the standard process streams
 	commander.IOStreams

--- a/redskyctl/internal/commands/configure/env.go
+++ b/redskyctl/internal/commands/configure/env.go
@@ -29,7 +29,7 @@ import (
 
 // EnvOptions are the options for viewing a configuration as environment variables
 type EnvOptions struct {
-	// Config is the Red Sky Configuration to view
+	// Config is the Optimize Configuration to view
 	Config *config.RedSkyConfig
 	// IOStreams are used to access the standard process streams
 	commander.IOStreams
@@ -43,7 +43,7 @@ func NewEnvCommand(o *EnvOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "env",
 		Short: "Generate environment variables from configuration",
-		Long:  "View the Red Sky Configuration file as environment variables",
+		Long:  "View the Optimize Configuration file as environment variables",
 
 		PreRun: commander.StreamsPreRun(&o.IOStreams),
 		RunE:   commander.WithoutArgsE(o.env),

--- a/redskyctl/internal/commands/configure/set.go
+++ b/redskyctl/internal/commands/configure/set.go
@@ -26,7 +26,7 @@ import (
 
 // SetOptions are the options for setting a configuration property to a new value
 type SetOptions struct {
-	// Config is the Red Sky Configuration to view
+	// Config is the Optimize Configuration to view
 	Config *config.RedSkyConfig
 
 	// Key is the name of the property being set
@@ -40,7 +40,7 @@ func NewSetCommand(o *SetOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "set NAME [VALUE]",
 		Short: "Modify the configuration file",
-		Long:  "Modify the Red Sky Configuration file",
+		Long:  "Modify the Optimize Configuration file",
 		Args:  cobra.RangeArgs(1, 2),
 
 		PreRun: func(cmd *cobra.Command, args []string) {

--- a/redskyctl/internal/commands/configure/view.go
+++ b/redskyctl/internal/commands/configure/view.go
@@ -36,7 +36,7 @@ import (
 
 // ViewOptions are the options for viewing a configuration file
 type ViewOptions struct {
-	// Config is the Red Sky Configuration to view
+	// Config is the Optimize Configuration to view
 	Config *config.RedSkyConfig
 	// IOStreams are used to access the standard process streams
 	commander.IOStreams
@@ -54,7 +54,7 @@ func NewViewCommand(o *ViewOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "view",
 		Short: "View the configuration file",
-		Long:  "View the Red Sky Ops configuration file",
+		Long:  "View the StormForge Optimize configuration file",
 
 		PreRun: commander.StreamsPreRun(&o.IOStreams),
 		RunE:   commander.WithoutArgsE(o.view),

--- a/redskyctl/internal/commands/debug/debug.go
+++ b/redskyctl/internal/commands/debug/debug.go
@@ -23,7 +23,7 @@ import (
 
 // Options includes the configuration for the subcommands.
 type Options struct {
-	// Config is the Red Sky Configuration
+	// Config is the Optimize Configuration
 	Config *config.RedSkyConfig
 }
 

--- a/redskyctl/internal/commands/docs/docs.go
+++ b/redskyctl/internal/commands/docs/docs.go
@@ -25,7 +25,7 @@ import (
 	"github.com/thestormforge/optimize-controller/v2/redskyctl/internal/commander"
 )
 
-// TODO Add support for fetching Red Sky OpenAPI specification
+// TODO Add support for fetching StormForge Optimize API OpenAPI specification
 
 // Options is the configuration for generating documentation
 type Options struct {
@@ -42,7 +42,7 @@ func NewCommand(o *Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "docs",
 		Short:  "Generate documentation",
-		Long:   "Generate documentation for Red Sky Ops",
+		Long:   "Generate documentation for StormForge Optimize",
 		Hidden: true,
 
 		RunE: func(cmd *cobra.Command, _ []string) error { return o.docs(cmd) },
@@ -75,7 +75,7 @@ func (o *Options) docs(cmd *cobra.Command) error {
 		}
 
 	case "man":
-		if err := doc.GenManTree(cmd.Root(), &doc.GenManHeader{Title: "RED SKY", Section: "1"}, o.Directory); err != nil {
+		if err := doc.GenManTree(cmd.Root(), &doc.GenManHeader{Title: "STORMFORGE OPTIMIZE", Section: "1"}, o.Directory); err != nil {
 			return err
 		}
 

--- a/redskyctl/internal/commands/experiments/delete.go
+++ b/redskyctl/internal/commands/experiments/delete.go
@@ -38,8 +38,8 @@ type DeleteOptions struct {
 func NewDeleteCommand(o *DeleteOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete (TYPE NAME | TYPE/NAME ...)",
-		Short: "Delete a Red Sky resource",
-		Long:  "Delete Red Sky resources from the remote server",
+		Short: "Delete an Optimize resource",
+		Long:  "Delete StormForge Optimize resources from the remote server",
 
 		ValidArgsFunction: o.validArgs,
 

--- a/redskyctl/internal/commands/experiments/experiments.go
+++ b/redskyctl/internal/commands/experiments/experiments.go
@@ -56,13 +56,13 @@ func normalizeType(t string) (normalType resourceType, pluralType string, err er
 	return "", "", fmt.Errorf("unknown resource type \"%s\"", t)
 }
 
-// Options are the common options for interacting with the Red Sky Experiments API
+// Options are the common options for interacting with the Optimize Experiments API
 type Options struct {
-	// Config is the Red Sky Control Configuration
+	// Config is the Optimize Configuration
 	Config *config.RedSkyConfig
-	// ExperimentsAPI is used to interact with the Red Sky Experiments API
+	// ExperimentsAPI is used to interact with the Optimize Experiments API
 	ExperimentsAPI experimentsv1alpha1.API
-	// Printer is the resource printer used to render objects from the Red Sky Experiments API
+	// Printer is the resource printer used to render objects from the Optimize Experiments API
 	Printer commander.ResourcePrinter
 	// IOStreams are used to access the standard process streams
 	commander.IOStreams
@@ -235,7 +235,7 @@ func (v *verbPrinter) PrintObj(obj interface{}, w io.Writer) error {
 	return nil
 }
 
-// experimentsMeta is the metadata extraction necessary for printing Red Sky Experiments API objects
+// experimentsMeta is the metadata extraction necessary for printing Optimize Experiments API objects
 type experimentsMeta struct{}
 
 // ExtractList returns the items from an API list object

--- a/redskyctl/internal/commands/experiments/get.go
+++ b/redskyctl/internal/commands/experiments/get.go
@@ -41,8 +41,8 @@ type GetOptions struct {
 func NewGetCommand(o *GetOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "get (TYPE NAME | TYPE/NAME ...)",
-		Short: "Display a Red Sky resource",
-		Long:  "Get Red Sky resources from the remote server",
+		Short: "Display an Optimize resource",
+		Long:  "Get StormForge Optimize resources from the remote server",
 
 		ValidArgsFunction: o.validArgs,
 

--- a/redskyctl/internal/commands/experiments/label.go
+++ b/redskyctl/internal/commands/experiments/label.go
@@ -38,8 +38,8 @@ type LabelOptions struct {
 func NewLabelCommand(o *LabelOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "label (TYPE NAME | TYPE/NAME ...) KEY_1=VAL_1 ... KEY_N=VAL_N",
-		Short: "Label a Red Sky resource",
-		Long:  "Label Red Sky resources on the remote server",
+		Short: "Label an Optimize resource",
+		Long:  "Label StormForge Optimize resources on the remote server",
 
 		ValidArgsFunction: o.validArgs,
 

--- a/redskyctl/internal/commands/export/export.go
+++ b/redskyctl/internal/commands/export/export.go
@@ -52,9 +52,9 @@ import (
 
 // Options are the configuration options for creating a patched experiment
 type Options struct {
-	// Config is the Red Sky Configuration used to generate the controller installation
+	// Config is the Optimize Configuration used to generate the controller installation
 	Config *config.RedSkyConfig
-	// ExperimentsAPI is used to interact with the Red Sky Experiments API
+	// ExperimentsAPI is used to interact with the Optimize Experiments API
 	ExperimentsAPI experimentsapi.API
 	// IOStreams are used to access the standard process streams
 	commander.IOStreams

--- a/redskyctl/internal/commands/generate/application.go
+++ b/redskyctl/internal/commands/generate/application.go
@@ -29,7 +29,7 @@ import (
 )
 
 type ApplicationOptions struct {
-	// Config is the Red Sky Configuration used to generate the application
+	// Config is the Optimize Configuration used to generate the application
 	Config *config.RedSkyConfig
 	// IOStreams are used to access the standard process streams
 	commander.IOStreams

--- a/redskyctl/internal/commands/generate/experiment.go
+++ b/redskyctl/internal/commands/generate/experiment.go
@@ -33,7 +33,7 @@ import (
 )
 
 type ExperimentOptions struct {
-	// Config is the Red Sky Configuration used to generate the experiment
+	// Config is the Optimize Configuration used to generate the experiment
 	Config *config.RedSkyConfig
 	// IOStreams are used to access the standard process streams
 	commander.IOStreams

--- a/redskyctl/internal/commands/generate/generate.go
+++ b/redskyctl/internal/commands/generate/generate.go
@@ -26,7 +26,7 @@ import (
 
 // Options includes the configuration for the subcommands
 type Options struct {
-	// Config is the Red Sky Configuration
+	// Config is the Optimize Configuration
 	Config *config.RedSkyConfig
 }
 
@@ -35,8 +35,8 @@ func NewCommand(o *Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "generate",
 		Aliases: []string{"gen"},
-		Short:   "Generate Red Sky Ops objects",
-		Long:    "Generate Red Sky Ops object manifests",
+		Short:   "Generate Optimize resources",
+		Long:    "Generate StormForge Optimize resource manifests",
 	}
 
 	cmd.AddCommand(initialize.NewGeneratorCommand(&initialize.GeneratorOptions{Config: o.Config}))

--- a/redskyctl/internal/commands/generate/rbac.go
+++ b/redskyctl/internal/commands/generate/rbac.go
@@ -42,7 +42,7 @@ import (
 // TODO Instead of it's own generator, have this be an option on the experiment generator
 
 type RBACOptions struct {
-	// Config is the Red Sky Configuration used to generate the role binding
+	// Config is the Optimize Configuration used to generate the role binding
 	Config *config.RedSkyConfig
 	// Printer is the resource printer used to render generated objects
 	Printer commander.ResourcePrinter

--- a/redskyctl/internal/commands/grant_permissions/generator.go
+++ b/redskyctl/internal/commands/grant_permissions/generator.go
@@ -32,7 +32,7 @@ import (
 
 // GeneratorOptions are the configuration options for generating the controller role definitions
 type GeneratorOptions struct {
-	// Config is the Red Sky Configuration used to generate the authorization secret
+	// Config is the Optimize Configuration used to generate the authorization secret
 	Config *config.RedSkyConfig
 	// Printer is the resource printer used to render generated objects
 	Printer commander.ResourcePrinter
@@ -53,8 +53,8 @@ type GeneratorOptions struct {
 func NewGeneratorCommand(o *GeneratorOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "controller-rbac",
-		Short: "Generate Red Sky Ops permissions",
-		Long:  "Generate RBAC for Red Sky Ops",
+		Short: "Generate Optimize permissions",
+		Long:  "Generate RBAC for StormForge Optimize",
 
 		Annotations: map[string]string{
 			commander.PrinterAllowedFormats: "json,yaml",

--- a/redskyctl/internal/commands/grant_permissions/grant_permissions.go
+++ b/redskyctl/internal/commands/grant_permissions/grant_permissions.go
@@ -34,7 +34,7 @@ func NewCommand(o *Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "grant-permissions",
 		Short: "Grant permissions",
-		Long:  "Grant the Red Sky Controller permissions",
+		Long:  "Grant the StormForge Optimize Controller permissions",
 
 		PreRun: commander.StreamsPreRun(&o.IOStreams),
 		RunE:   commander.WithContextE(o.grantPermissions),

--- a/redskyctl/internal/commands/initialize/generator.go
+++ b/redskyctl/internal/commands/initialize/generator.go
@@ -35,7 +35,7 @@ import (
 
 // GeneratorOptions are the configuration options for generating the controller installation
 type GeneratorOptions struct {
-	// Config is the Red Sky Configuration used to generate the controller installation
+	// Config is the Optimize Configuration used to generate the controller installation
 	Config *config.RedSkyConfig
 	// IOStreams are used to access the standard process streams
 	commander.IOStreams
@@ -57,8 +57,8 @@ type GeneratorOptions struct {
 func NewGeneratorCommand(o *GeneratorOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "install",
-		Short: "Generate Red Sky Ops manifests",
-		Long:  "Generate installation manifests for Red Sky Ops",
+		Short: "Generate Optimize manifests",
+		Long:  "Generate installation manifests for StormForge Optimize",
 
 		Annotations: map[string]string{
 			commander.PrinterAllowedFormats: "json,yaml",

--- a/redskyctl/internal/commands/initialize/initialize.go
+++ b/redskyctl/internal/commands/initialize/initialize.go
@@ -37,7 +37,7 @@ func NewCommand(o *Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "init",
 		Short: "Install to a cluster",
-		Long:  "Install Red Sky Ops to a cluster",
+		Long:  "Install StormForge Optimize to a cluster",
 
 		PreRun: commander.StreamsPreRun(&o.IOStreams),
 		RunE:   commander.WithContextE(o.Initialize),

--- a/redskyctl/internal/commands/kustomize/config.go
+++ b/redskyctl/internal/commands/kustomize/config.go
@@ -42,7 +42,7 @@ func NewConfigCommand(o *ConfigOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "config",
 		Short: "Configure Kustomize transformers",
-		Long:  "Configure Kustomize transformers for Red Sky types",
+		Long:  "Configure Kustomize transformers for StormForge Optimize types",
 
 		PreRun: commander.StreamsPreRun(&o.IOStreams),
 		RunE:   commander.WithoutArgsE(o.config),

--- a/redskyctl/internal/commands/kustomize/kustomize.go
+++ b/redskyctl/internal/commands/kustomize/kustomize.go
@@ -25,7 +25,7 @@ func NewCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "kustomize",
 		Short: "Kustomize integrations",
-		Long:  "Kustomize integrations for Red Sky Ops",
+		Long:  "Kustomize integrations for StormForge Optimize",
 	}
 
 	cmd.AddCommand(NewConfigCommand(&ConfigOptions{}))

--- a/redskyctl/internal/commands/login/login.go
+++ b/redskyctl/internal/commands/login/login.go
@@ -62,7 +62,7 @@ If you are having problems scanning, use your browser to visit: %s
 
 // Options is the configuration for creating new authorization entries in a configuration
 type Options struct {
-	// Config is the Red Sky Configuration to modify
+	// Config is the Optimize Configuration to modify
 	Config *config.RedSkyConfig
 	// IOStreams are used to access the standard process streams
 	commander.IOStreams
@@ -89,7 +89,7 @@ func NewCommand(o *Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "login",
 		Short: "Authenticate",
-		Long:  "Log into your Red Sky Account.",
+		Long:  "Log into your StormForge Account.",
 
 		PersistentPreRunE: commander.WithoutArgsE(o.LoadConfig),
 		PreRun:            commander.StreamsPreRun(&o.IOStreams),
@@ -100,7 +100,7 @@ func NewCommand(o *Options) *cobra.Command {
 	_ = cmd.Flags().MarkDeprecated("name", "use --context instead")
 
 	cmd.Flags().StringVar(&o.Environment, "env", "", "override the execution environment")
-	cmd.Flags().StringVar(&o.Server, "server", "", "override the Red Sky API server identifier")
+	cmd.Flags().StringVar(&o.Server, "server", "", "override the StormForge Optimize API server identifier")
 	cmd.Flags().StringVar(&o.Issuer, "issuer", "", "override the authorization server identifier")
 	cmd.Flags().BoolVar(&o.DisplayURL, "url", false, "display the URL instead of opening a browser")
 	cmd.Flags().BoolVar(&o.DisplayQR, "qr", false, "display a QR code instead of opening a browser")
@@ -136,7 +136,7 @@ func (o *Options) complete() error {
 		} else if u.Scheme != "https" && u.Scheme != "http" {
 			return fmt.Errorf("server must be an 'https' URL")
 		} else if u.Path != "/v1/" {
-			_, _ = fmt.Fprintf(o.ErrOut, "Warning: Server URL does not have a path of '/v1/', Red Sky API endpoints may not resolve correctly")
+			_, _ = fmt.Fprintf(o.ErrOut, "Warning: Server URL does not have a path of '/v1/', StormForge API endpoints may not resolve correctly")
 		}
 	}
 

--- a/redskyctl/internal/commands/ping/ping.go
+++ b/redskyctl/internal/commands/ping/ping.go
@@ -33,19 +33,19 @@ import (
 )
 
 type Options struct {
-	// Config is the Red Sky Configuration
+	// Config is the Optimize Configuration
 	Config *config.RedSkyConfig
-	// ExperimentsAPI is used to interact with the Red Sky Experiments API
+	// ExperimentsAPI is used to interact with the Optimize Experiments API
 	ExperimentsAPI experimentsv1alpha1.API
 	// IOStreams are used to access the standard process streams
 	commander.IOStreams
 }
 
-// NewPingCommand creates a new command for pinging the Red Sky API
+// NewPingCommand creates a new command for pinging the Optimize API
 func NewCommand(o *Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "ping",
-		Short: "Ping the Red Sky API",
+		Short: "Ping the StormForge Optimize API",
 
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			commander.SetStreams(&o.IOStreams, cmd)

--- a/redskyctl/internal/commands/reset/reset.go
+++ b/redskyctl/internal/commands/reset/reset.go
@@ -28,7 +28,7 @@ import (
 
 // Options is the configuration for suggesting assignments
 type Options struct {
-	// Config is the Red Sky Configuration used to generate the controller manifests for reset
+	// Config is the Optimize Configuration used to generate the controller manifests for reset
 	Config *config.RedSkyConfig
 	// IOStreams are used to access the standard process streams
 	commander.IOStreams
@@ -38,7 +38,7 @@ func NewCommand(o *Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "reset",
 		Short: "Uninstall from a cluster",
-		Long:  "Uninstall Red Sky Ops from a cluster",
+		Long:  "Uninstall StormForge Optimize from a cluster",
 
 		PreRun: commander.StreamsPreRun(&o.IOStreams),
 		RunE:   commander.WithContextE(o.reset),

--- a/redskyctl/internal/commands/results/results.go
+++ b/redskyctl/internal/commands/results/results.go
@@ -29,7 +29,7 @@ import (
 
 // Options is the configuration for displaying the results UI
 type Options struct {
-	// Config is the Red Sky Configuration to get redirect URLs from
+	// Config is the Optimize Configuration to get redirect URLs from
 	Config *config.RedSkyConfig
 	// IOStreams are used to access the standard process streams
 	commander.IOStreams

--- a/redskyctl/internal/commands/revoke/revoke.go
+++ b/redskyctl/internal/commands/revoke/revoke.go
@@ -32,7 +32,7 @@ import (
 
 // Options is the configuration for removing authorization entries in a configuration
 type Options struct {
-	// Config is the Red Sky Configuration to modify
+	// Config is the Optimize Configuration to modify
 	Config *config.RedSkyConfig
 	// IOStreams are used to access the standard process streams
 	commander.IOStreams
@@ -43,7 +43,7 @@ func NewCommand(o *Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "revoke",
 		Short:   "Revoke an authorization",
-		Long:    "Log out of your Red Sky Account.",
+		Long:    "Log out of your StormForge Account.",
 		Aliases: []string{"logout"},
 
 		PreRun: commander.StreamsPreRun(&o.IOStreams),

--- a/redskyctl/internal/commands/run/run.go
+++ b/redskyctl/internal/commands/run/run.go
@@ -44,9 +44,9 @@ import (
 )
 
 type Options struct {
-	// Config is the Red Sky Configuration.
+	// Config is the Optimize Configuration.
 	Config *config.RedSkyConfig
-	// ExperimentsAPI is used to interact with the Red Sky Experiments API.
+	// ExperimentsAPI is used to interact with the Optimize Experiments API.
 	ExperimentsAPI experimentsv1alpha1.API
 
 	// Flag indicating we should print verbose prompts.

--- a/redskyctl/internal/commands/version/version.go
+++ b/redskyctl/internal/commands/version/version.go
@@ -32,7 +32,7 @@ import (
 	"github.com/thestormforge/optimize-go/pkg/config"
 )
 
-// TODO Add support for getting Red Sky server version
+// TODO Add support for getting Experiment API server version
 // TODO Add "--client" and "--server" and "--manager" for only printing some versions
 // TODO Add a "--notes" option to print the release notes?
 // TODO Add an "--output" to control format (json, yaml)
@@ -46,9 +46,9 @@ const defaultTemplate = `{{range $key, $value := . }}{{$key}} version: {{$value}
 
 // Options is the configuration for reporting version information
 type Options struct {
-	// Config is the Red Sky Configuration
+	// Config is the Optimize Configuration
 	Config *config.RedSkyConfig
-	// ExperimentsAPI is used to interact with the Red Sky Experiments API
+	// ExperimentsAPI is used to interact with the Optimize Experiments API
 	ExperimentsAPI experimentsv1alpha1.API
 	// IOStreams are used to access the standard process streams
 	commander.IOStreams
@@ -68,7 +68,7 @@ func NewCommand(o *Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Print the version information",
-		Long:  "Print the version information for Red Sky Ops components",
+		Long:  "Print the version information for StormForge Optimize components",
 
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if o.Product == "" {

--- a/redskyctl/internal/kustomize/options.go
+++ b/redskyctl/internal/kustomize/options.go
@@ -195,7 +195,7 @@ fieldSpecs:
 	}
 }
 
-// WithAPI configures the controller to use the RedSky API.
+// WithAPI configures the controller to use the Optimize API.
 // If true, the controller deployment is patched to pull environment variables from the secret.
 func WithAPI(o bool) Option {
 	return func(k *Kustomize) error {


### PR DESCRIPTION
This PR changes a bunch of "Red Sky" text over to "Optimize" or "StormForge Optimize" depending on the context. I tried to keep it somewhat consistent, e.g. in the "Long" descriptions of the command (shown when you use `--help`) I tried to use "StormForge Optimize" where are most other references are just "Optimize" to keep things short.