### PR TITLE
Update Import aliases

### DIFF
--- a/api/v1alpha1/experiment_conversion_test.go
+++ b/api/v1alpha1/experiment_conversion_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -31,14 +31,14 @@ func TestConvert_v1alpha1_Metric_To_v1beta1_Metric(t *testing.T) {
 
 	cases := []struct {
 		v1alpha1Metric Metric
-		v1beta1Metric  redskyv1beta1.Metric
+		v1beta1Metric  optimizev1beta1.Metric
 	}{
 		{
 			v1alpha1Metric: Metric{
 				Name:  "constant",
 				Query: "1.1",
 			},
-			v1beta1Metric: redskyv1beta1.Metric{
+			v1beta1Metric: optimizev1beta1.Metric{
 				Name:  "constant",
 				Query: "1.1",
 			},
@@ -56,12 +56,12 @@ func TestConvert_v1alpha1_Metric_To_v1beta1_Metric(t *testing.T) {
 				},
 			},
 			// If you start with v1alpha1, we preserve the selector and use "redskyops.dev" as a placeholder
-			v1beta1Metric: redskyv1beta1.Metric{
+			v1beta1Metric: optimizev1beta1.Metric{
 				Name:  "throughput",
-				Type:  redskyv1beta1.MetricJSONPath,
+				Type:  optimizev1beta1.MetricJSONPath,
 				Query: `{.total}`,
 				URL:   "http://redskyops.dev:5000/metrics",
-				Target: &redskyv1beta1.ResourceTarget{
+				Target: &optimizev1beta1.ResourceTarget{
 					LabelSelector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{"component": "result-exporter"},
 					},
@@ -80,11 +80,11 @@ func TestConvert_v1alpha1_Metric_To_v1beta1_Metric(t *testing.T) {
 				},
 			},
 			// In v1beta1 you need to change the type to "kubernetes" (default type) and add a pod list target reference
-			v1beta1Metric: redskyv1beta1.Metric{
+			v1beta1Metric: optimizev1beta1.Metric{
 				Name:     "cost",
 				Minimize: true,
 				Query:    `{{resourceRequests .Pods "cpu=0.022,memory=0.000000000003"}}`,
-				Target: &redskyv1beta1.ResourceTarget{
+				Target: &optimizev1beta1.ResourceTarget{
 					Kind: "PodList",
 					LabelSelector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{"app": "voting-app"},
@@ -107,12 +107,12 @@ func TestConvert_v1alpha1_Metric_To_v1beta1_Metric(t *testing.T) {
 			// This takes a v1alpha1 metric for the built-in Prometheus and preserves default behaviors
 			// NOTE: Since no URL is generated, it will be defaulted later
 			// NOTE: Having a port number of 9090 is required to get the conversion to round trip correctly
-			v1beta1Metric: redskyv1beta1.Metric{
+			v1beta1Metric: optimizev1beta1.Metric{
 				Name:     "cost",
 				Minimize: true,
-				Type:     redskyv1beta1.MetricPrometheus,
+				Type:     optimizev1beta1.MetricPrometheus,
 				Query:    `({{ cpuRequests . "app=postgres" }} * 17) + ({{ memoryRequests . "app=postgres" | GB }} * 3)`,
-				Target: &redskyv1beta1.ResourceTarget{
+				Target: &optimizev1beta1.ResourceTarget{
 					LabelSelector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{"app": "prometheus"},
 					},
@@ -123,7 +123,7 @@ func TestConvert_v1alpha1_Metric_To_v1beta1_Metric(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.v1alpha1Metric.Name+"_v1alpha1_to_v1beta1", func(t *testing.T) {
 			in := c.v1alpha1Metric
-			actual := redskyv1beta1.Metric{}
+			actual := optimizev1beta1.Metric{}
 			if err := Convert_v1alpha1_Metric_To_v1beta1_Metric(&in, &actual, nil); assert.NoError(t, err) {
 				assert.Equal(t, c.v1beta1Metric, actual)
 			}
@@ -146,14 +146,14 @@ func TestConvert_v1alpha1_Metric_To_v1beta1_Metric(t *testing.T) {
 
 func TestConvert_v1beta1_Metric_To_v1alpha1_Metric(t *testing.T) {
 	cases := []struct {
-		v1beta1Metric  redskyv1beta1.Metric
+		v1beta1Metric  optimizev1beta1.Metric
 		v1alpha1Metric Metric
 	}{
 		{
-			v1beta1Metric: redskyv1beta1.Metric{
+			v1beta1Metric: optimizev1beta1.Metric{
 				Name:     "cpu_requests",
 				Minimize: true,
-				Type:     redskyv1beta1.MetricPrometheus,
+				Type:     optimizev1beta1.MetricPrometheus,
 				Query:    "{{ cpuRequests . \"app=postgres\" }}",
 				URL:      "http://my-prometheus.monitoring:9999",
 			},

--- a/controllers/patch_controller.go
+++ b/controllers/patch_controller.go
@@ -21,7 +21,7 @@ import (
 	"sort"
 
 	"github.com/go-logr/logr"
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	"github.com/thestormforge/optimize-controller/v2/internal/controller"
 	"github.com/thestormforge/optimize-controller/v2/internal/patch"
 	"github.com/thestormforge/optimize-controller/v2/internal/ready"
@@ -55,7 +55,7 @@ func (r *PatchReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	ctx := context.Background()
 	now := metav1.Now()
 
-	t := &redskyv1beta1.Trial{}
+	t := &optimizev1beta1.Trial{}
 	if err := r.Get(ctx, req.NamespacedName, t); err != nil || r.ignoreTrial(t) {
 		return ctrl.Result{}, controller.IgnoreNotFound(err)
 	}
@@ -75,19 +75,19 @@ func (r *PatchReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 func (r *PatchReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("patch").
-		For(&redskyv1beta1.Trial{}).
+		For(&optimizev1beta1.Trial{}).
 		Complete(r)
 }
 
 // ignoreTrial determines which trial objects can be ignored by this reconciler
-func (r *PatchReconciler) ignoreTrial(t *redskyv1beta1.Trial) bool {
+func (r *PatchReconciler) ignoreTrial(t *optimizev1beta1.Trial) bool {
 	// Ignore deleted trials
 	if !t.DeletionTimestamp.IsZero() {
 		return true
 	}
 
 	// Ignore failed trials
-	if trial.CheckCondition(&t.Status, redskyv1beta1.TrialFailed, corev1.ConditionTrue) {
+	if trial.CheckCondition(&t.Status, optimizev1beta1.TrialFailed, corev1.ConditionTrue) {
 		return true
 	}
 
@@ -98,12 +98,12 @@ func (r *PatchReconciler) ignoreTrial(t *redskyv1beta1.Trial) bool {
 
 	// Ignore trials that have setup tasks which haven't run yet
 	// TODO This is to solve a specific race condition with establishing an initializer, is there a better check?
-	if len(t.Spec.SetupTasks) > 0 && !trial.CheckCondition(&t.Status, redskyv1beta1.TrialSetupCreated, corev1.ConditionTrue) {
+	if len(t.Spec.SetupTasks) > 0 && !trial.CheckCondition(&t.Status, optimizev1beta1.TrialSetupCreated, corev1.ConditionTrue) {
 		return true
 	}
 
 	// Ignore patched trials
-	if trial.CheckCondition(&t.Status, redskyv1beta1.TrialPatched, corev1.ConditionTrue) {
+	if trial.CheckCondition(&t.Status, optimizev1beta1.TrialPatched, corev1.ConditionTrue) {
 		return true
 	}
 
@@ -112,14 +112,14 @@ func (r *PatchReconciler) ignoreTrial(t *redskyv1beta1.Trial) bool {
 }
 
 // evaluatePatchOperations will render the patch templates from the experiment using the trial assignments to create "patch operations" on the trial
-func (r *PatchReconciler) evaluatePatchOperations(ctx context.Context, t *redskyv1beta1.Trial, probeTime *metav1.Time) (*ctrl.Result, error) {
+func (r *PatchReconciler) evaluatePatchOperations(ctx context.Context, t *optimizev1beta1.Trial, probeTime *metav1.Time) (*ctrl.Result, error) {
 	// Only evaluate patches if the "patched" status is "unknown"
-	if !trial.CheckCondition(&t.Status, redskyv1beta1.TrialPatched, corev1.ConditionUnknown) {
+	if !trial.CheckCondition(&t.Status, optimizev1beta1.TrialPatched, corev1.ConditionUnknown) {
 		return nil, nil
 	}
 
 	// Get the experiment
-	exp := &redskyv1beta1.Experiment{}
+	exp := &optimizev1beta1.Experiment{}
 	if err := r.Get(ctx, t.ExperimentNamespacedName(), exp); err != nil {
 		return &ctrl.Result{}, err
 	}
@@ -169,15 +169,15 @@ func (r *PatchReconciler) evaluatePatchOperations(ctx context.Context, t *redsky
 	t.Status.ReadinessChecks = append(t.Status.ReadinessChecks, readinessChecks...)
 
 	// Update the status to indicate that patches are evaluated
-	trial.ApplyCondition(&t.Status, redskyv1beta1.TrialPatched, corev1.ConditionFalse, "", "", probeTime)
+	trial.ApplyCondition(&t.Status, optimizev1beta1.TrialPatched, corev1.ConditionFalse, "", "", probeTime)
 	err := r.Update(ctx, t)
 	return controller.RequeueConflict(err)
 }
 
 // applyPatches will actually patch the objects from the patch operations
-func (r *PatchReconciler) applyPatches(ctx context.Context, t *redskyv1beta1.Trial, probeTime *metav1.Time) (*ctrl.Result, error) {
+func (r *PatchReconciler) applyPatches(ctx context.Context, t *optimizev1beta1.Trial, probeTime *metav1.Time) (*ctrl.Result, error) {
 	// Only apply patches if the "patched" status is "false"
-	if !trial.CheckCondition(&t.Status, redskyv1beta1.TrialPatched, corev1.ConditionFalse) {
+	if !trial.CheckCondition(&t.Status, optimizev1beta1.TrialPatched, corev1.ConditionFalse) {
 		return nil, nil
 	}
 
@@ -198,7 +198,7 @@ func (r *PatchReconciler) applyPatches(ctx context.Context, t *redskyv1beta1.Tri
 			p.AttemptsRemaining = p.AttemptsRemaining - 1
 			if p.AttemptsRemaining == 0 {
 				// There are no remaining patch attempts remaining, fail the trial
-				trial.ApplyCondition(&t.Status, redskyv1beta1.TrialFailed, corev1.ConditionTrue, "PatchFailed", err.Error(), probeTime)
+				trial.ApplyCondition(&t.Status, optimizev1beta1.TrialFailed, corev1.ConditionTrue, "PatchFailed", err.Error(), probeTime)
 			}
 		} else {
 			p.AttemptsRemaining = 0
@@ -210,13 +210,13 @@ func (r *PatchReconciler) applyPatches(ctx context.Context, t *redskyv1beta1.Tri
 	}
 
 	// We made it through all of the patches without needing additional changes
-	trial.ApplyCondition(&t.Status, redskyv1beta1.TrialPatched, corev1.ConditionTrue, "", "", probeTime)
+	trial.ApplyCondition(&t.Status, optimizev1beta1.TrialPatched, corev1.ConditionTrue, "", "", probeTime)
 	err := r.Update(ctx, t)
 	return controller.RequeueConflict(err)
 }
 
 // createReadinessCheck creates a readiness check for a patch operation
-func (r *PatchReconciler) createReadinessCheck(t *redskyv1beta1.Trial, ref *corev1.ObjectReference, readinessGates []redskyv1beta1.PatchReadinessGate) (*redskyv1beta1.ReadinessCheck, error) {
+func (r *PatchReconciler) createReadinessCheck(t *optimizev1beta1.Trial, ref *corev1.ObjectReference, readinessGates []optimizev1beta1.PatchReadinessGate) (*optimizev1beta1.ReadinessCheck, error) {
 	// Do not create a readiness check on the trial job or if there is already an explicit readiness gate
 	if trial.IsTrialJobReference(t, ref) || hasTrialReadinessGate(t, ref) {
 		return nil, nil
@@ -225,7 +225,7 @@ func (r *PatchReconciler) createReadinessCheck(t *redskyv1beta1.Trial, ref *core
 	// NOTE: There is a cardinality mismatch between the `PatchReadinessGate` type and the `ReadinessCheck` type in
 	// regard to condition types. We purposely do not expose user facing configuration for these checks (users can
 	// skip patch readiness checks and specify them manually for fine grained control).
-	rc := &redskyv1beta1.ReadinessCheck{
+	rc := &optimizev1beta1.ReadinessCheck{
 		TargetRef:         *ref,
 		PeriodSeconds:     5,
 		AttemptsRemaining: 36, // ...targeting a 3 minute max for applications to come back after a patch
@@ -253,7 +253,7 @@ func (r *PatchReconciler) createReadinessCheck(t *redskyv1beta1.Trial, ref *core
 // hasTrialReadinessGate checks to see if the trial has an explicit readiness gate for the supplied
 // object reference. If there is a readiness gate defined by the user, we do not need to add an
 // implicit readiness check because of the patch.
-func hasTrialReadinessGate(t *redskyv1beta1.Trial, ref *corev1.ObjectReference) bool {
+func hasTrialReadinessGate(t *optimizev1beta1.Trial, ref *corev1.ObjectReference) bool {
 	// There is no way to have a readiness gate in a different namespace from the trial
 	if ref.Namespace != t.Namespace {
 		return false

--- a/controllers/ready_controller.go
+++ b/controllers/ready_controller.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	"github.com/thestormforge/optimize-controller/v2/internal/controller"
 	"github.com/thestormforge/optimize-controller/v2/internal/ready"
 	"github.com/thestormforge/optimize-controller/v2/internal/trial"
@@ -56,7 +56,7 @@ func (r *ReadyReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	ctx := context.Background()
 	now := metav1.Now()
 
-	t := &redskyv1beta1.Trial{}
+	t := &optimizev1beta1.Trial{}
 	if err := r.Get(ctx, req.NamespacedName, t); err != nil || r.ignoreTrial(t) {
 		return ctrl.Result{}, controller.IgnoreNotFound(err)
 	}
@@ -77,29 +77,29 @@ func (r *ReadyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.apiReader = mgr.GetAPIReader()
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("ready").
-		For(&redskyv1beta1.Trial{}).
+		For(&optimizev1beta1.Trial{}).
 		Complete(r)
 }
 
 // ignoreTrial determines which trial objects can be ignored by this reconciler
-func (r *ReadyReconciler) ignoreTrial(t *redskyv1beta1.Trial) bool {
+func (r *ReadyReconciler) ignoreTrial(t *optimizev1beta1.Trial) bool {
 	// Ignore deleted trials
 	if !t.DeletionTimestamp.IsZero() {
 		return true
 	}
 
 	// Ignore failed trials
-	if trial.CheckCondition(&t.Status, redskyv1beta1.TrialFailed, corev1.ConditionTrue) {
+	if trial.CheckCondition(&t.Status, optimizev1beta1.TrialFailed, corev1.ConditionTrue) {
 		return true
 	}
 
 	// Ignore unpatched trials
-	if !trial.CheckCondition(&t.Status, redskyv1beta1.TrialPatched, corev1.ConditionTrue) {
+	if !trial.CheckCondition(&t.Status, optimizev1beta1.TrialPatched, corev1.ConditionTrue) {
 		return true
 	}
 
 	// Ignore ready trials
-	if trial.CheckCondition(&t.Status, redskyv1beta1.TrialReady, corev1.ConditionTrue) {
+	if trial.CheckCondition(&t.Status, optimizev1beta1.TrialReady, corev1.ConditionTrue) {
 		return true
 	}
 
@@ -108,9 +108,9 @@ func (r *ReadyReconciler) ignoreTrial(t *redskyv1beta1.Trial) bool {
 }
 
 // evaluateReadinessChecks will prepare all of the readiness checks for the trial
-func (r *ReadyReconciler) evaluateReadinessChecks(ctx context.Context, t *redskyv1beta1.Trial, probeTime *metav1.Time) (*ctrl.Result, error) {
+func (r *ReadyReconciler) evaluateReadinessChecks(ctx context.Context, t *optimizev1beta1.Trial, probeTime *metav1.Time) (*ctrl.Result, error) {
 	// Only evaluate readiness checks if the "ready" status is "unknown"
-	if !trial.CheckCondition(&t.Status, redskyv1beta1.TrialReady, corev1.ConditionUnknown) {
+	if !trial.CheckCondition(&t.Status, optimizev1beta1.TrialReady, corev1.ConditionUnknown) {
 		return nil, nil
 	}
 
@@ -119,7 +119,7 @@ func (r *ReadyReconciler) evaluateReadinessChecks(ctx context.Context, t *redsky
 	// Add readiness checks for the trial itself
 	for i := range t.Spec.ReadinessGates {
 		c := &t.Spec.ReadinessGates[i]
-		rc := redskyv1beta1.ReadinessCheck{
+		rc := optimizev1beta1.ReadinessCheck{
 			TargetRef: corev1.ObjectReference{
 				Kind:       c.Kind,
 				Namespace:  t.Namespace,
@@ -149,15 +149,15 @@ func (r *ReadyReconciler) evaluateReadinessChecks(ctx context.Context, t *redsky
 	}
 
 	// Update the status to indicate that readiness checks are evaluated
-	trial.ApplyCondition(&t.Status, redskyv1beta1.TrialReady, corev1.ConditionFalse, "", "", probeTime)
+	trial.ApplyCondition(&t.Status, optimizev1beta1.TrialReady, corev1.ConditionFalse, "", "", probeTime)
 	err := r.Update(ctx, t)
 	return controller.RequeueConflict(err)
 }
 
 // checkReadiness will evaluate the readiness checks for the trial
-func (r *ReadyReconciler) checkReadiness(ctx context.Context, t *redskyv1beta1.Trial, probeTime *metav1.Time) (*ctrl.Result, error) {
+func (r *ReadyReconciler) checkReadiness(ctx context.Context, t *optimizev1beta1.Trial, probeTime *metav1.Time) (*ctrl.Result, error) {
 	// Only check readiness checks if the "ready" status is "false"
-	if !trial.CheckCondition(&t.Status, redskyv1beta1.TrialReady, corev1.ConditionFalse) {
+	if !trial.CheckCondition(&t.Status, optimizev1beta1.TrialReady, corev1.ConditionFalse) {
 		return nil, nil
 	}
 
@@ -184,7 +184,7 @@ func (r *ReadyReconciler) checkReadiness(ctx context.Context, t *redskyv1beta1.T
 			return controller.RequeueConflict(err)
 		} else if !isReady {
 			// This will get overwritten with anything that isn't ready as we progress through the loop
-			trial.ApplyCondition(&t.Status, redskyv1beta1.TrialReady, corev1.ConditionFalse, "Waiting", msg, probeTime)
+			trial.ApplyCondition(&t.Status, optimizev1beta1.TrialReady, corev1.ConditionFalse, "Waiting", msg, probeTime)
 		}
 	}
 
@@ -195,14 +195,14 @@ func (r *ReadyReconciler) checkReadiness(ctx context.Context, t *redskyv1beta1.T
 
 	// Update the trial (and the status, if all the checks are complete)
 	if checker.ready {
-		trial.ApplyCondition(&t.Status, redskyv1beta1.TrialReady, corev1.ConditionTrue, "", "", probeTime)
+		trial.ApplyCondition(&t.Status, optimizev1beta1.TrialReady, corev1.ConditionTrue, "", "", probeTime)
 	}
 	err := r.Update(ctx, t)
 	return controller.RequeueConflict(err)
 }
 
 // getCheckTargets returns the list of target objects for the readiness check
-func (r *ReadyReconciler) getCheckTargets(ctx context.Context, rc *redskyv1beta1.ReadinessCheck) (*unstructured.UnstructuredList, error) {
+func (r *ReadyReconciler) getCheckTargets(ctx context.Context, rc *optimizev1beta1.ReadinessCheck) (*unstructured.UnstructuredList, error) {
 	ul := &unstructured.UnstructuredList{}
 
 	// If there is no kind on the target reference, we can't actually fetch anything
@@ -237,7 +237,7 @@ func (r *ReadyReconciler) getCheckTargets(ctx context.Context, rc *redskyv1beta1
 }
 
 // readinessCheckFailed puts a trial into a failed state due to a failed readiness check
-func readinessCheckFailed(t *redskyv1beta1.Trial, probeTime *metav1.Time, err error) {
+func readinessCheckFailed(t *optimizev1beta1.Trial, probeTime *metav1.Time, err error) {
 	reason, message := "ReadinessCheckFailed", err.Error()
 	if rerr, ok := err.(*ready.ReadinessError); ok {
 		if rerr.Reason != "" {
@@ -247,7 +247,7 @@ func readinessCheckFailed(t *redskyv1beta1.Trial, probeTime *metav1.Time, err er
 			message = rerr.Message
 		}
 	}
-	trial.ApplyCondition(&t.Status, redskyv1beta1.TrialFailed, corev1.ConditionTrue, reason, message, probeTime)
+	trial.ApplyCondition(&t.Status, optimizev1beta1.TrialFailed, corev1.ConditionTrue, reason, message, probeTime)
 }
 
 // readinessChecker is the loop state used to evaluate readiness checks
@@ -265,11 +265,11 @@ type readinessChecker struct {
 }
 
 // newReadinessChecker returns a new checker for the supplied trial
-func newReadinessChecker(reader client.Reader, t *redskyv1beta1.Trial) *readinessChecker {
+func newReadinessChecker(reader client.Reader, t *optimizev1beta1.Trial) *readinessChecker {
 	checker := ready.ReadinessChecker{Reader: reader}
 	epoch := t.GetCreationTimestamp()
 	for i := range t.Status.Conditions {
-		if t.Status.Conditions[i].Type == redskyv1beta1.TrialPatched {
+		if t.Status.Conditions[i].Type == optimizev1beta1.TrialPatched {
 			epoch = t.Status.Conditions[i].LastTransitionTime
 		}
 	}
@@ -277,7 +277,7 @@ func newReadinessChecker(reader client.Reader, t *redskyv1beta1.Trial) *readines
 }
 
 // skipCheck determines if a check should be evaluated, recording the results internally
-func (rc *readinessChecker) skipCheck(c *redskyv1beta1.ReadinessCheck, now *metav1.Time) bool {
+func (rc *readinessChecker) skipCheck(c *optimizev1beta1.ReadinessCheck, now *metav1.Time) bool {
 	// Determine if the check is completed
 	if c.AttemptsRemaining <= 0 {
 		return true
@@ -311,7 +311,7 @@ func (rc *readinessChecker) skipCheck(c *redskyv1beta1.ReadinessCheck, now *meta
 
 // check evaluates a readiness check against a (possibly nil) target, returning a status message and boolean indicating
 // if the target is in fact ready
-func (rc *readinessChecker) check(ctx context.Context, c *redskyv1beta1.ReadinessCheck, ul *unstructured.UnstructuredList, now *metav1.Time) (string, bool, error) {
+func (rc *readinessChecker) check(ctx context.Context, c *optimizev1beta1.ReadinessCheck, ul *unstructured.UnstructuredList, now *metav1.Time) (string, bool, error) {
 	// Evaluate the actual conditions (stop at the first one that isn't "ready")
 	var msg string
 	var ok bool
@@ -367,7 +367,7 @@ func (rc *readinessChecker) check(ctx context.Context, c *redskyv1beta1.Readines
 }
 
 // nextCheckTime returns the approximate time that an attempt should be made to evaluate a check
-func (rc *readinessChecker) nextCheckTime(c *redskyv1beta1.ReadinessCheck) *metav1.Time {
+func (rc *readinessChecker) nextCheckTime(c *optimizev1beta1.ReadinessCheck) *metav1.Time {
 	if c.LastCheckTime != nil {
 		periodSeconds := c.PeriodSeconds
 		if periodSeconds < 1 {

--- a/controllers/server_controller.go
+++ b/controllers/server_controller.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	"github.com/thestormforge/optimize-controller/v2/internal/controller"
 	"github.com/thestormforge/optimize-controller/v2/internal/experiment"
 	"github.com/thestormforge/optimize-controller/v2/internal/meta"
@@ -88,7 +88,7 @@ func (r *ServerReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	log := r.Log.WithValues("experiment", req.NamespacedName)
 
 	// Fetch the experiment state from the cluster
-	exp := &redskyv1beta1.Experiment{}
+	exp := &optimizev1beta1.Experiment{}
 	if err := r.Get(ctx, req.NamespacedName, exp); err != nil {
 		return ctrl.Result{}, controller.IgnoreNotFound(err)
 	}
@@ -105,7 +105,7 @@ func (r *ServerReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 
 	// Get the current list of trials
 	// NOTE: No need to use limits, the cache will just return the full list anyway
-	trialList := &redskyv1beta1.TrialList{}
+	trialList := &optimizev1beta1.TrialList{}
 	if err := r.listTrials(ctx, trialList, exp.TrialSelector()); err != nil {
 		return ctrl.Result{}, err
 	}
@@ -140,7 +140,7 @@ func (r *ServerReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	}
 
 	// Create a new trial if necessary
-	if exp.GetAnnotations()[redskyv1beta1.AnnotationNextTrialURL] != "" && activeTrials < exp.Replicas() {
+	if exp.GetAnnotations()[optimizev1beta1.AnnotationNextTrialURL] != "" && activeTrials < exp.Replicas() {
 		if result, err := r.nextTrial(ctx, log, exp, trialList); result != nil {
 			return *result, err
 		}
@@ -213,7 +213,7 @@ func (r *ServerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("server").
-		For(&redskyv1beta1.Experiment{}).
+		For(&optimizev1beta1.Experiment{}).
 		WithEventFilter(&createFilter{}).
 		Complete(r)
 }
@@ -227,7 +227,7 @@ func (*createFilter) Update(event.UpdateEvent) bool   { return true }
 func (*createFilter) Generic(event.GenericEvent) bool { return true }
 
 // listTrials retrieves the list of trial objects matching the specified selector
-func (r *ServerReconciler) listTrials(ctx context.Context, trialList *redskyv1beta1.TrialList, selector *metav1.LabelSelector) error {
+func (r *ServerReconciler) listTrials(ctx context.Context, trialList *optimizev1beta1.TrialList, selector *metav1.LabelSelector) error {
 	s, err := metav1.LabelSelectorAsSelector(selector)
 	if err != nil {
 		return err
@@ -237,7 +237,7 @@ func (r *ServerReconciler) listTrials(ctx context.Context, trialList *redskyv1be
 
 // createExperiment will create a new experiment on the server using the cluster state; any default values from the
 // server will be copied back into cluster along with the URLs needed for future interactions with server.
-func (r *ServerReconciler) createExperiment(ctx context.Context, log logr.Logger, exp *redskyv1beta1.Experiment) (*ctrl.Result, error) {
+func (r *ServerReconciler) createExperiment(ctx context.Context, log logr.Logger, exp *optimizev1beta1.Experiment) (*ctrl.Result, error) {
 	// If the server finalizer is already present, do not try to recreate the experiment on the server
 	if meta.HasFinalizer(exp, server.Finalizer) {
 		return nil, nil
@@ -289,13 +289,13 @@ func (r *ServerReconciler) createExperiment(ctx context.Context, log logr.Logger
 		return controller.RequeueConflict(err)
 	}
 
-	log.Info("Created remote experiment", "experimentURL", exp.Annotations[redskyv1beta1.AnnotationExperimentURL])
+	log.Info("Created remote experiment", "experimentURL", exp.Annotations[optimizev1beta1.AnnotationExperimentURL])
 	return nil, nil
 }
 
 // unlinkExperiment will delete the experiment from the server using the URLs recorded in the cluster; the finalizer
 // added when the experiment was created on the server will also be removed
-func (r *ServerReconciler) unlinkExperiment(ctx context.Context, log logr.Logger, exp *redskyv1beta1.Experiment) (*ctrl.Result, error) {
+func (r *ServerReconciler) unlinkExperiment(ctx context.Context, log logr.Logger, exp *optimizev1beta1.Experiment) (*ctrl.Result, error) {
 	// Try to remove the finalizer, if it is already gone we do not need to do anything
 	if !meta.RemoveFinalizer(exp, server.Finalizer) {
 		return nil, nil
@@ -303,17 +303,17 @@ func (r *ServerReconciler) unlinkExperiment(ctx context.Context, log logr.Logger
 
 	// Check to see if we should delete the experiment on the server
 	// NOTE: Deleting the server experiment is unusual, we normally want to preserve the server data
-	if u := exp.GetAnnotations()[redskyv1beta1.AnnotationExperimentURL]; u != "" && server.DeleteServerExperiment(exp) {
+	if u := exp.GetAnnotations()[optimizev1beta1.AnnotationExperimentURL]; u != "" && server.DeleteServerExperiment(exp) {
 		if err := r.ExperimentsAPI.DeleteExperiment(ctx, u); controller.IgnoreNotFound(err) != nil {
 			log.Error(err, "Failed to delete server experiment")
 		}
 	}
 
 	// Update the in-cluster experiment to reflect it is no-longer linked to the server
-	experiment.ApplyCondition(&exp.Status, redskyv1beta1.ExperimentComplete, corev1.ConditionTrue, "", "", nil)
-	delete(exp.GetAnnotations(), redskyv1beta1.AnnotationExperimentURL)
-	delete(exp.GetAnnotations(), redskyv1beta1.AnnotationNextTrialURL)
-	delete(exp.GetAnnotations(), redskyv1beta1.AnnotationReportTrialURL)
+	experiment.ApplyCondition(&exp.Status, optimizev1beta1.ExperimentComplete, corev1.ConditionTrue, "", "", nil)
+	delete(exp.GetAnnotations(), optimizev1beta1.AnnotationExperimentURL)
+	delete(exp.GetAnnotations(), optimizev1beta1.AnnotationNextTrialURL)
+	delete(exp.GetAnnotations(), optimizev1beta1.AnnotationReportTrialURL)
 	if err := r.Update(ctx, exp); err != nil {
 		return controller.RequeueConflict(err)
 	}
@@ -324,7 +324,7 @@ func (r *ServerReconciler) unlinkExperiment(ctx context.Context, log logr.Logger
 
 // nextTrial will try to obtain a suggestion from the server and create the corresponding cluster state in the form of
 // a trial; if the cluster can not accommodate additional trials at the time of invocation, not action will be taken
-func (r *ServerReconciler) nextTrial(ctx context.Context, log logr.Logger, exp *redskyv1beta1.Experiment, trialList *redskyv1beta1.TrialList) (*ctrl.Result, error) {
+func (r *ServerReconciler) nextTrial(ctx context.Context, log logr.Logger, exp *optimizev1beta1.Experiment, trialList *optimizev1beta1.TrialList) (*ctrl.Result, error) {
 	// Enforce a rate limit on trial creation
 	res := r.trialCreation.Reserve()
 	if !res.OK() {
@@ -347,7 +347,7 @@ func (r *ServerReconciler) nextTrial(ctx context.Context, log logr.Logger, exp *
 	}
 
 	// Obtain a suggestion from the server
-	suggestion, err := r.ExperimentsAPI.NextTrial(ctx, exp.GetAnnotations()[redskyv1beta1.AnnotationNextTrialURL])
+	suggestion, err := r.ExperimentsAPI.NextTrial(ctx, exp.GetAnnotations()[optimizev1beta1.AnnotationNextTrialURL])
 	if err != nil {
 		if server.StopExperiment(exp, err) {
 			err := r.Update(ctx, exp)
@@ -357,7 +357,7 @@ func (r *ServerReconciler) nextTrial(ctx context.Context, log logr.Logger, exp *
 	}
 
 	// Generate a new trial from the template on the experiment and apply the server response
-	t := &redskyv1beta1.Trial{}
+	t := &optimizev1beta1.Trial{}
 	experiment.PopulateTrialFromTemplate(exp, t)
 	t.Namespace = namespace
 	server.ToClusterTrial(t, &suggestion)
@@ -371,23 +371,23 @@ func (r *ServerReconciler) nextTrial(ctx context.Context, log logr.Logger, exp *
 	// Create the trial
 	if err := r.Create(ctx, t); err != nil {
 		// If creation fails, abandon the suggestion (ignoring those errors)
-		if url := t.GetAnnotations()[redskyv1beta1.AnnotationReportTrialURL]; url != "" {
+		if url := t.GetAnnotations()[optimizev1beta1.AnnotationReportTrialURL]; url != "" {
 			_ = r.ExperimentsAPI.AbandonRunningTrial(ctx, url)
 		}
 		return &ctrl.Result{}, err
 	}
 
-	log.Info("Created new trial", "reportTrialURL", t.GetAnnotations()[redskyv1beta1.AnnotationReportTrialURL], "assignments", t.Spec.Assignments)
+	log.Info("Created new trial", "reportTrialURL", t.GetAnnotations()[optimizev1beta1.AnnotationReportTrialURL], "assignments", t.Spec.Assignments)
 	return nil, nil
 }
 
 // reportTrial will report the values from a finished in cluster trial back to the server
-func (r *ServerReconciler) reportTrial(ctx context.Context, log logr.Logger, t *redskyv1beta1.Trial) (*ctrl.Result, error) {
+func (r *ServerReconciler) reportTrial(ctx context.Context, log logr.Logger, t *optimizev1beta1.Trial) (*ctrl.Result, error) {
 	if !meta.RemoveFinalizer(t, server.Finalizer) {
 		return nil, nil
 	}
 
-	if reportTrialURL := t.GetAnnotations()[redskyv1beta1.AnnotationReportTrialURL]; reportTrialURL != "" {
+	if reportTrialURL := t.GetAnnotations()[optimizev1beta1.AnnotationReportTrialURL]; reportTrialURL != "" {
 		trialValues := server.FromClusterTrial(t)
 		err := r.ExperimentsAPI.ReportTrial(ctx, reportTrialURL, *trialValues)
 		if controller.IgnoreReportError(err) != nil {
@@ -398,7 +398,7 @@ func (r *ServerReconciler) reportTrial(ctx context.Context, log logr.Logger, t *
 		log = log.WithValues("reportTrialURL", reportTrialURL, "values", trialValues)
 		for i := range t.Status.Conditions {
 			c := t.Status.Conditions[i]
-			if c.Type == redskyv1beta1.TrialFailed && c.Status == corev1.ConditionTrue {
+			if c.Type == optimizev1beta1.TrialFailed && c.Status == corev1.ConditionTrue {
 				log = log.WithValues("failureReason", c.Reason, "failureMessage", c.Message)
 				break
 			}
@@ -415,12 +415,12 @@ func (r *ServerReconciler) reportTrial(ctx context.Context, log logr.Logger, t *
 }
 
 // abandonTrial will remove the finalizer and try to notify the server that the trial will not be reported
-func (r *ServerReconciler) abandonTrial(ctx context.Context, log logr.Logger, t *redskyv1beta1.Trial) (*ctrl.Result, error) {
+func (r *ServerReconciler) abandonTrial(ctx context.Context, log logr.Logger, t *optimizev1beta1.Trial) (*ctrl.Result, error) {
 	if !meta.RemoveFinalizer(t, server.Finalizer) {
 		return nil, nil
 	}
 
-	if reportTrialURL := t.GetAnnotations()[redskyv1beta1.AnnotationReportTrialURL]; reportTrialURL != "" {
+	if reportTrialURL := t.GetAnnotations()[optimizev1beta1.AnnotationReportTrialURL]; reportTrialURL != "" {
 		err := r.ExperimentsAPI.AbandonRunningTrial(ctx, reportTrialURL)
 		if controller.IgnoreNotFound(err) != nil {
 			return &ctrl.Result{}, err

--- a/controllers/setup_controller.go
+++ b/controllers/setup_controller.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	"github.com/thestormforge/optimize-controller/v2/internal/controller"
 	"github.com/thestormforge/optimize-controller/v2/internal/meta"
 	"github.com/thestormforge/optimize-controller/v2/internal/setup"
@@ -51,7 +51,7 @@ func (r *SetupReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	ctx := context.Background()
 	now := metav1.Now()
 
-	t := &redskyv1beta1.Trial{}
+	t := &optimizev1beta1.Trial{}
 	if err := r.Get(ctx, req.NamespacedName, t); err != nil {
 		return ctrl.Result{}, controller.IgnoreNotFound(err)
 	}
@@ -83,16 +83,16 @@ func (r *SetupReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// TODO Have some type of setting to by-pass this
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("setup").
-		For(&redskyv1beta1.Trial{}).
+		For(&optimizev1beta1.Trial{}).
 		Owns(&batchv1.Job{}).
 		Complete(r)
 }
 
 // inspectSetupJobs will look for the setup jobs and update the trial status accordingly
-func (r *SetupReconciler) inspectSetupJobs(ctx context.Context, t *redskyv1beta1.Trial, probeTime *metav1.Time) (*ctrl.Result, error) {
+func (r *SetupReconciler) inspectSetupJobs(ctx context.Context, t *optimizev1beta1.Trial, probeTime *metav1.Time) (*ctrl.Result, error) {
 	// Find the setup jobs for this trial
 	list := &batchv1.JobList{}
-	setupJobLabels := map[string]string{redskyv1beta1.LabelTrial: t.Name, redskyv1beta1.LabelTrialRole: "trialSetup"}
+	setupJobLabels := map[string]string{optimizev1beta1.LabelTrial: t.Name, optimizev1beta1.LabelTrialRole: "trialSetup"}
 	if err := r.List(ctx, list, client.InNamespace(t.Namespace), client.MatchingLabels(setupJobLabels)); err != nil {
 		return &ctrl.Result{}, err
 	}
@@ -103,16 +103,16 @@ func (r *SetupReconciler) inspectSetupJobs(ctx context.Context, t *redskyv1beta1
 			// Normally if the trial hasn't been deleted and there are no jobs, the status will already be unknown
 			// NOTE: Do not use ApplyCondition unless we are sure the condition is already there
 			for i := range t.Status.Conditions {
-				if ct := t.Status.Conditions[i].Type; ct == redskyv1beta1.TrialSetupCreated || ct == redskyv1beta1.TrialSetupDeleted {
+				if ct := t.Status.Conditions[i].Type; ct == optimizev1beta1.TrialSetupCreated || ct == optimizev1beta1.TrialSetupDeleted {
 					trial.ApplyCondition(&t.Status, ct, corev1.ConditionUnknown, "", "", probeTime)
 				}
 			}
-		} else if trial.CheckCondition(&t.Status, redskyv1beta1.TrialSetupDeleted, corev1.ConditionFalse) {
+		} else if trial.CheckCondition(&t.Status, optimizev1beta1.TrialSetupDeleted, corev1.ConditionFalse) {
 			// We only need this for the delete job (the corresponding failure for the create job is handled when creating the jobs):
 			// If "setup deleted" condition is "false" then we must have started job, but if the list is empty someone
 			// deleted the job (e.g. the namespace was deleted while the setup delete job was running); mark the setup
 			// deletion as "true" to ensure the finalizers are cleaned up.
-			trial.ApplyCondition(&t.Status, redskyv1beta1.TrialSetupDeleted, corev1.ConditionTrue, "MissingJob", "", probeTime)
+			trial.ApplyCondition(&t.Status, optimizev1beta1.TrialSetupDeleted, corev1.ConditionTrue, "MissingJob", "", probeTime)
 		}
 	}
 
@@ -136,7 +136,7 @@ func (r *SetupReconciler) inspectSetupJobs(ctx context.Context, t *redskyv1beta1
 		// Only fail the trial itself if it isn't already finished; both to prevent overwriting an existing success
 		// or failure status and to avoid updating the probe time (which would get us stuck in a busy loop)
 		if failureMessage != "" && !trial.IsFinished(t) {
-			trial.ApplyCondition(&t.Status, redskyv1beta1.TrialFailed, corev1.ConditionTrue, "SetupJobFailed", failureMessage, probeTime)
+			trial.ApplyCondition(&t.Status, optimizev1beta1.TrialFailed, corev1.ConditionTrue, "SetupJobFailed", failureMessage, probeTime)
 		}
 	}
 
@@ -171,11 +171,11 @@ func (r *SetupReconciler) inspectSetupJobPods(ctx context.Context, j *batchv1.Jo
 }
 
 // createSetupJob determines if a setup job is necessary and creates it
-func (r *SetupReconciler) createSetupJob(ctx context.Context, t *redskyv1beta1.Trial, probeTime *metav1.Time) (*ctrl.Result, error) {
+func (r *SetupReconciler) createSetupJob(ctx context.Context, t *optimizev1beta1.Trial, probeTime *metav1.Time) (*ctrl.Result, error) {
 	mode := ""
 
 	// If the created condition is unknown, we may need a create job
-	if trial.CheckCondition(&t.Status, redskyv1beta1.TrialSetupCreated, corev1.ConditionUnknown) {
+	if trial.CheckCondition(&t.Status, optimizev1beta1.TrialSetupCreated, corev1.ConditionUnknown) {
 		// Before we can create the job, we need an initializer/finalizer
 		if trial.AddInitializer(t, setup.Initializer) || meta.AddFinalizer(t, setup.Finalizer) {
 			err := r.Update(ctx, t)
@@ -189,7 +189,7 @@ func (r *SetupReconciler) createSetupJob(ctx context.Context, t *redskyv1beta1.T
 	}
 
 	// If the deleted condition is unknown, we may need a delete job
-	if trial.CheckCondition(&t.Status, redskyv1beta1.TrialSetupDeleted, corev1.ConditionUnknown) {
+	if trial.CheckCondition(&t.Status, optimizev1beta1.TrialSetupDeleted, corev1.ConditionUnknown) {
 		// We do not need the deleted job until the trial is finished or it gets deleted
 		if trial.IsFinished(t) || !t.DeletionTimestamp.IsZero() {
 			mode = setup.ModeDelete
@@ -209,7 +209,7 @@ func (r *SetupReconciler) createSetupJob(ctx context.Context, t *redskyv1beta1.T
 
 		// Forbidden for a delete job indicates that namespace was probably deleted
 		if apierrs.IsForbidden(err) && mode == setup.ModeDelete {
-			trial.ApplyCondition(&t.Status, redskyv1beta1.TrialSetupDeleted, corev1.ConditionTrue, "Forbidden", err.Error(), probeTime)
+			trial.ApplyCondition(&t.Status, optimizev1beta1.TrialSetupDeleted, corev1.ConditionTrue, "Forbidden", err.Error(), probeTime)
 			err := r.Update(ctx, t)
 			return controller.RequeueConflict(err)
 		}
@@ -221,16 +221,16 @@ func (r *SetupReconciler) createSetupJob(ctx context.Context, t *redskyv1beta1.T
 }
 
 // finish takes care of removing initializers and finalizers
-func (r *SetupReconciler) finish(ctx context.Context, t *redskyv1beta1.Trial) (*ctrl.Result, error) {
+func (r *SetupReconciler) finish(ctx context.Context, t *optimizev1beta1.Trial) (*ctrl.Result, error) {
 	// If the create job isn't finished, wait for it (unless the trial is already finished, i.e. failed)
-	if trial.CheckCondition(&t.Status, redskyv1beta1.TrialSetupCreated, corev1.ConditionFalse) {
+	if trial.CheckCondition(&t.Status, optimizev1beta1.TrialSetupCreated, corev1.ConditionFalse) {
 		if !trial.IsFinished(t) && t.DeletionTimestamp.IsZero() {
 			return &ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 		}
 	}
 
 	// If the create job is finished, remove the initializer so the rest of the trial can run
-	if trial.CheckCondition(&t.Status, redskyv1beta1.TrialSetupCreated, corev1.ConditionTrue) {
+	if trial.CheckCondition(&t.Status, optimizev1beta1.TrialSetupCreated, corev1.ConditionTrue) {
 		if trial.RemoveInitializer(t, setup.Initializer) {
 			err := r.Update(ctx, t)
 			return controller.RequeueConflict(err)
@@ -238,7 +238,7 @@ func (r *SetupReconciler) finish(ctx context.Context, t *redskyv1beta1.Trial) (*
 	}
 
 	// Do not remove the finalizer until the delete job is finished
-	if trial.CheckCondition(&t.Status, redskyv1beta1.TrialSetupDeleted, corev1.ConditionTrue) {
+	if trial.CheckCondition(&t.Status, optimizev1beta1.TrialSetupDeleted, corev1.ConditionTrue) {
 		if meta.RemoveFinalizer(t, setup.Finalizer) {
 			err := r.Update(ctx, t)
 			return controller.RequeueConflict(err)
@@ -247,8 +247,8 @@ func (r *SetupReconciler) finish(ctx context.Context, t *redskyv1beta1.Trial) (*
 
 	// The trial is deleted and _both_ jobs are started but not completed; assume the trial job is misconfigured.
 	if !t.DeletionTimestamp.IsZero() &&
-		trial.CheckCondition(&t.Status, redskyv1beta1.TrialSetupCreated, corev1.ConditionFalse) &&
-		trial.CheckCondition(&t.Status, redskyv1beta1.TrialSetupDeleted, corev1.ConditionFalse) {
+		trial.CheckCondition(&t.Status, optimizev1beta1.TrialSetupCreated, corev1.ConditionFalse) &&
+		trial.CheckCondition(&t.Status, optimizev1beta1.TrialSetupDeleted, corev1.ConditionFalse) {
 		// To get into this state, just delete a trial that has a setup job with an invalid volume map (e.g. missing config map).
 		// TODO Is it possible we got here because the create job just never had a chance to finish?
 		if meta.RemoveFinalizer(t, setup.Finalizer) {

--- a/controllers/trial_job_controller.go
+++ b/controllers/trial_job_controller.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	"github.com/thestormforge/optimize-controller/v2/internal/controller"
 	"github.com/thestormforge/optimize-controller/v2/internal/meta"
 	"github.com/thestormforge/optimize-controller/v2/internal/trial"
@@ -51,7 +51,7 @@ func (r *TrialJobReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	ctx := context.Background()
 	now := metav1.Now()
 
-	t := &redskyv1beta1.Trial{}
+	t := &optimizev1beta1.Trial{}
 	if err := r.Get(ctx, req.NamespacedName, t); err != nil || r.ignoreTrial(t) {
 		return ctrl.Result{}, controller.IgnoreNotFound(err)
 	}
@@ -75,7 +75,7 @@ func (r *TrialJobReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	// Insert a "sleep" between "ready" and the trial job
 	if ids := time.Duration(t.Spec.InitialDelaySeconds) * time.Second; ids > 0 {
 		for _, c := range t.Status.Conditions {
-			if c.Type == redskyv1beta1.TrialReady {
+			if c.Type == optimizev1beta1.TrialReady {
 				startTime := c.LastTransitionTime.Add(ids)
 				if startTime.After(now.Time) {
 					return ctrl.Result{RequeueAfter: startTime.Sub(now.Time)}, nil
@@ -95,24 +95,24 @@ func (r *TrialJobReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 func (r *TrialJobReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("trial-job").
-		For(&redskyv1beta1.Trial{}).
+		For(&optimizev1beta1.Trial{}).
 		Owns(&batchv1.Job{}).
 		Complete(r)
 }
 
-func (r *TrialJobReconciler) ignoreTrial(t *redskyv1beta1.Trial) bool {
+func (r *TrialJobReconciler) ignoreTrial(t *optimizev1beta1.Trial) bool {
 	// Ignore deleted trials
 	if !t.DeletionTimestamp.IsZero() {
 		return true
 	}
 
 	// Ignore failed trials
-	if trial.CheckCondition(&t.Status, redskyv1beta1.TrialFailed, corev1.ConditionTrue) {
+	if trial.CheckCondition(&t.Status, optimizev1beta1.TrialFailed, corev1.ConditionTrue) {
 		return true
 	}
 
 	// Ignore trials that are not ready yet
-	if !trial.CheckCondition(&t.Status, redskyv1beta1.TrialReady, corev1.ConditionTrue) {
+	if !trial.CheckCondition(&t.Status, optimizev1beta1.TrialReady, corev1.ConditionTrue) {
 		return true
 	}
 
@@ -126,7 +126,7 @@ func (r *TrialJobReconciler) ignoreTrial(t *redskyv1beta1.Trial) bool {
 }
 
 // updateStatus will update the trial status based on the supplied list of trial run jobs
-func (r *TrialJobReconciler) updateStatus(ctx context.Context, t *redskyv1beta1.Trial, jobList *batchv1.JobList, probeTime *metav1.Time) (*ctrl.Result, error) {
+func (r *TrialJobReconciler) updateStatus(ctx context.Context, t *optimizev1beta1.Trial, jobList *batchv1.JobList, probeTime *metav1.Time) (*ctrl.Result, error) {
 	for i := range jobList.Items {
 		if update, requeue := r.applyJobStatus(ctx, t, &jobList.Items[i], probeTime); update {
 			err := r.Update(ctx, t)
@@ -141,7 +141,7 @@ func (r *TrialJobReconciler) updateStatus(ctx context.Context, t *redskyv1beta1.
 }
 
 // createJob will create a new trial run job
-func (r *TrialJobReconciler) createJob(ctx context.Context, t *redskyv1beta1.Trial) (*ctrl.Result, error) {
+func (r *TrialJobReconciler) createJob(ctx context.Context, t *optimizev1beta1.Trial) (*ctrl.Result, error) {
 	job := trial.NewJob(t)
 	if err := controllerutil.SetControllerReference(t, job, r.Scheme); err != nil {
 		return &ctrl.Result{}, err
@@ -165,7 +165,7 @@ func (r *TrialJobReconciler) listJobs(ctx context.Context, jobList *batchv1.JobL
 	// NOTE: We do not use label selectors on search because we don't know if they are user modified
 	items := jobList.Items[:0]
 	for i := range jobList.Items {
-		if jobList.Items[i].Labels[redskyv1beta1.LabelTrialRole] != "trialSetup" {
+		if jobList.Items[i].Labels[optimizev1beta1.LabelTrialRole] != "trialSetup" {
 			items = append(items, jobList.Items[i])
 		}
 	}
@@ -174,7 +174,7 @@ func (r *TrialJobReconciler) listJobs(ctx context.Context, jobList *batchv1.JobL
 	return nil
 }
 
-func (r *TrialJobReconciler) applyJobStatus(ctx context.Context, t *redskyv1beta1.Trial, job *batchv1.Job, time *metav1.Time) (bool, bool) {
+func (r *TrialJobReconciler) applyJobStatus(ctx context.Context, t *optimizev1beta1.Trial, job *batchv1.Job, time *metav1.Time) (bool, bool) {
 	var dirty bool
 
 	// Get the interval of the container execution in the job pods
@@ -188,14 +188,14 @@ func (r *TrialJobReconciler) applyJobStatus(ctx context.Context, t *redskyv1beta
 			for i := range podList.Items {
 				s := &podList.Items[i].Status
 				if s.Phase == corev1.PodFailed {
-					trial.ApplyCondition(&t.Status, redskyv1beta1.TrialFailed, corev1.ConditionTrue, s.Reason, "trial pod failed", time)
+					trial.ApplyCondition(&t.Status, optimizev1beta1.TrialFailed, corev1.ConditionTrue, s.Reason, "trial pod failed", time)
 					dirty = true
 				}
 
 				// TODO We should consolidate this with `internal/ready/podFailed`
 				for _, c := range s.Conditions {
 					if c.Type == corev1.PodScheduled && c.Status == corev1.ConditionFalse && c.Reason == corev1.PodReasonUnschedulable {
-						trial.ApplyCondition(&t.Status, redskyv1beta1.TrialFailed, corev1.ConditionTrue, c.Reason, fmt.Sprintf("trial pod: %s", c.Message), time)
+						trial.ApplyCondition(&t.Status, optimizev1beta1.TrialFailed, corev1.ConditionTrue, c.Reason, fmt.Sprintf("trial pod: %s", c.Message), time)
 
 						// Patch the job and set parallelism to 0 to suspend the job and terminate any active pods
 						if err := r.Patch(ctx, job, client.RawPatch(types.StrategicMergePatchType, []byte(`{ "spec": { "parallelism": 0  } }`))); err != nil {
@@ -229,7 +229,7 @@ func (r *TrialJobReconciler) applyJobStatus(ctx context.Context, t *redskyv1beta
 	// Mark the trial as failed if the job itself failed
 	for _, c := range job.Status.Conditions {
 		if c.Type == batchv1.JobFailed && c.Status == corev1.ConditionTrue {
-			trial.ApplyCondition(&t.Status, redskyv1beta1.TrialFailed, corev1.ConditionTrue, c.Reason, c.Message, time)
+			trial.ApplyCondition(&t.Status, optimizev1beta1.TrialFailed, corev1.ConditionTrue, c.Reason, c.Message, time)
 			dirty = true
 		}
 	}

--- a/internal/application/application.go
+++ b/internal/application/application.go
@@ -23,12 +23,12 @@ import (
 	"strings"
 	"unicode"
 
-	redskyappsv1alpha1 "github.com/thestormforge/optimize-controller/v2/api/apps/v1alpha1"
+	optimizeappsv1alpha1 "github.com/thestormforge/optimize-controller/v2/api/apps/v1alpha1"
 	"sigs.k8s.io/kustomize/kyaml/kio/kioutil"
 )
 
 // GetScenario returns the named scenario from the application, if possible.
-func GetScenario(app *redskyappsv1alpha1.Application, scenario string) (*redskyappsv1alpha1.Scenario, error) {
+func GetScenario(app *optimizeappsv1alpha1.Application, scenario string) (*optimizeappsv1alpha1.Scenario, error) {
 	if scenario == "" && len(app.Scenarios) == 1 {
 		return &app.Scenarios[0], nil
 	}
@@ -38,7 +38,7 @@ func GetScenario(app *redskyappsv1alpha1.Application, scenario string) (*redskya
 	}
 
 	cleanScenario := cleanName(scenario)
-	var result *redskyappsv1alpha1.Scenario
+	var result *optimizeappsv1alpha1.Scenario
 	var names []string
 	for i := range app.Scenarios {
 		names = append(names, app.Scenarios[i].Name)
@@ -65,7 +65,7 @@ func GetScenario(app *redskyappsv1alpha1.Application, scenario string) (*redskya
 }
 
 // GetObjective returns the goals of an objective, if possible.
-func GetObjective(app *redskyappsv1alpha1.Application, objective string) (*redskyappsv1alpha1.Objective, error) {
+func GetObjective(app *optimizeappsv1alpha1.Application, objective string) (*optimizeappsv1alpha1.Objective, error) {
 	if objective == "" && len(app.Objectives) == 1 {
 		return &app.Objectives[0], nil
 	}
@@ -75,7 +75,7 @@ func GetObjective(app *redskyappsv1alpha1.Application, objective string) (*redsk
 	}
 
 	cleanObjective := cleanName(objective)
-	var result *redskyappsv1alpha1.Objective
+	var result *optimizeappsv1alpha1.Objective
 	var names []string
 	for i := range app.Objectives {
 		names = append(names, app.Objectives[i].Name)
@@ -102,7 +102,7 @@ func GetObjective(app *redskyappsv1alpha1.Application, objective string) (*redsk
 }
 
 // ExperimentName returns the name of an experiment corresponding to the application.
-func ExperimentName(app *redskyappsv1alpha1.Application, scenario, objective string) string {
+func ExperimentName(app *optimizeappsv1alpha1.Application, scenario, objective string) string {
 	name := cleanName(app.Name)
 
 	// Cap name length to 54 so we can add 9 more characters before hitting 63
@@ -120,7 +120,7 @@ func ExperimentName(app *redskyappsv1alpha1.Application, scenario, objective str
 
 // GuessScenarioAndObjective attempts to match an experiment name back to the scenario
 // and objective names used to generate it.
-func GuessScenarioAndObjective(app *redskyappsv1alpha1.Application, experimentName string) (scenario, objective string) {
+func GuessScenarioAndObjective(app *optimizeappsv1alpha1.Application, experimentName string) (scenario, objective string) {
 	for i := range app.Scenarios {
 		for j := range app.Objectives {
 			if ExperimentName(app, app.Scenarios[i].Name, app.Objectives[j].Name) == experimentName {
@@ -135,7 +135,7 @@ func GuessScenarioAndObjective(app *redskyappsv1alpha1.Application, experimentNa
 // WorkingDirectory returns the directory the application was loaded from. This
 // directory should be used as the effective working directory when resolving relative
 // paths found in the application definition.
-func WorkingDirectory(app *redskyappsv1alpha1.Application) string {
+func WorkingDirectory(app *optimizeappsv1alpha1.Application) string {
 	if path := app.Annotations[kioutil.PathAnnotation]; path != "" {
 		return filepath.Dir(path)
 	}

--- a/internal/application/application_test.go
+++ b/internal/application/application_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	redskyappsv1alpha1 "github.com/thestormforge/optimize-controller/v2/api/apps/v1alpha1"
+	optimizeappsv1alpha1 "github.com/thestormforge/optimize-controller/v2/api/apps/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -52,7 +52,7 @@ func TestExperimentName(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.applicationName, func(t *testing.T) {
-			actual := ExperimentName(&redskyappsv1alpha1.Application{
+			actual := ExperimentName(&optimizeappsv1alpha1.Application{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: c.applicationName,
 				},

--- a/internal/application/documentation.go
+++ b/internal/application/documentation.go
@@ -21,7 +21,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	redskyappsv1alpha1 "github.com/thestormforge/optimize-controller/v2/api/apps/v1alpha1"
+	optimizeappsv1alpha1 "github.com/thestormforge/optimize-controller/v2/api/apps/v1alpha1"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
@@ -142,7 +142,7 @@ func (f *DocumentationFilter) Filter(nodes []*yaml.RNode) ([]*yaml.RNode, error)
 			continue
 		}
 
-		if meta.Kind != "Application" || meta.APIVersion != redskyappsv1alpha1.GroupVersion.String() {
+		if meta.Kind != "Application" || meta.APIVersion != optimizeappsv1alpha1.GroupVersion.String() {
 			continue
 		}
 

--- a/internal/application/generator.go
+++ b/internal/application/generator.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	"github.com/thestormforge/konjure/pkg/konjure"
-	redskyappsv1alpha1 "github.com/thestormforge/optimize-controller/v2/api/apps/v1alpha1"
+	optimizeappsv1alpha1 "github.com/thestormforge/optimize-controller/v2/api/apps/v1alpha1"
 	"github.com/thestormforge/optimize-controller/v2/internal/scan"
 	"github.com/thestormforge/optimize-controller/v2/internal/sfio"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -79,13 +79,13 @@ func (g *Generator) Map(node *yaml.RNode, meta yaml.ResourceMeta) ([]interface{}
 
 	// If the resource stream already contains an application, we will use that
 	// as a starting point for the rest of the generation.
-	if meta.Kind == "Application" && meta.APIVersion == redskyappsv1alpha1.GroupVersion.String() {
+	if meta.Kind == "Application" && meta.APIVersion == optimizeappsv1alpha1.GroupVersion.String() {
 		data, err := node.MarshalJSON()
 		if err != nil {
 			return nil, err
 		}
 
-		app := &redskyappsv1alpha1.Application{}
+		app := &optimizeappsv1alpha1.Application{}
 		if err := json.Unmarshal(data, app); err != nil {
 			return nil, err
 		}
@@ -100,11 +100,11 @@ func (g *Generator) Map(node *yaml.RNode, meta yaml.ResourceMeta) ([]interface{}
 func (g *Generator) Transform(_ []*yaml.RNode, selected []interface{}) ([]*yaml.RNode, error) {
 	result := sfio.ObjectSlice{}
 
-	app := &redskyappsv1alpha1.Application{}
+	app := &optimizeappsv1alpha1.Application{}
 	for _, sel := range selected {
 		switch s := sel.(type) {
 
-		case *redskyappsv1alpha1.Application:
+		case *optimizeappsv1alpha1.Application:
 			g.merge(s, app)
 
 		}
@@ -123,7 +123,7 @@ func (g *Generator) Transform(_ []*yaml.RNode, selected []interface{}) ([]*yaml.
 }
 
 // merge a source application into another application.
-func (g *Generator) merge(src, dst *redskyappsv1alpha1.Application) {
+func (g *Generator) merge(src, dst *optimizeappsv1alpha1.Application) {
 	if src.Name != "" {
 		dst.Name = src.Name
 	}
@@ -154,9 +154,9 @@ func (g *Generator) merge(src, dst *redskyappsv1alpha1.Application) {
 }
 
 // apply adds the generator configuration to the supplied application
-func (g *Generator) apply(app *redskyappsv1alpha1.Application) error {
+func (g *Generator) apply(app *optimizeappsv1alpha1.Application) error {
 	now := time.Now().UTC().Format(time.RFC3339)
-	metav1.SetMetaDataAnnotation(&app.ObjectMeta, redskyappsv1alpha1.AnnotationLastScanned, now)
+	metav1.SetMetaDataAnnotation(&app.ObjectMeta, optimizeappsv1alpha1.AnnotationLastScanned, now)
 
 	if g.Name != "" {
 		app.Name = g.Name
@@ -180,7 +180,7 @@ func (g *Generator) apply(app *redskyappsv1alpha1.Application) error {
 }
 
 // clean ensures that the application state is reasonable.
-func (g *Generator) clean(app *redskyappsv1alpha1.Application) error {
+func (g *Generator) clean(app *optimizeappsv1alpha1.Application) error {
 	var resources []konjure.Resource
 	for _, r := range app.Resources {
 		switch {
@@ -210,7 +210,7 @@ func (g *Generator) clean(app *redskyappsv1alpha1.Application) error {
 }
 
 // readScenario attempts to create a scenario for the application.
-func (g *Generator) readScenario() (*redskyappsv1alpha1.Scenario, error) {
+func (g *Generator) readScenario() (*optimizeappsv1alpha1.Scenario, error) {
 	// If there is no scenario file, do nothing
 	if g.ScenarioFile == "" {
 		return nil, nil
@@ -219,15 +219,15 @@ func (g *Generator) readScenario() (*redskyappsv1alpha1.Scenario, error) {
 	// This is a really basic assumption given we only support two scenario flavors right now
 	switch filepath.Ext(g.ScenarioFile) {
 	case ".js":
-		return &redskyappsv1alpha1.Scenario{
-			StormForger: &redskyappsv1alpha1.StormForgerScenario{
+		return &optimizeappsv1alpha1.Scenario{
+			StormForger: &optimizeappsv1alpha1.StormForgerScenario{
 				TestCaseFile: g.ScenarioFile,
 			},
 		}, nil
 
 	case ".py":
-		return &redskyappsv1alpha1.Scenario{
-			Locust: &redskyappsv1alpha1.LocustScenario{
+		return &optimizeappsv1alpha1.Scenario{
+			Locust: &optimizeappsv1alpha1.LocustScenario{
 				Locustfile: g.ScenarioFile,
 			},
 		}, nil
@@ -237,15 +237,15 @@ func (g *Generator) readScenario() (*redskyappsv1alpha1.Scenario, error) {
 }
 
 // readObjective attempts to create an objective for the application.
-func (g *Generator) readObjective() (*redskyappsv1alpha1.Objective, error) {
+func (g *Generator) readObjective() (*optimizeappsv1alpha1.Objective, error) {
 	if len(g.Goals) == 0 {
 		return nil, nil
 	}
 
-	obj := &redskyappsv1alpha1.Objective{}
+	obj := &optimizeappsv1alpha1.Objective{}
 	for _, goal := range g.Goals {
 		if goal != "" {
-			obj.Goals = append(obj.Goals, redskyappsv1alpha1.Goal{Name: goal})
+			obj.Goals = append(obj.Goals, optimizeappsv1alpha1.Goal{Name: goal})
 		}
 	}
 

--- a/internal/controller/errors.go
+++ b/internal/controller/errors.go
@@ -17,7 +17,7 @@ limitations under the License.
 package controller
 
 import (
-	redskyapi "github.com/thestormforge/optimize-go/pkg/api/experiments/v1alpha1"
+	experimentsv1alpha1 "github.com/thestormforge/optimize-go/pkg/api/experiments/v1alpha1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 )
 
@@ -26,8 +26,8 @@ func IgnoreNotFound(err error) error {
 	if apierrs.IsNotFound(err) {
 		return nil
 	}
-	if rserr, ok := err.(*redskyapi.Error); ok {
-		if rserr.Type == redskyapi.ErrExperimentNotFound || rserr.Type == redskyapi.ErrTrialNotFound {
+	if rserr, ok := err.(*experimentsv1alpha1.Error); ok {
+		if rserr.Type == experimentsv1alpha1.ErrExperimentNotFound || rserr.Type == experimentsv1alpha1.ErrTrialNotFound {
 			return nil
 		}
 	}
@@ -47,8 +47,8 @@ func IgnoreReportError(err error) error {
 	if IgnoreNotFound(err) == nil {
 		return nil
 	}
-	if rserr, ok := err.(*redskyapi.Error); ok {
-		if rserr.Type == redskyapi.ErrTrialAlreadyReported {
+	if rserr, ok := err.(*experimentsv1alpha1.Error); ok {
+		if rserr.Type == experimentsv1alpha1.ErrTrialAlreadyReported {
 			return nil
 		}
 	}

--- a/internal/controller/errors_test.go
+++ b/internal/controller/errors_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	redskyapi "github.com/thestormforge/optimize-go/pkg/api/experiments/v1alpha1"
+	experimentsv1alpha1 "github.com/thestormforge/optimize-go/pkg/api/experiments/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -48,15 +48,15 @@ func TestIgnoreNotFound(t *testing.T) {
 		},
 		{
 			desc: "api error experiment not found",
-			in: &redskyapi.Error{
-				Type: redskyapi.ErrExperimentNotFound,
+			in: &experimentsv1alpha1.Error{
+				Type: experimentsv1alpha1.ErrExperimentNotFound,
 			},
 			expectedErr: nil,
 		},
 		{
 			desc: "api error trial not found",
-			in: &redskyapi.Error{
-				Type: redskyapi.ErrTrialNotFound,
+			in: &experimentsv1alpha1.Error{
+				Type: experimentsv1alpha1.ErrTrialNotFound,
 			},
 			expectedErr: nil,
 		},
@@ -130,8 +130,8 @@ func TestIgnoreReportError(t *testing.T) {
 		},
 		{
 			desc: "redskyapi error trial already reported",
-			in: &redskyapi.Error{
-				Type: redskyapi.ErrTrialAlreadyReported,
+			in: &experimentsv1alpha1.Error{
+				Type: experimentsv1alpha1.ErrTrialAlreadyReported,
 			},
 			expectedErr: nil,
 		},

--- a/internal/controller/result.go
+++ b/internal/controller/result.go
@@ -21,7 +21,7 @@ import (
 	"runtime"
 	"strings"
 
-	redskyapi "github.com/thestormforge/optimize-go/pkg/api/experiments/v1alpha1"
+	experimentsv1alpha1 "github.com/thestormforge/optimize-go/pkg/api/experiments/v1alpha1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
@@ -33,7 +33,7 @@ import (
 // RequeueIfUnavailable will return a new result and the supplied error, adjusted for trial unavailable errors
 func RequeueIfUnavailable(err error) (*ctrl.Result, error) {
 	result := &ctrl.Result{}
-	if rse, ok := err.(*redskyapi.Error); ok && rse.Type == redskyapi.ErrTrialUnavailable {
+	if rse, ok := err.(*experimentsv1alpha1.Error); ok && rse.Type == experimentsv1alpha1.ErrTrialUnavailable {
 		result.RequeueAfter = rse.RetryAfter
 		err = nil
 	}

--- a/internal/controller/result_test.go
+++ b/internal/controller/result_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	redskyapi "github.com/thestormforge/optimize-go/pkg/api/experiments/v1alpha1"
+	experimentsv1alpha1 "github.com/thestormforge/optimize-go/pkg/api/experiments/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -145,8 +145,8 @@ func TestRequeueIfUnavailable(t *testing.T) {
 		},
 		{
 			desc: "trial unavailable",
-			err: &redskyapi.Error{
-				Type:       redskyapi.ErrTrialUnavailable,
+			err: &experimentsv1alpha1.Error{
+				Type:       experimentsv1alpha1.ErrTrialUnavailable,
 				RetryAfter: 111,
 			},
 			result: &ctrl.Result{

--- a/internal/experiment/experiment.go
+++ b/internal/experiment/experiment.go
@@ -17,7 +17,7 @@ limitations under the License.
 package experiment
 
 import (
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	"github.com/thestormforge/optimize-controller/v2/internal/controller"
 	"github.com/thestormforge/optimize-controller/v2/internal/trial"
 	corev1 "k8s.io/api/core/v1"
@@ -51,7 +51,7 @@ const (
 
 // UpdateStatus will ensure the experiment's status matches what is in the supplied trial list; returns true only if
 // changes were necessary
-func UpdateStatus(exp *redskyv1beta1.Experiment, trialList *redskyv1beta1.TrialList) bool {
+func UpdateStatus(exp *optimizev1beta1.Experiment, trialList *optimizev1beta1.TrialList) bool {
 	// Count the active trials
 	activeTrials := int32(0)
 	for i := range trialList.Items {
@@ -84,18 +84,18 @@ func UpdateStatus(exp *redskyv1beta1.Experiment, trialList *redskyv1beta1.TrialL
 	return false
 }
 
-func summarize(exp *redskyv1beta1.Experiment, activeTrials int32, totalTrials int) string {
+func summarize(exp *optimizev1beta1.Experiment, activeTrials int32, totalTrials int) string {
 	if !exp.GetDeletionTimestamp().IsZero() {
 		return PhaseDeleted
 	}
 
 	for _, c := range exp.Status.Conditions {
 		switch c.Type {
-		case redskyv1beta1.ExperimentComplete:
+		case optimizev1beta1.ExperimentComplete:
 			if c.Status == corev1.ConditionTrue {
 				return PhaseCompleted
 			}
-		case redskyv1beta1.ExperimentFailed:
+		case optimizev1beta1.ExperimentFailed:
 			if c.Status == corev1.ConditionTrue {
 				return PhaseFailed
 			}
@@ -111,7 +111,7 @@ func summarize(exp *redskyv1beta1.Experiment, activeTrials int32, totalTrials in
 	}
 
 	if totalTrials == 0 {
-		if exp.Annotations[redskyv1beta1.AnnotationExperimentURL] != "" {
+		if exp.Annotations[optimizev1beta1.AnnotationExperimentURL] != "" {
 			return PhaseCreated
 		}
 		return PhaseEmpty
@@ -120,10 +120,10 @@ func summarize(exp *redskyv1beta1.Experiment, activeTrials int32, totalTrials in
 	return PhaseIdle
 }
 
-func IsFinished(exp *redskyv1beta1.Experiment) bool {
+func IsFinished(exp *optimizev1beta1.Experiment) bool {
 	for _, c := range exp.Status.Conditions {
 		if c.Status == corev1.ConditionTrue {
-			if c.Type == redskyv1beta1.ExperimentComplete || c.Type == redskyv1beta1.ExperimentFailed {
+			if c.Type == optimizev1beta1.ExperimentComplete || c.Type == optimizev1beta1.ExperimentFailed {
 				return true
 			}
 		}
@@ -131,13 +131,13 @@ func IsFinished(exp *redskyv1beta1.Experiment) bool {
 	return false
 }
 
-func ApplyCondition(status *redskyv1beta1.ExperimentStatus, conditionType redskyv1beta1.ExperimentConditionType, conditionStatus corev1.ConditionStatus, reason, message string, time *metav1.Time) {
+func ApplyCondition(status *optimizev1beta1.ExperimentStatus, conditionType optimizev1beta1.ExperimentConditionType, conditionStatus corev1.ConditionStatus, reason, message string, time *metav1.Time) {
 	if time == nil {
 		now := metav1.Now()
 		time = &now
 	}
 
-	newCondition := redskyv1beta1.ExperimentCondition{
+	newCondition := optimizev1beta1.ExperimentCondition{
 		Type:               conditionType,
 		Status:             conditionStatus,
 		Reason:             reason,

--- a/internal/experiment/experiment_test.go
+++ b/internal/experiment/experiment_test.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	redsky "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -39,22 +39,22 @@ func TestSummarize(t *testing.T) {
 
 	testCases := []struct {
 		desc          string
-		experiment    *redsky.Experiment
+		experiment    *optimizev1beta1.Experiment
 		expectedPhase string
 		activeTrials  int32
 		totalTrials   int
 	}{
 		{
 			desc:          "empty",
-			experiment:    &redsky.Experiment{},
+			experiment:    &optimizev1beta1.Experiment{},
 			expectedPhase: PhaseEmpty,
 		},
 		{
 			desc: "created",
-			experiment: &redsky.Experiment{
+			experiment: &optimizev1beta1.Experiment{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						redsky.AnnotationExperimentURL: experimentURL,
+						optimizev1beta1.AnnotationExperimentURL: experimentURL,
 					},
 				},
 			},
@@ -62,7 +62,7 @@ func TestSummarize(t *testing.T) {
 		},
 		{
 			desc: "deleted",
-			experiment: &redsky.Experiment{
+			experiment: &optimizev1beta1.Experiment{
 				ObjectMeta: metav1.ObjectMeta{
 					DeletionTimestamp: &now,
 				},
@@ -71,7 +71,7 @@ func TestSummarize(t *testing.T) {
 		},
 		{
 			desc: "deleted ignore active trials",
-			experiment: &redsky.Experiment{
+			experiment: &optimizev1beta1.Experiment{
 				ObjectMeta: metav1.ObjectMeta{
 					DeletionTimestamp: &now,
 				},
@@ -81,11 +81,11 @@ func TestSummarize(t *testing.T) {
 		},
 		{
 			desc: "deleted ignore replicas",
-			experiment: &redsky.Experiment{
+			experiment: &optimizev1beta1.Experiment{
 				ObjectMeta: metav1.ObjectMeta{
 					DeletionTimestamp: &now,
 				},
-				Spec: redsky.ExperimentSpec{
+				Spec: optimizev1beta1.ExperimentSpec{
 					Replicas: &oneReplica,
 				},
 			},
@@ -93,8 +93,8 @@ func TestSummarize(t *testing.T) {
 		},
 		{
 			desc: "paused no active trials",
-			experiment: &redsky.Experiment{
-				Spec: redsky.ExperimentSpec{
+			experiment: &optimizev1beta1.Experiment{
+				Spec: optimizev1beta1.ExperimentSpec{
 					Replicas: &zeroReplicas,
 				},
 			},
@@ -102,8 +102,8 @@ func TestSummarize(t *testing.T) {
 		},
 		{
 			desc: "paused active trials",
-			experiment: &redsky.Experiment{
-				Spec: redsky.ExperimentSpec{
+			experiment: &optimizev1beta1.Experiment{
+				Spec: optimizev1beta1.ExperimentSpec{
 					Replicas: &oneReplica,
 				},
 			},
@@ -112,19 +112,19 @@ func TestSummarize(t *testing.T) {
 		},
 		{
 			desc: "paused budget done",
-			experiment: &redsky.Experiment{
+			experiment: &optimizev1beta1.Experiment{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						redsky.AnnotationExperimentURL: experimentURL,
+						optimizev1beta1.AnnotationExperimentURL: experimentURL,
 					},
 				},
-				Spec: redsky.ExperimentSpec{
+				Spec: optimizev1beta1.ExperimentSpec{
 					Replicas: &zeroReplicas,
 				},
-				Status: redsky.ExperimentStatus{
-					Conditions: []redsky.ExperimentCondition{
+				Status: optimizev1beta1.ExperimentStatus{
+					Conditions: []optimizev1beta1.ExperimentCondition{
 						{
-							Type:   redsky.ExperimentComplete,
+							Type:   optimizev1beta1.ExperimentComplete,
 							Status: corev1.ConditionTrue,
 						},
 					},
@@ -134,14 +134,14 @@ func TestSummarize(t *testing.T) {
 		},
 		{
 			desc: "paused budget",
-			experiment: &redsky.Experiment{
+			experiment: &optimizev1beta1.Experiment{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						redsky.AnnotationExperimentURL: experimentURL,
-						redsky.AnnotationNextTrialURL:  nextExperimentURL,
+						optimizev1beta1.AnnotationExperimentURL: experimentURL,
+						optimizev1beta1.AnnotationNextTrialURL:  nextExperimentURL,
 					},
 				},
-				Spec: redsky.ExperimentSpec{
+				Spec: optimizev1beta1.ExperimentSpec{
 					Replicas: &zeroReplicas,
 				},
 			},
@@ -149,16 +149,16 @@ func TestSummarize(t *testing.T) {
 		},
 		{
 			desc:          "idle not synced",
-			experiment:    &redsky.Experiment{},
+			experiment:    &optimizev1beta1.Experiment{},
 			expectedPhase: PhaseIdle,
 			totalTrials:   1,
 		},
 		{
 			desc: "idle synced",
-			experiment: &redsky.Experiment{
+			experiment: &optimizev1beta1.Experiment{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						redsky.AnnotationExperimentURL: experimentURL,
+						optimizev1beta1.AnnotationExperimentURL: experimentURL,
 					},
 				},
 			},
@@ -167,11 +167,11 @@ func TestSummarize(t *testing.T) {
 		},
 		{
 			desc: "failed",
-			experiment: &redsky.Experiment{
-				Status: redsky.ExperimentStatus{
-					Conditions: []redsky.ExperimentCondition{
+			experiment: &optimizev1beta1.Experiment{
+				Status: optimizev1beta1.ExperimentStatus{
+					Conditions: []optimizev1beta1.ExperimentCondition{
 						{
-							Type:   redsky.ExperimentFailed,
+							Type:   optimizev1beta1.ExperimentFailed,
 							Status: corev1.ConditionTrue,
 						},
 					},
@@ -195,24 +195,24 @@ func TestApplyCondition(t *testing.T) {
 
 	cases := []struct {
 		desc               string
-		conditionType      redsky.ExperimentConditionType
+		conditionType      optimizev1beta1.ExperimentConditionType
 		conditionStatus    corev1.ConditionStatus
 		reason             string
 		message            string
 		time               *metav1.Time
-		initialConditions  []redsky.ExperimentCondition
-		expectedConditions []redsky.ExperimentCondition
+		initialConditions  []optimizev1beta1.ExperimentCondition
+		expectedConditions []optimizev1beta1.ExperimentCondition
 	}{
 		{
 			desc:            "add to empty",
-			conditionType:   redsky.ExperimentFailed,
+			conditionType:   optimizev1beta1.ExperimentFailed,
 			conditionStatus: corev1.ConditionTrue,
 			reason:          "Testing",
 			message:         "Test Test",
 			time:            &now,
-			expectedConditions: []redsky.ExperimentCondition{
+			expectedConditions: []optimizev1beta1.ExperimentCondition{
 				{
-					Type:               redsky.ExperimentFailed,
+					Type:               optimizev1beta1.ExperimentFailed,
 					Status:             corev1.ConditionTrue,
 					LastProbeTime:      now,
 					LastTransitionTime: now,
@@ -223,14 +223,14 @@ func TestApplyCondition(t *testing.T) {
 		},
 		{
 			desc:            "update status",
-			conditionType:   redsky.ExperimentFailed,
+			conditionType:   optimizev1beta1.ExperimentFailed,
 			conditionStatus: corev1.ConditionTrue,
 			reason:          "Testing",
 			message:         "Test Test",
 			time:            &now,
-			initialConditions: []redsky.ExperimentCondition{
+			initialConditions: []optimizev1beta1.ExperimentCondition{
 				{
-					Type:               redsky.ExperimentFailed,
+					Type:               optimizev1beta1.ExperimentFailed,
 					Status:             corev1.ConditionFalse,
 					LastProbeTime:      then,
 					LastTransitionTime: then,
@@ -238,9 +238,9 @@ func TestApplyCondition(t *testing.T) {
 					Message:            "Bar",
 				},
 			},
-			expectedConditions: []redsky.ExperimentCondition{
+			expectedConditions: []optimizev1beta1.ExperimentCondition{
 				{
-					Type:               redsky.ExperimentFailed,
+					Type:               optimizev1beta1.ExperimentFailed,
 					Status:             corev1.ConditionTrue,
 					LastProbeTime:      now,
 					LastTransitionTime: now,
@@ -251,14 +251,14 @@ func TestApplyCondition(t *testing.T) {
 		},
 		{
 			desc:            "update no change",
-			conditionType:   redsky.ExperimentFailed,
+			conditionType:   optimizev1beta1.ExperimentFailed,
 			conditionStatus: corev1.ConditionTrue,
 			reason:          "Testing",
 			message:         "Test Test",
 			time:            &now,
-			initialConditions: []redsky.ExperimentCondition{
+			initialConditions: []optimizev1beta1.ExperimentCondition{
 				{
-					Type:               redsky.ExperimentFailed,
+					Type:               optimizev1beta1.ExperimentFailed,
 					Status:             corev1.ConditionTrue,
 					LastProbeTime:      then,
 					LastTransitionTime: then,
@@ -266,9 +266,9 @@ func TestApplyCondition(t *testing.T) {
 					Message:            "Bar",
 				},
 			},
-			expectedConditions: []redsky.ExperimentCondition{
+			expectedConditions: []optimizev1beta1.ExperimentCondition{
 				{
-					Type:               redsky.ExperimentFailed,
+					Type:               optimizev1beta1.ExperimentFailed,
 					Status:             corev1.ConditionTrue,
 					LastProbeTime:      now,
 					LastTransitionTime: then,
@@ -281,7 +281,7 @@ func TestApplyCondition(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.desc, func(t *testing.T) {
-			actual := redsky.ExperimentStatus{Conditions: c.initialConditions}
+			actual := optimizev1beta1.ExperimentStatus{Conditions: c.initialConditions}
 			ApplyCondition(&actual, c.conditionType, c.conditionStatus, c.reason, c.message, c.time)
 			assert.Equal(t, c.expectedConditions, actual.Conditions)
 		})

--- a/internal/experiment/generation/application.go
+++ b/internal/experiment/generation/application.go
@@ -17,16 +17,16 @@ limitations under the License.
 package generation
 
 import (
-	redskyappsv1alpha1 "github.com/thestormforge/optimize-controller/v2/api/apps/v1alpha1"
+	optimizeappsv1alpha1 "github.com/thestormforge/optimize-controller/v2/api/apps/v1alpha1"
 	"github.com/thestormforge/optimize-controller/v2/internal/scan"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
 // ApplicationSelector is responsible for "scanning" the application definition itself.
 type ApplicationSelector struct {
-	Application *redskyappsv1alpha1.Application
-	Scenario    *redskyappsv1alpha1.Scenario
-	Objective   *redskyappsv1alpha1.Objective
+	Application *optimizeappsv1alpha1.Application
+	Scenario    *optimizeappsv1alpha1.Scenario
+	Objective   *optimizeappsv1alpha1.Objective
 }
 
 var _ scan.Selector = &ApplicationSelector{}

--- a/internal/experiment/generation/containerresources.go
+++ b/internal/experiment/generation/containerresources.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 
 	"github.com/thestormforge/konjure/pkg/filters"
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	"github.com/thestormforge/optimize-controller/v2/internal/scan"
 	"github.com/thestormforge/optimize-controller/v2/internal/sfio"
 	corev1 "k8s.io/api/core/v1"
@@ -200,15 +200,15 @@ func (p *containerResourcesParameter) Patch(name ParameterNamer) (yaml.Filter, e
 }
 
 // Parameters lists the parameters used by the patch.
-func (p *containerResourcesParameter) Parameters(name ParameterNamer) ([]redskyv1beta1.Parameter, error) {
+func (p *containerResourcesParameter) Parameters(name ParameterNamer) ([]optimizev1beta1.Parameter, error) {
 	ind, err := p.indexContainerResources()
 	if err != nil {
 		return nil, err
 	}
 
-	var result []redskyv1beta1.Parameter
+	var result []optimizev1beta1.Parameter
 	for _, rn := range p.resources {
-		result = append(result, redskyv1beta1.Parameter{
+		result = append(result, optimizev1beta1.Parameter{
 			Name:     name(p.meta, p.fieldPath, string(rn)),
 			Max:      ind[rn].Max(),
 			Min:      ind[rn].Min(),

--- a/internal/experiment/generation/containerresources_test.go
+++ b/internal/experiment/generation/containerresources_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -35,7 +35,7 @@ func TestContainerResourcesParameter(t *testing.T) {
 	cases := []struct {
 		desc string
 		containerResourcesParameter
-		expectedParameters []redskyv1beta1.Parameter
+		expectedParameters []optimizev1beta1.Parameter
 		expectedPatch      string
 	}{
 		{
@@ -53,7 +53,7 @@ func TestContainerResourcesParameter(t *testing.T) {
 				resources: []corev1.ResourceName{corev1.ResourceMemory},
 			},
 
-			expectedParameters: []redskyv1beta1.Parameter{
+			expectedParameters: []optimizev1beta1.Parameter{
 				{
 					Name:     "memory",
 					Baseline: newInt(2048),
@@ -85,7 +85,7 @@ func TestContainerResourcesParameter(t *testing.T) {
 				resources: []corev1.ResourceName{corev1.ResourceMemory},
 			},
 
-			expectedParameters: []redskyv1beta1.Parameter{
+			expectedParameters: []optimizev1beta1.Parameter{
 				{
 					Name:     "memory",
 					Baseline: newInt(2000),
@@ -117,7 +117,7 @@ func TestContainerResourcesParameter(t *testing.T) {
 				resources: []corev1.ResourceName{corev1.ResourceCPU},
 			},
 
-			expectedParameters: []redskyv1beta1.Parameter{
+			expectedParameters: []optimizev1beta1.Parameter{
 				{
 					Name:     "cpu",
 					Baseline: newInt(2000),
@@ -149,7 +149,7 @@ func TestContainerResourcesParameter(t *testing.T) {
 				resources: []corev1.ResourceName{corev1.ResourceMemory},
 			},
 
-			expectedParameters: []redskyv1beta1.Parameter{
+			expectedParameters: []optimizev1beta1.Parameter{
 				{
 					Name:     "memory",
 					Baseline: newInt(256),

--- a/internal/experiment/generation/custom.go
+++ b/internal/experiment/generation/custom.go
@@ -23,22 +23,22 @@ import (
 	"strings"
 	"time"
 
-	redskyappsv1alpha1 "github.com/thestormforge/optimize-controller/v2/api/apps/v1alpha1"
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizeappsv1alpha1 "github.com/thestormforge/optimize-controller/v2/api/apps/v1alpha1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type CustomSource struct {
-	Scenario    *redskyappsv1alpha1.Scenario
-	Objective   *redskyappsv1alpha1.Objective
-	Application *redskyappsv1alpha1.Application
+	Scenario    *optimizeappsv1alpha1.Scenario
+	Objective   *optimizeappsv1alpha1.Objective
+	Application *optimizeappsv1alpha1.Application
 }
 
 var _ ExperimentSource = &CustomSource{}
 var _ MetricSource = &CustomSource{}
 
-func (s *CustomSource) Update(exp *redskyv1beta1.Experiment) error {
+func (s *CustomSource) Update(exp *optimizev1beta1.Experiment) error {
 	if s.Scenario == nil || s.Application == nil {
 		return nil
 	}
@@ -81,8 +81,8 @@ func (s *CustomSource) Update(exp *redskyv1beta1.Experiment) error {
 	return nil
 }
 
-func (s *CustomSource) Metrics() ([]redskyv1beta1.Metric, error) {
-	var result []redskyv1beta1.Metric
+func (s *CustomSource) Metrics() ([]optimizev1beta1.Metric, error) {
+	var result []optimizev1beta1.Metric
 	if s.Objective == nil {
 		return result, nil
 	}
@@ -117,7 +117,7 @@ func (s *CustomSource) Metrics() ([]redskyv1beta1.Metric, error) {
 
 			m := newGoalMetric(goal, query)
 			m.Type = ""
-			m.Target = &redskyv1beta1.ResourceTarget{
+			m.Target = &optimizev1beta1.ResourceTarget{
 				APIVersion:    "v1",
 				Kind:          "PodList",
 				LabelSelector: labelSelector,

--- a/internal/experiment/generation/datadog.go
+++ b/internal/experiment/generation/datadog.go
@@ -19,24 +19,24 @@ package generation
 import (
 	"net/url"
 
-	redskyappsv1alpha1 "github.com/thestormforge/optimize-controller/v2/api/apps/v1alpha1"
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizeappsv1alpha1 "github.com/thestormforge/optimize-controller/v2/api/apps/v1alpha1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 )
 
 type DatadogMetricsSource struct {
-	Goal *redskyappsv1alpha1.Goal
+	Goal *optimizeappsv1alpha1.Goal
 }
 
 var _ MetricSource = &DatadogMetricsSource{}
 
-func (s *DatadogMetricsSource) Metrics() ([]redskyv1beta1.Metric, error) {
-	var result []redskyv1beta1.Metric
+func (s *DatadogMetricsSource) Metrics() ([]optimizev1beta1.Metric, error) {
+	var result []optimizev1beta1.Metric
 	if s.Goal == nil || s.Goal.Implemented {
 		return result, nil
 	}
 
 	m := newGoalMetric(s.Goal, s.Goal.Datadog.Query)
-	m.Type = redskyv1beta1.MetricDatadog
+	m.Type = optimizev1beta1.MetricDatadog
 	m.Minimize = !s.Goal.Datadog.Maximize
 	if s.Goal.Datadog.Aggregator != "" {
 		m.URL = "?" + url.Values{"aggregator": []string{s.Goal.Datadog.Aggregator}}.Encode()

--- a/internal/experiment/generation/duration.go
+++ b/internal/experiment/generation/duration.go
@@ -17,24 +17,24 @@ limitations under the License.
 package generation
 
 import (
-	redskyappsv1alpha1 "github.com/thestormforge/optimize-controller/v2/api/apps/v1alpha1"
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizeappsv1alpha1 "github.com/thestormforge/optimize-controller/v2/api/apps/v1alpha1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 )
 
 type DurationMetricsSource struct {
-	Goal *redskyappsv1alpha1.Goal
+	Goal *optimizeappsv1alpha1.Goal
 }
 
 var _ MetricSource = &DurationMetricsSource{}
 
-func (s *DurationMetricsSource) Metrics() ([]redskyv1beta1.Metric, error) {
-	var result []redskyv1beta1.Metric
+func (s *DurationMetricsSource) Metrics() ([]optimizev1beta1.Metric, error) {
+	var result []optimizev1beta1.Metric
 	if s.Goal == nil || s.Goal.Implemented {
 		return result, nil
 	}
 
 	switch s.Goal.Duration.DurationType {
-	case redskyappsv1alpha1.DurationTrial:
+	case optimizeappsv1alpha1.DurationTrial:
 		m := newGoalMetric(s.Goal, `{{ duration .StartTime .CompletionTime }}`)
 		m.Type = ""
 		result = append(result, m)

--- a/internal/experiment/generation/environmentvariables.go
+++ b/internal/experiment/generation/environmentvariables.go
@@ -22,7 +22,7 @@ import (
 	"strconv"
 	"strings"
 
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	"github.com/thestormforge/optimize-controller/v2/internal/scan"
 	"github.com/thestormforge/optimize-controller/v2/internal/sfio"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -109,8 +109,8 @@ func (p *environmentVariablesParameter) Patch(name ParameterNamer) (yaml.Filter,
 	), nil
 }
 
-func (p *environmentVariablesParameter) Parameters(name ParameterNamer) ([]redskyv1beta1.Parameter, error) {
-	param := redskyv1beta1.Parameter{
+func (p *environmentVariablesParameter) Parameters(name ParameterNamer) ([]optimizev1beta1.Parameter, error) {
+	param := optimizev1beta1.Parameter{
 		Name:     name(p.meta, p.fieldPath, ""),
 		Baseline: new(intstr.IntOrString),
 	}
@@ -132,7 +132,7 @@ func (p *environmentVariablesParameter) Parameters(name ParameterNamer) ([]redsk
 		param.Max = 4000
 	}
 
-	return []redskyv1beta1.Parameter{param}, nil
+	return []optimizev1beta1.Parameter{param}, nil
 }
 
 func appendMissing(slice []string, elem string) []string {

--- a/internal/experiment/generation/filter.go
+++ b/internal/experiment/generation/filter.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 
 	"github.com/thestormforge/konjure/pkg/filters"
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"sigs.k8s.io/kustomize/kyaml/openapi"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
@@ -88,8 +88,8 @@ func SetExperimentName(name string) yaml.Filter {
 
 func isExperiment() yaml.Filter {
 	return filters.FilterOne(&filters.ResourceMetaFilter{
-		Group:   redskyv1beta1.GroupVersion.Group,
-		Version: redskyv1beta1.GroupVersion.Version,
+		Group:   optimizev1beta1.GroupVersion.Group,
+		Version: optimizev1beta1.GroupVersion.Version,
 		Kind:    "Experiment",
 	})
 }

--- a/internal/experiment/generation/generation.go
+++ b/internal/experiment/generation/generation.go
@@ -23,8 +23,8 @@ import (
 	"os"
 	"path/filepath"
 
-	redskyappsv1alpha1 "github.com/thestormforge/optimize-controller/v2/api/apps/v1alpha1"
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizeappsv1alpha1 "github.com/thestormforge/optimize-controller/v2/api/apps/v1alpha1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	"github.com/thestormforge/optimize-controller/v2/internal/application"
 	"github.com/yujunz/go-getter"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
@@ -32,10 +32,10 @@ import (
 )
 
 // newGoalMetric creates a new metric for the supplied goal with most fields pre-filled.
-func newGoalMetric(obj *redskyappsv1alpha1.Goal, query string) redskyv1beta1.Metric {
+func newGoalMetric(obj *optimizeappsv1alpha1.Goal, query string) optimizev1beta1.Metric {
 	defer func() { obj.Implemented = true }()
-	return redskyv1beta1.Metric{
-		Type:     redskyv1beta1.MetricPrometheus,
+	return optimizev1beta1.Metric{
+		Type:     optimizev1beta1.MetricPrometheus,
 		Query:    query,
 		Minimize: true,
 		Name:     obj.Name,
@@ -46,7 +46,7 @@ func newGoalMetric(obj *redskyappsv1alpha1.Goal, query string) redskyv1beta1.Met
 }
 
 // ensureTrialJobPod returns the pod template for the trial job, creating the job template if necessary.
-func ensureTrialJobPod(exp *redskyv1beta1.Experiment) *corev1.PodTemplateSpec {
+func ensureTrialJobPod(exp *optimizev1beta1.Experiment) *corev1.PodTemplateSpec {
 	if exp.Spec.TrialTemplate.Spec.JobTemplate == nil {
 		exp.Spec.TrialTemplate.Spec.JobTemplate = &batchv1beta1.JobTemplateSpec{}
 	}
@@ -72,7 +72,7 @@ func trialJobImage(job string) string {
 }
 
 // loadApplicationData loads data (e.g. a supporting test file).
-func loadApplicationData(app *redskyappsv1alpha1.Application, src string) ([]byte, error) {
+func loadApplicationData(app *optimizeappsv1alpha1.Application, src string) ([]byte, error) {
 	dst := filepath.Join(os.TempDir(), fmt.Sprintf("load-application-data-%x", md5.Sum([]byte(src))))
 	defer os.Remove(dst)
 

--- a/internal/experiment/generation/locust.go
+++ b/internal/experiment/generation/locust.go
@@ -19,8 +19,8 @@ package generation
 import (
 	"fmt"
 
-	redskyappsv1alpha1 "github.com/thestormforge/optimize-controller/v2/api/apps/v1alpha1"
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizeappsv1alpha1 "github.com/thestormforge/optimize-controller/v2/api/apps/v1alpha1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	"github.com/thestormforge/optimize-controller/v2/internal/sfio"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/kustomize/kyaml/kio"
@@ -28,16 +28,16 @@ import (
 )
 
 type LocustSource struct {
-	Scenario    *redskyappsv1alpha1.Scenario
-	Objective   *redskyappsv1alpha1.Objective
-	Application *redskyappsv1alpha1.Application
+	Scenario    *optimizeappsv1alpha1.Scenario
+	Objective   *optimizeappsv1alpha1.Objective
+	Application *optimizeappsv1alpha1.Application
 }
 
 var _ ExperimentSource = &LocustSource{} // Update trial job
 var _ MetricSource = &LocustSource{}     // Locust specific metrics
 var _ kio.Reader = &LocustSource{}       // ConfigMap for the locustfile.py
 
-func (s *LocustSource) Update(exp *redskyv1beta1.Experiment) error {
+func (s *LocustSource) Update(exp *optimizev1beta1.Experiment) error {
 	if s.Scenario == nil || s.Application == nil {
 		return nil
 	}
@@ -104,8 +104,8 @@ func (s *LocustSource) Read() ([]*yaml.RNode, error) {
 	return result.Read()
 }
 
-func (s *LocustSource) Metrics() ([]redskyv1beta1.Metric, error) {
-	var result []redskyv1beta1.Metric
+func (s *LocustSource) Metrics() ([]optimizev1beta1.Metric, error) {
+	var result []optimizev1beta1.Metric
 	if s.Objective == nil {
 		return result, nil
 	}
@@ -124,7 +124,7 @@ func (s *LocustSource) Metrics() ([]redskyv1beta1.Metric, error) {
 			}
 
 		case goal.ErrorRate != nil:
-			if goal.ErrorRate.ErrorRateType == redskyappsv1alpha1.ErrorRateRequests {
+			if goal.ErrorRate.ErrorRateType == optimizeappsv1alpha1.ErrorRateRequests {
 				query := `scalar(failure_count{job="trialRun",instance="{{ .Trial.Name }}"} / request_count{job="trialRun",instance="{{ .Trial.Name }}"})`
 				result = append(result, newGoalMetric(goal, query))
 			}
@@ -168,19 +168,19 @@ func (s *LocustSource) locustEnv() []corev1.EnvVar {
 	return env
 }
 
-func (s *LocustSource) locustLatency(lt redskyappsv1alpha1.LatencyType) string {
-	switch redskyappsv1alpha1.FixLatency(lt) {
-	case redskyappsv1alpha1.LatencyMinimum:
+func (s *LocustSource) locustLatency(lt optimizeappsv1alpha1.LatencyType) string {
+	switch optimizeappsv1alpha1.FixLatency(lt) {
+	case optimizeappsv1alpha1.LatencyMinimum:
 		return "min_response_time"
-	case redskyappsv1alpha1.LatencyMaximum:
+	case optimizeappsv1alpha1.LatencyMaximum:
 		return "max_response_time"
-	case redskyappsv1alpha1.LatencyMean:
+	case optimizeappsv1alpha1.LatencyMean:
 		return "average_response_time"
-	case redskyappsv1alpha1.LatencyPercentile50:
+	case optimizeappsv1alpha1.LatencyPercentile50:
 		return "p50"
-	case redskyappsv1alpha1.LatencyPercentile95:
+	case optimizeappsv1alpha1.LatencyPercentile95:
 		return "p95"
-	case redskyappsv1alpha1.LatencyPercentile99:
+	case optimizeappsv1alpha1.LatencyPercentile99:
 		return "p99"
 	default:
 		return ""

--- a/internal/experiment/generation/prometheus.go
+++ b/internal/experiment/generation/prometheus.go
@@ -17,8 +17,8 @@ limitations under the License.
 package generation
 
 import (
-	redskyappsv1alpha1 "github.com/thestormforge/optimize-controller/v2/api/apps/v1alpha1"
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizeappsv1alpha1 "github.com/thestormforge/optimize-controller/v2/api/apps/v1alpha1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	"github.com/thestormforge/optimize-controller/v2/internal/sfio"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -27,13 +27,13 @@ import (
 )
 
 type PrometheusMetricsSource struct {
-	Goal *redskyappsv1alpha1.Goal
+	Goal *optimizeappsv1alpha1.Goal
 }
 
 var _ MetricSource = &PrometheusMetricsSource{}
 
-func (s *PrometheusMetricsSource) Metrics() ([]redskyv1beta1.Metric, error) {
-	var result []redskyv1beta1.Metric
+func (s *PrometheusMetricsSource) Metrics() ([]optimizev1beta1.Metric, error) {
+	var result []optimizev1beta1.Metric
 	if s.Goal == nil || s.Goal.Implemented {
 		return result, nil
 	}
@@ -58,11 +58,11 @@ type BuiltInPrometheus struct {
 var _ ExperimentSource = &BuiltInPrometheus{} // Service Account name and Setup Task
 var _ kio.Reader = &BuiltInPrometheus{}       // RBAC
 
-func (p *BuiltInPrometheus) Update(exp *redskyv1beta1.Experiment) error {
+func (p *BuiltInPrometheus) Update(exp *optimizev1beta1.Experiment) error {
 	// Detect if we need built-in Prometheus by checking the generated metrics
 	var needsPrometheus bool
 	for _, m := range exp.Spec.Metrics {
-		if m.Type == redskyv1beta1.MetricPrometheus && m.URL == "" {
+		if m.Type == optimizev1beta1.MetricPrometheus && m.URL == "" {
 			needsPrometheus = true
 			break
 		}
@@ -74,7 +74,7 @@ func (p *BuiltInPrometheus) Update(exp *redskyv1beta1.Experiment) error {
 
 	exp.Spec.TrialTemplate.Spec.SetupServiceAccountName = p.ServiceAccountName
 	exp.Spec.TrialTemplate.Spec.SetupTasks = append(exp.Spec.TrialTemplate.Spec.SetupTasks,
-		redskyv1beta1.SetupTask{
+		optimizev1beta1.SetupTask{
 			Name: p.SetupTaskName,
 			Args: []string{"prometheus", "$(MODE)"},
 		})

--- a/internal/experiment/generation/replicas.go
+++ b/internal/experiment/generation/replicas.go
@@ -17,7 +17,7 @@ limitations under the License.
 package generation
 
 import (
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	"github.com/thestormforge/optimize-controller/v2/internal/scan"
 	"github.com/thestormforge/optimize-controller/v2/internal/sfio"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -90,7 +90,7 @@ func (p *replicaParameter) Patch(name ParameterNamer) (yaml.Filter, error) {
 	), nil
 }
 
-func (p *replicaParameter) Parameters(name ParameterNamer) ([]redskyv1beta1.Parameter, error) {
+func (p *replicaParameter) Parameters(name ParameterNamer) ([]optimizev1beta1.Parameter, error) {
 	var v int
 	if err := p.value.Decode(&v); err != nil {
 		return nil, err
@@ -107,7 +107,7 @@ func (p *replicaParameter) Parameters(name ParameterNamer) ([]redskyv1beta1.Para
 		maxReplicas = baselineReplicas.IntVal
 	}
 
-	return []redskyv1beta1.Parameter{{
+	return []optimizev1beta1.Parameter{{
 		Name:     name(p.meta, p.fieldPath, "replicas"),
 		Min:      minReplicas,
 		Max:      maxReplicas,

--- a/internal/experiment/generation/requests.go
+++ b/internal/experiment/generation/requests.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"strings"
 
-	redskyappsv1alpha1 "github.com/thestormforge/optimize-controller/v2/api/apps/v1alpha1"
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizeappsv1alpha1 "github.com/thestormforge/optimize-controller/v2/api/apps/v1alpha1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
@@ -30,13 +30,13 @@ var zero = resource.MustParse("0")
 const requestsQueryFormat = `({{ cpuRequests . %q }} * %d) + ({{ memoryRequests . %q | GB }} * %d)`
 
 type RequestsMetricsSource struct {
-	Goal *redskyappsv1alpha1.Goal
+	Goal *optimizeappsv1alpha1.Goal
 }
 
 var _ MetricSource = &RequestsMetricsSource{}
 
-func (s *RequestsMetricsSource) Metrics() ([]redskyv1beta1.Metric, error) {
-	var result []redskyv1beta1.Metric
+func (s *RequestsMetricsSource) Metrics() ([]optimizev1beta1.Metric, error) {
+	var result []optimizev1beta1.Metric
 	if s.Goal == nil || s.Goal.Implemented {
 		return result, nil
 	}
@@ -61,11 +61,11 @@ func (s *RequestsMetricsSource) Metrics() ([]redskyv1beta1.Metric, error) {
 
 		nonOptimized := false
 		result = append(result,
-			newGoalMetric(&redskyappsv1alpha1.Goal{
+			newGoalMetric(&optimizeappsv1alpha1.Goal{
 				Name:     result[0].Name + "-cpu-requests",
 				Optimize: &nonOptimized,
 			}, fmt.Sprintf("{{ cpuRequests . %q }}", s.Goal.Requests.Selector)),
-			newGoalMetric(&redskyappsv1alpha1.Goal{
+			newGoalMetric(&optimizeappsv1alpha1.Goal{
 				Name:     result[0].Name + "-memory-requests",
 				Optimize: &nonOptimized,
 			}, fmt.Sprintf("{{ memoryRequests . %q | GB }}", s.Goal.Requests.Selector)),

--- a/internal/experiment/generation/stormforger.go
+++ b/internal/experiment/generation/stormforger.go
@@ -23,8 +23,8 @@ import (
 	"strings"
 
 	"github.com/pelletier/go-toml"
-	redskyappsv1alpha1 "github.com/thestormforge/optimize-controller/v2/api/apps/v1alpha1"
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizeappsv1alpha1 "github.com/thestormforge/optimize-controller/v2/api/apps/v1alpha1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	"github.com/thestormforge/optimize-controller/v2/internal/sfio"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/kustomize/kyaml/kio"
@@ -32,16 +32,16 @@ import (
 )
 
 type StormForgerSource struct {
-	Scenario    *redskyappsv1alpha1.Scenario
-	Objective   *redskyappsv1alpha1.Objective
-	Application *redskyappsv1alpha1.Application
+	Scenario    *optimizeappsv1alpha1.Scenario
+	Objective   *optimizeappsv1alpha1.Objective
+	Application *optimizeappsv1alpha1.Application
 }
 
 var _ ExperimentSource = &StormForgerSource{} // Update trial job
 var _ MetricSource = &StormForgerSource{}     // StormForger specific metrics
 var _ kio.Reader = &StormForgerSource{}       // ConfigMap for the test case file
 
-func (s *StormForgerSource) Update(exp *redskyv1beta1.Experiment) error {
+func (s *StormForgerSource) Update(exp *optimizev1beta1.Experiment) error {
 	if s.Scenario == nil || s.Application == nil {
 		return nil
 	}
@@ -164,8 +164,8 @@ func (s *StormForgerSource) Read() ([]*yaml.RNode, error) {
 	return result.Read()
 }
 
-func (s *StormForgerSource) Metrics() ([]redskyv1beta1.Metric, error) {
-	var result []redskyv1beta1.Metric
+func (s *StormForgerSource) Metrics() ([]optimizev1beta1.Metric, error) {
+	var result []optimizev1beta1.Metric
 	if s.Objective == nil {
 		return result, nil
 	}
@@ -184,7 +184,7 @@ func (s *StormForgerSource) Metrics() ([]redskyv1beta1.Metric, error) {
 			}
 
 		case goal.ErrorRate != nil:
-			if goal.ErrorRate.ErrorRateType == redskyappsv1alpha1.ErrorRateRequests {
+			if goal.ErrorRate.ErrorRateType == optimizeappsv1alpha1.ErrorRateRequests {
 				query := `scalar(error_ratio{job="trialRun",instance="{{ .Trial.Name }}"})`
 				result = append(result, newGoalMetric(goal, query))
 			}
@@ -219,15 +219,15 @@ func (s *StormForgerSource) stormForgerConfigMapName() string {
 }
 
 // stormForgerAccessToken returns the effective access token information.
-func (s *StormForgerSource) stormForgerAccessToken(org string) *redskyappsv1alpha1.StormForgerAccessToken {
+func (s *StormForgerSource) stormForgerAccessToken(org string) *optimizeappsv1alpha1.StormForgerAccessToken {
 	// This helper function ensures we return something with a populated secret key ref
-	fixRef := func(accessToken *redskyappsv1alpha1.StormForgerAccessToken) *redskyappsv1alpha1.StormForgerAccessToken {
+	fixRef := func(accessToken *optimizeappsv1alpha1.StormForgerAccessToken) *optimizeappsv1alpha1.StormForgerAccessToken {
 		if accessToken.SecretKeyRef == nil {
 			accessToken.SecretKeyRef = &corev1.SecretKeySelector{}
 		}
 
 		if accessToken.SecretKeyRef.Name == "" {
-			accessToken.SecretKeyRef.Name = redskyappsv1alpha1.StormForgerAccessTokenSecretName
+			accessToken.SecretKeyRef.Name = optimizeappsv1alpha1.StormForgerAccessTokenSecretName
 		}
 
 		if accessToken.SecretKeyRef.Key == "" {
@@ -249,7 +249,7 @@ func (s *StormForgerSource) stormForgerAccessToken(org string) *redskyappsv1alph
 			// organizations since service accounts are associated only with a single organization
 			for _, key := range []string{org + ".jwt", "jwt"} {
 				if v := config.Get(key); v != nil {
-					return fixRef(&redskyappsv1alpha1.StormForgerAccessToken{
+					return fixRef(&optimizeappsv1alpha1.StormForgerAccessToken{
 						Literal: v.(string),
 					})
 				}
@@ -260,19 +260,19 @@ func (s *StormForgerSource) stormForgerAccessToken(org string) *redskyappsv1alph
 	return nil
 }
 
-func (s *StormForgerSource) stormForgerLatency(lt redskyappsv1alpha1.LatencyType) string {
-	switch redskyappsv1alpha1.FixLatency(lt) {
-	case redskyappsv1alpha1.LatencyMinimum:
+func (s *StormForgerSource) stormForgerLatency(lt optimizeappsv1alpha1.LatencyType) string {
+	switch optimizeappsv1alpha1.FixLatency(lt) {
+	case optimizeappsv1alpha1.LatencyMinimum:
 		return "min"
-	case redskyappsv1alpha1.LatencyMaximum:
+	case optimizeappsv1alpha1.LatencyMaximum:
 		return "max"
-	case redskyappsv1alpha1.LatencyMean:
+	case optimizeappsv1alpha1.LatencyMean:
 		return "mean"
-	case redskyappsv1alpha1.LatencyPercentile50:
+	case optimizeappsv1alpha1.LatencyPercentile50:
 		return "median"
-	case redskyappsv1alpha1.LatencyPercentile95:
+	case optimizeappsv1alpha1.LatencyPercentile95:
 		return "percentile_95"
-	case redskyappsv1alpha1.LatencyPercentile99:
+	case optimizeappsv1alpha1.LatencyPercentile99:
 		return "percentile_99"
 	default:
 		return ""

--- a/internal/experiment/generation/transformer.go
+++ b/internal/experiment/generation/transformer.go
@@ -22,7 +22,7 @@ import (
 	"regexp"
 	"strings"
 
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	"github.com/thestormforge/optimize-controller/v2/internal/scan"
 	"github.com/thestormforge/optimize-controller/v2/internal/sfio"
 	corev1 "k8s.io/api/core/v1"
@@ -38,14 +38,14 @@ type ParameterNamer func(meta yaml.ResourceMeta, path []string, name string) str
 // for adding parameters, patches, or metrics, the appropriate source should be
 // used instead.
 type ExperimentSource interface {
-	Update(exp *redskyv1beta1.Experiment) error
+	Update(exp *optimizev1beta1.Experiment) error
 }
 
 // ParameterSource allows selectors to add parameters to an experiment. In
 // general PatchSources should also be ParameterSources to ensure the parameters
 // used in the generated patches are configured on the experiment.
 type ParameterSource interface {
-	Parameters(name ParameterNamer) ([]redskyv1beta1.Parameter, error)
+	Parameters(name ParameterNamer) ([]optimizev1beta1.Parameter, error)
 }
 
 // PatchSource allows selectors to contribute changes to the patch of a
@@ -58,7 +58,7 @@ type PatchSource interface {
 
 // MetricSource allows selectors to contribute metrics to an experiment.
 type MetricSource interface {
-	Metrics() ([]redskyv1beta1.Metric, error)
+	Metrics() ([]optimizev1beta1.Metric, error)
 }
 
 // Transformer is used to convert all of the output from the selectors, only selector output
@@ -78,7 +78,7 @@ func (t *Transformer) Transform(nodes []*yaml.RNode, selected []interface{}) ([]
 	name := parameterNamer(selected)
 
 	// Start with a new experiment and collect the scan results into it
-	exp := redskyv1beta1.Experiment{}
+	exp := optimizev1beta1.Experiment{}
 	patches := make(map[corev1.ObjectReference][]yaml.Filter)
 	for _, sel := range selected {
 		// DO NOT use a type switch, there may be multiple implementations
@@ -155,7 +155,7 @@ func (t *Transformer) Transform(nodes []*yaml.RNode, selected []interface{}) ([]
 
 // renderPatches converts accumulated patch contributes (in the form of yaml.Filter instances) into
 // actual patch templates on an experiment.
-func (t *Transformer) renderPatches(patches map[corev1.ObjectReference][]yaml.Filter, exp *redskyv1beta1.Experiment) error {
+func (t *Transformer) renderPatches(patches map[corev1.ObjectReference][]yaml.Filter, exp *optimizev1beta1.Experiment) error {
 	for ref, fs := range patches {
 		// Start with an empty node
 		patch := yaml.NewRNode(&yaml.Node{
@@ -178,7 +178,7 @@ func (t *Transformer) renderPatches(patches map[corev1.ObjectReference][]yaml.Fi
 		data := regexp.MustCompile(`!!int '(.*)'`).ReplaceAll(buf.Bytes(), []byte("$1"))
 
 		// Add the actual patch to the experiment
-		exp.Spec.Patches = append(exp.Spec.Patches, redskyv1beta1.PatchTemplate{
+		exp.Spec.Patches = append(exp.Spec.Patches, optimizev1beta1.PatchTemplate{
 			Patch:     string(data),
 			TargetRef: ref.DeepCopy(),
 		})
@@ -187,7 +187,7 @@ func (t *Transformer) renderPatches(patches map[corev1.ObjectReference][]yaml.Fi
 	return nil
 }
 
-func (t *Transformer) checkExperiment(exp *redskyv1beta1.Experiment, nodes []*yaml.RNode) error {
+func (t *Transformer) checkExperiment(exp *optimizev1beta1.Experiment, nodes []*yaml.RNode) error {
 	// If there are no parameters or metrics, the experiment isn't valid
 	if len(exp.Spec.Parameters) == 0 {
 		// Only report this error if we were going to fail anyway

--- a/internal/experiment/generator.go
+++ b/internal/experiment/generator.go
@@ -19,7 +19,7 @@ package experiment
 import (
 	"fmt"
 
-	redskyappsv1alpha1 "github.com/thestormforge/optimize-controller/v2/api/apps/v1alpha1"
+	optimizeappsv1alpha1 "github.com/thestormforge/optimize-controller/v2/api/apps/v1alpha1"
 	"github.com/thestormforge/optimize-controller/v2/internal/application"
 	"github.com/thestormforge/optimize-controller/v2/internal/experiment/generation"
 	"github.com/thestormforge/optimize-controller/v2/internal/scan"
@@ -31,7 +31,7 @@ import (
 // Generator is used to create an experiment definition.
 type Generator struct {
 	// The definition of the application to generate an experiment for.
-	Application redskyappsv1alpha1.Application
+	Application optimizeappsv1alpha1.Application
 	// The name of the experiment to generate.
 	ExperimentName string
 	// The name of the scenario to generate an experiment for. Required if there are more then one scenario.
@@ -92,12 +92,12 @@ func (g *Generator) Execute(output kio.Writer) error {
 			},
 
 			// Label the generated resources
-			kio.FilterAll(yaml.SetLabel(redskyappsv1alpha1.LabelApplication, g.Application.Name)),
+			kio.FilterAll(yaml.SetLabel(optimizeappsv1alpha1.LabelApplication, g.Application.Name)),
 			kio.FilterAll(generation.SetNamespace(g.Application.Namespace)),
 			kio.FilterAll(generation.SetExperimentName(experimentName)),
-			kio.FilterAll(generation.SetExperimentLabel(redskyappsv1alpha1.LabelApplication, g.Application.Name)),
-			kio.FilterAll(generation.SetExperimentLabel(redskyappsv1alpha1.LabelScenario, scenarioName)),
-			kio.FilterAll(generation.SetExperimentLabel(redskyappsv1alpha1.LabelObjective, objectiveName)),
+			kio.FilterAll(generation.SetExperimentLabel(optimizeappsv1alpha1.LabelApplication, g.Application.Name)),
+			kio.FilterAll(generation.SetExperimentLabel(optimizeappsv1alpha1.LabelScenario, scenarioName)),
+			kio.FilterAll(generation.SetExperimentLabel(optimizeappsv1alpha1.LabelObjective, objectiveName)),
 
 			// Apply Kubernetes formatting conventions and clean up the objects
 			&filters.FormatFilter{UseSchema: true},

--- a/internal/experiment/namespace_template.go
+++ b/internal/experiment/namespace_template.go
@@ -19,7 +19,7 @@ package experiment
 import (
 	"context"
 
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	"github.com/thestormforge/optimize-controller/v2/internal/trial"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -29,7 +29,7 @@ import (
 )
 
 // NextTrialNamespace searches for or creates a new namespace to run a new trial in, returning an empty string if no such namespace can be found
-func NextTrialNamespace(ctx context.Context, c client.Client, exp *redskyv1beta1.Experiment, trialList *redskyv1beta1.TrialList) (string, error) {
+func NextTrialNamespace(ctx context.Context, c client.Client, exp *optimizev1beta1.Experiment, trialList *optimizev1beta1.TrialList) (string, error) {
 	// Determine which namespaces have an active trial
 	activeNamespaces := make(map[string]bool, len(trialList.Items))
 	activeTrials := int32(0)
@@ -93,7 +93,7 @@ func ignorePermissions(err error) error {
 	return err
 }
 
-func createNamespaceFromTemplate(ctx context.Context, c client.Client, exp *redskyv1beta1.Experiment) (string, error) {
+func createNamespaceFromTemplate(ctx context.Context, c client.Client, exp *optimizev1beta1.Experiment) (string, error) {
 	// Use the template to populate a new namespace
 	n := &corev1.Namespace{}
 	exp.Spec.NamespaceTemplate.ObjectMeta.DeepCopyInto(&n.ObjectMeta)
@@ -104,8 +104,8 @@ func createNamespaceFromTemplate(ctx context.Context, c client.Client, exp *reds
 	if n.Labels == nil {
 		n.Labels = map[string]string{}
 	}
-	n.Labels[redskyv1beta1.LabelExperiment] = exp.Name
-	n.Labels[redskyv1beta1.LabelTrialRole] = "trialSetup"
+	n.Labels[optimizev1beta1.LabelExperiment] = exp.Name
+	n.Labels[optimizev1beta1.LabelTrialRole] = "trialSetup"
 
 	// TODO We should also record the fact that we created the namespace for possible clean up later
 
@@ -148,7 +148,7 @@ type trialNamespace struct {
 	RoleBindings   []rbacv1.RoleBinding
 }
 
-func createTrialNamespace(exp *redskyv1beta1.Experiment, namespace string) *trialNamespace {
+func createTrialNamespace(exp *optimizev1beta1.Experiment, namespace string) *trialNamespace {
 	ts := &trialNamespace{}
 
 	// Fill in the details about the service account

--- a/internal/experiment/trial_template.go
+++ b/internal/experiment/trial_template.go
@@ -17,13 +17,13 @@ limitations under the License.
 package experiment
 
 import (
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // PopulateTrialFromTemplate creates a new trial for an experiment
-func PopulateTrialFromTemplate(exp *redskyv1beta1.Experiment, t *redskyv1beta1.Trial) {
+func PopulateTrialFromTemplate(exp *optimizev1beta1.Experiment, t *optimizev1beta1.Trial) {
 	// Start with the trial template
 	exp.Spec.TrialTemplate.ObjectMeta.DeepCopyInto(&t.ObjectMeta)
 	exp.Spec.TrialTemplate.Spec.DeepCopyInto(&t.Spec)
@@ -44,7 +44,7 @@ func PopulateTrialFromTemplate(exp *redskyv1beta1.Experiment, t *redskyv1beta1.T
 	}
 
 	// Record the experiment
-	t.Labels[redskyv1beta1.LabelExperiment] = exp.Name
+	t.Labels[optimizev1beta1.LabelExperiment] = exp.Name
 	t.Spec.ExperimentRef = &corev1.ObjectReference{
 		Name:      exp.Name,
 		Namespace: exp.Namespace,

--- a/internal/experiment/visitor.go
+++ b/internal/experiment/visitor.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 )
 
@@ -40,49 +40,49 @@ func Walk(ctx context.Context, v Visitor, obj interface{}) {
 
 	switch o := obj.(type) {
 
-	case *redskyv1beta1.Experiment:
+	case *optimizev1beta1.Experiment:
 		Walk(withPath(ctx, "spec"), v, &o.Spec)
 
-	case *redskyv1beta1.ExperimentSpec:
+	case *optimizev1beta1.ExperimentSpec:
 		Walk(withPath(ctx, "optimization"), v, o.Optimization)
 		Walk(withPath(ctx, "parameters"), v, o.Parameters)
 		Walk(withPath(ctx, "metrics"), v, o.Metrics)
 		Walk(withPath(ctx, "patches"), v, o.Patches)
 		Walk(withPath(ctx, "trialTemplate"), v, &o.TrialTemplate)
 
-	case []redskyv1beta1.Optimization:
+	case []optimizev1beta1.Optimization:
 		for i := range o {
 			Walk(withPath(ctx, map[string]string{"name": o[i].Name}), v, &o[i])
 		}
 
-	case *redskyv1beta1.Optimization:
+	case *optimizev1beta1.Optimization:
 		// Do nothing
 
-	case []redskyv1beta1.Parameter:
+	case []optimizev1beta1.Parameter:
 		for i := range o {
 			Walk(withPath(ctx, map[string]string{"name": o[i].Name}), v, &o[i])
 		}
 
-	case *redskyv1beta1.Parameter:
+	case *optimizev1beta1.Parameter:
 		// Do nothing
 
-	case []redskyv1beta1.Metric:
+	case []optimizev1beta1.Metric:
 		for i := range o {
 			Walk(withPath(ctx, map[string]string{"name": o[i].Name}), v, &o[i])
 		}
 
-	case *redskyv1beta1.Metric:
+	case *optimizev1beta1.Metric:
 		// Do nothing
 
-	case []redskyv1beta1.PatchTemplate:
+	case []optimizev1beta1.PatchTemplate:
 		for i := range o {
 			Walk(withPath(ctx, i), v, &o[i])
 		}
 
-	case *redskyv1beta1.PatchTemplate:
+	case *optimizev1beta1.PatchTemplate:
 		// Do nothing
 
-	case *redskyv1beta1.TrialTemplateSpec:
+	case *optimizev1beta1.TrialTemplateSpec:
 		if o.Spec.JobTemplate != nil {
 			Walk(withPath(withPath(ctx, "spec"), "jobTemplate"), v, o.Spec.JobTemplate)
 		}

--- a/internal/metric/datadog.go
+++ b/internal/metric/datadog.go
@@ -23,11 +23,11 @@ import (
 	"os"
 	"time"
 
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
-	datadog "github.com/zorkian/go-datadog-api"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	"github.com/zorkian/go-datadog-api"
 )
 
-func captureDatadogMetric(m *redskyv1beta1.Metric, startTime, completionTime time.Time) (float64, float64, error) {
+func captureDatadogMetric(m *optimizev1beta1.Metric, startTime, completionTime time.Time) (float64, float64, error) {
 	apiKey := os.Getenv("DATADOG_API_KEY")
 	if apiKey == "" {
 		apiKey = os.Getenv("DD_API_KEY")

--- a/internal/metric/jsonpath.go
+++ b/internal/metric/jsonpath.go
@@ -26,14 +26,14 @@ import (
 	"strconv"
 	"time"
 
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	"k8s.io/client-go/util/jsonpath"
 )
 
 // TODO We need some type of client util to encapsulate this
 var httpClient = &http.Client{Timeout: 10 * time.Second}
 
-func captureJSONPathMetric(m *redskyv1beta1.Metric) (value float64, valueError float64, err error) {
+func captureJSONPathMetric(m *optimizev1beta1.Metric) (value float64, valueError float64, err error) {
 	// Fetch the URL
 	req, err := http.NewRequest(http.MethodGet, m.URL, nil)
 	if err != nil {

--- a/internal/metric/metric.go
+++ b/internal/metric/metric.go
@@ -23,13 +23,13 @@ import (
 	"strconv"
 
 	"github.com/go-logr/logr"
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	"github.com/thestormforge/optimize-controller/v2/internal/template"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // CaptureMetric captures a point-in-time metric value and it's error rate.
-func CaptureMetric(ctx context.Context, log logr.Logger, trial *redskyv1beta1.Trial, metric *redskyv1beta1.Metric, target runtime.Object) (float64, float64, error) {
+func CaptureMetric(ctx context.Context, log logr.Logger, trial *optimizev1beta1.Trial, metric *optimizev1beta1.Metric, target runtime.Object) (float64, float64, error) {
 	// Execute the queries as Go templates
 	var err error
 	if metric.Query, metric.ErrorQuery, err = template.New().RenderMetricQueries(metric, trial, target); err != nil {
@@ -38,16 +38,16 @@ func CaptureMetric(ctx context.Context, log logr.Logger, trial *redskyv1beta1.Tr
 
 	// Capture the value based on the metric type
 	switch metric.Type {
-	case redskyv1beta1.MetricKubernetes, "":
+	case optimizev1beta1.MetricKubernetes, "":
 		value, err := strconv.ParseFloat(metric.Query, 64)
 		return value, math.NaN(), err
-	case redskyv1beta1.MetricPrometheus:
+	case optimizev1beta1.MetricPrometheus:
 		return capturePrometheusMetric(ctx, log, metric, trial.Status.CompletionTime.Time)
-	case redskyv1beta1.MetricDatadog:
+	case optimizev1beta1.MetricDatadog:
 		return captureDatadogMetric(metric, trial.Status.StartTime.Time, trial.Status.CompletionTime.Time)
-	case redskyv1beta1.MetricJSONPath:
+	case optimizev1beta1.MetricJSONPath:
 		return captureJSONPathMetric(metric)
-	case redskyv1beta1.MetricNewRelic:
+	case optimizev1beta1.MetricNewRelic:
 		return captureNewRelicMetric(metric, trial.Status.StartTime.Time, trial.Status.CompletionTime.Time)
 	default:
 		return 0, 0, fmt.Errorf("unknown metric type: %s", metric.Type)

--- a/internal/metric/metric_test.go
+++ b/internal/metric/metric_test.go
@@ -26,7 +26,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -52,13 +52,13 @@ func TestCaptureMetric(t *testing.T) {
 
 	testCases := []struct {
 		desc     string
-		metric   *redskyv1beta1.Metric
+		metric   *optimizev1beta1.Metric
 		obj      runtime.Object
 		expected float64
 	}{
 		{
 			desc: "default kubernetes",
-			metric: &redskyv1beta1.Metric{
+			metric: &optimizev1beta1.Metric{
 				Name:  "testMetric",
 				Query: "{{duration .StartTime .CompletionTime}}",
 			},
@@ -66,19 +66,19 @@ func TestCaptureMetric(t *testing.T) {
 		},
 		{
 			desc: "explicit kubernetes",
-			metric: &redskyv1beta1.Metric{
+			metric: &optimizev1beta1.Metric{
 				Name:  "testMetric",
 				Query: "{{duration .StartTime .CompletionTime}}",
-				Type:  redskyv1beta1.MetricKubernetes,
+				Type:  optimizev1beta1.MetricKubernetes,
 			},
 			expected: 5,
 		},
 		{
 			desc: "kubernetes target",
-			metric: &redskyv1beta1.Metric{
+			metric: &optimizev1beta1.Metric{
 				Name:  "testMetric",
 				Query: "{{with index .Target.Items 0}}{{ (indexResource .Usage \"cpu\").MilliValue }}{{ end }}",
-				Type:  redskyv1beta1.MetricKubernetes,
+				Type:  optimizev1beta1.MetricKubernetes,
 			},
 			obj: &metricsv1beta1.NodeMetricsList{
 				Items: []metricsv1beta1.NodeMetrics{
@@ -98,10 +98,10 @@ func TestCaptureMetric(t *testing.T) {
 		},
 		{
 			desc: "prometheus url",
-			metric: &redskyv1beta1.Metric{
+			metric: &optimizev1beta1.Metric{
 				Name:  "testMetric",
 				Query: "scalar(prometheus_build_info)",
-				Type:  redskyv1beta1.MetricPrometheus,
+				Type:  optimizev1beta1.MetricPrometheus,
 				URL:   promHttpTest.URL,
 			},
 			expected: 1,
@@ -109,10 +109,10 @@ func TestCaptureMetric(t *testing.T) {
 
 		{
 			desc: "jsonpath url",
-			metric: &redskyv1beta1.Metric{
+			metric: &optimizev1beta1.Metric{
 				Name:  "testMetric",
 				Query: "{.current_response_time_percentile_95}",
-				Type:  redskyv1beta1.MetricJSONPath,
+				Type:  optimizev1beta1.MetricJSONPath,
 				URL:   jsonHttpTest.URL,
 			},
 			expected: 5,
@@ -122,8 +122,8 @@ func TestCaptureMetric(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("%q", tc.desc), func(t *testing.T) {
 			log := log.WithValues("test", tc.desc)
-			trial := &redskyv1beta1.Trial{
-				Status: redskyv1beta1.TrialStatus{
+			trial := &optimizev1beta1.Trial{
+				Status: optimizev1beta1.TrialStatus{
 					StartTime:      &now,
 					CompletionTime: &later,
 				},

--- a/internal/metric/newrelic.go
+++ b/internal/metric/newrelic.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/newrelic/newrelic-client-go/newrelic"
 	"github.com/newrelic/newrelic-client-go/pkg/nrdb"
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 )
 
 const query = `
@@ -42,7 +42,7 @@ const query = `
 		}
 	}`
 
-func captureNewRelicMetric(m *redskyv1beta1.Metric, startTime, completionTime time.Time) (float64, float64, error) {
+func captureNewRelicMetric(m *optimizev1beta1.Metric, startTime, completionTime time.Time) (float64, float64, error) {
 	apiKey := os.Getenv("NEW_RELIC_API_KEY")
 	if apiKey == "" {
 		return 0, 0, errors.New("NEW_RELIC_API_KEY environment variable missing")

--- a/internal/metric/prometheus.go
+++ b/internal/metric/prometheus.go
@@ -26,7 +26,7 @@ import (
 	prom "github.com/prometheus/client_golang/api"
 	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 )
 
 // CaptureError describes problems that arise while capturing Prometheus metric values.
@@ -45,7 +45,7 @@ func (e *CaptureError) Error() string {
 	return e.Message
 }
 
-func capturePrometheusMetric(ctx context.Context, log logr.Logger, m *redskyv1beta1.Metric, completionTime time.Time) (value float64, valueError float64, err error) {
+func capturePrometheusMetric(ctx context.Context, log logr.Logger, m *optimizev1beta1.Metric, completionTime time.Time) (value float64, valueError float64, err error) {
 	// Get the Prometheus API
 	c, err := prom.NewClient(prom.Config{Address: m.URL})
 	if err != nil {

--- a/internal/patch/patch_test.go
+++ b/internal/patch/patch_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	redsky "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	"github.com/thestormforge/optimize-controller/v2/internal/template"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,7 +31,7 @@ import (
 func TestPatch(t *testing.T) {
 	te := template.New()
 
-	trial := &redsky.Trial{
+	trial := &optimizev1beta1.Trial{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "mytrial",
 			Namespace: "default",
@@ -63,8 +63,8 @@ metadata:
 
 	testCases := []struct {
 		desc                string
-		trial               *redsky.Trial
-		patchTemplate       *redsky.PatchTemplate
+		trial               *optimizev1beta1.Trial
+		patchTemplate       *optimizev1beta1.PatchTemplate
 		attemptsRemaining   int
 		expectedError       bool
 		expectedRenderError bool
@@ -73,7 +73,7 @@ metadata:
 		{
 			desc:  "default",
 			trial: trial,
-			patchTemplate: &redsky.PatchTemplate{
+			patchTemplate: &optimizev1beta1.PatchTemplate{
 				// Note: defining an empty string ("") results
 				// in a `null` being returned. Think this is valid
 				// but makes testing a little more complicated.
@@ -90,8 +90,8 @@ metadata:
 		{
 			desc:  "strategic w/o targetref",
 			trial: trial,
-			patchTemplate: &redsky.PatchTemplate{
-				Type:      redsky.PatchStrategic,
+			patchTemplate: &optimizev1beta1.PatchTemplate{
+				Type:      optimizev1beta1.PatchStrategic,
 				Patch:     fullPatch,
 				TargetRef: nil,
 			},
@@ -100,8 +100,8 @@ metadata:
 		{
 			desc:  "strategic w/o targetref w/o full",
 			trial: trial,
-			patchTemplate: &redsky.PatchTemplate{
-				Type:      redsky.PatchStrategic,
+			patchTemplate: &optimizev1beta1.PatchTemplate{
+				Type:      optimizev1beta1.PatchStrategic,
 				Patch:     patchSpec,
 				TargetRef: nil,
 			},
@@ -110,8 +110,8 @@ metadata:
 		{
 			desc:  "patchmerge",
 			trial: trial,
-			patchTemplate: &redsky.PatchTemplate{
-				Type:  redsky.PatchMerge,
+			patchTemplate: &optimizev1beta1.PatchTemplate{
+				Type:  optimizev1beta1.PatchMerge,
 				Patch: fullPatch,
 				TargetRef: &corev1.ObjectReference{
 					Kind:       "Deployment",
@@ -125,8 +125,8 @@ metadata:
 		{
 			desc:  "patchjson",
 			trial: trial,
-			patchTemplate: &redsky.PatchTemplate{
-				Type:  redsky.PatchJSON,
+			patchTemplate: &optimizev1beta1.PatchTemplate{
+				Type:  optimizev1beta1.PatchJSON,
 				Patch: jsonPatch,
 				TargetRef: &corev1.ObjectReference{
 					Kind:       "Deployment",
@@ -140,8 +140,8 @@ metadata:
 		{
 			desc:  "patchTrial - json",
 			trial: trial,
-			patchTemplate: &redsky.PatchTemplate{
-				Type:  redsky.PatchJSON,
+			patchTemplate: &optimizev1beta1.PatchTemplate{
+				Type:  optimizev1beta1.PatchJSON,
 				Patch: patchSpec,
 				TargetRef: &corev1.ObjectReference{
 					Kind:       "Job",
@@ -155,8 +155,8 @@ metadata:
 		{
 			desc:  "patchTrial - strategic merge",
 			trial: trial,
-			patchTemplate: &redsky.PatchTemplate{
-				Type:  redsky.PatchStrategic,
+			patchTemplate: &optimizev1beta1.PatchTemplate{
+				Type:  optimizev1beta1.PatchStrategic,
 				Patch: patchSpec,
 				TargetRef: &corev1.ObjectReference{
 					Kind:       "Job",
@@ -170,8 +170,8 @@ metadata:
 		{
 			desc:  "patchTrial - optional name",
 			trial: trial,
-			patchTemplate: &redsky.PatchTemplate{
-				Type:  redsky.PatchStrategic,
+			patchTemplate: &optimizev1beta1.PatchTemplate{
+				Type:  optimizev1beta1.PatchStrategic,
 				Patch: patchSpec,
 				TargetRef: &corev1.ObjectReference{
 					Kind:       "Job",
@@ -201,11 +201,11 @@ metadata:
 			}
 
 			switch tc.patchTemplate.Type {
-			case redsky.PatchStrategic, redsky.PatchMerge:
+			case optimizev1beta1.PatchStrategic, optimizev1beta1.PatchMerge:
 				if !strings.Contains(tc.desc, "patchTrial") {
 					assert.Equal(t, tc.patchTemplate.Patch, fullPatch)
 				}
-			case redsky.PatchJSON:
+			case optimizev1beta1.PatchJSON:
 				if !strings.Contains(tc.desc, "patchTrial") {
 					assert.Equal(t, tc.patchTemplate.Patch, jsonPatch)
 				}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -24,10 +24,10 @@ import (
 	"strconv"
 	"strings"
 
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	"github.com/thestormforge/optimize-controller/v2/internal/experiment"
 	"github.com/thestormforge/optimize-controller/v2/internal/trial"
-	redskyapi "github.com/thestormforge/optimize-go/pkg/api/experiments/v1alpha1"
+	experimentsv1alpha1 "github.com/thestormforge/optimize-go/pkg/api/experiments/v1alpha1"
 	"github.com/thestormforge/optimize-go/pkg/api/experiments/v1alpha1/numstr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -42,13 +42,13 @@ const (
 // TODO Split this into trial.go and experiment.go ?
 
 // FromCluster converts cluster state to API state
-func FromCluster(in *redskyv1beta1.Experiment) (redskyapi.ExperimentName, *redskyapi.Experiment, *redskyapi.TrialAssignments, error) {
-	out := &redskyapi.Experiment{}
+func FromCluster(in *optimizev1beta1.Experiment) (experimentsv1alpha1.ExperimentName, *experimentsv1alpha1.Experiment, *experimentsv1alpha1.TrialAssignments, error) {
+	out := &experimentsv1alpha1.Experiment{}
 	out.ExperimentMeta.LastModified = in.CreationTimestamp.Time
-	out.ExperimentMeta.SelfURL = in.Annotations[redskyv1beta1.AnnotationExperimentURL]
-	out.ExperimentMeta.NextTrialURL = in.Annotations[redskyv1beta1.AnnotationNextTrialURL]
+	out.ExperimentMeta.SelfURL = in.Annotations[optimizev1beta1.AnnotationExperimentURL]
+	out.ExperimentMeta.NextTrialURL = in.Annotations[optimizev1beta1.AnnotationNextTrialURL]
 
-	baseline := &redskyapi.TrialAssignments{Labels: map[string]string{"baseline": "true"}}
+	baseline := &experimentsv1alpha1.TrialAssignments{Labels: map[string]string{"baseline": "true"}}
 
 	if l := len(in.ObjectMeta.Labels); l > 0 {
 		out.Labels = make(map[string]string, l)
@@ -60,7 +60,7 @@ func FromCluster(in *redskyv1beta1.Experiment) (redskyapi.ExperimentName, *redsk
 
 	out.Optimization = nil
 	for _, o := range in.Spec.Optimization {
-		out.Optimization = append(out.Optimization, redskyapi.Optimization{
+		out.Optimization = append(out.Optimization, experimentsv1alpha1.Optimization{
 			Name:  o.Name,
 			Value: o.Value,
 		})
@@ -74,16 +74,16 @@ func FromCluster(in *redskyv1beta1.Experiment) (redskyapi.ExperimentName, *redsk
 		}
 
 		if len(p.Values) > 0 {
-			out.Parameters = append(out.Parameters, redskyapi.Parameter{
-				Type:   redskyapi.ParameterTypeCategorical,
+			out.Parameters = append(out.Parameters, experimentsv1alpha1.Parameter{
+				Type:   experimentsv1alpha1.ParameterTypeCategorical,
 				Name:   p.Name,
 				Values: p.Values,
 			})
 		} else {
-			out.Parameters = append(out.Parameters, redskyapi.Parameter{
-				Type: redskyapi.ParameterTypeInteger,
+			out.Parameters = append(out.Parameters, experimentsv1alpha1.Parameter{
+				Type: experimentsv1alpha1.ParameterTypeInteger,
 				Name: p.Name,
-				Bounds: &redskyapi.Bounds{
+				Bounds: &experimentsv1alpha1.Bounds{
 					Min: json.Number(strconv.FormatInt(int64(p.Min), 10)),
 					Max: json.Number(strconv.FormatInt(int64(p.Max), 10)),
 				},
@@ -105,7 +105,7 @@ func FromCluster(in *redskyv1beta1.Experiment) (redskyapi.ExperimentName, *redsk
 				}
 				v = numstr.FromInt64(int64(vi))
 			}
-			baseline.Assignments = append(baseline.Assignments, redskyapi.Assignment{
+			baseline.Assignments = append(baseline.Assignments, experimentsv1alpha1.Assignment{
 				ParameterName: p.Name,
 				Value:         v,
 			})
@@ -116,16 +116,16 @@ func FromCluster(in *redskyv1beta1.Experiment) (redskyapi.ExperimentName, *redsk
 	for _, c := range in.Spec.Constraints {
 		switch {
 		case c.Order != nil:
-			out.Constraints = append(out.Constraints, redskyapi.Constraint{
+			out.Constraints = append(out.Constraints, experimentsv1alpha1.Constraint{
 				Name:           c.Name,
-				ConstraintType: redskyapi.ConstraintOrder,
-				OrderConstraint: redskyapi.OrderConstraint{
+				ConstraintType: experimentsv1alpha1.ConstraintOrder,
+				OrderConstraint: experimentsv1alpha1.OrderConstraint{
 					LowerParameter: c.Order.LowerParameter,
 					UpperParameter: c.Order.UpperParameter,
 				},
 			})
 		case c.Sum != nil:
-			sc := redskyapi.SumConstraint{
+			sc := experimentsv1alpha1.SumConstraint{
 				IsUpperBound: c.Sum.IsUpperBound,
 				Bound:        float64(c.Sum.Bound.MilliValue()) / 1000,
 			}
@@ -135,15 +135,15 @@ func FromCluster(in *redskyv1beta1.Experiment) (redskyapi.ExperimentName, *redsk
 					continue
 				}
 
-				sc.Parameters = append(sc.Parameters, redskyapi.SumConstraintParameter{
+				sc.Parameters = append(sc.Parameters, experimentsv1alpha1.SumConstraintParameter{
 					Name:   p.Name,
 					Weight: float64(p.Weight.MilliValue()) / 1000,
 				})
 			}
 
-			out.Constraints = append(out.Constraints, redskyapi.Constraint{
+			out.Constraints = append(out.Constraints, experimentsv1alpha1.Constraint{
 				Name:           c.Name,
-				ConstraintType: redskyapi.ConstraintSum,
+				ConstraintType: experimentsv1alpha1.ConstraintSum,
 				SumConstraint:  sc,
 			})
 		}
@@ -151,7 +151,7 @@ func FromCluster(in *redskyv1beta1.Experiment) (redskyapi.ExperimentName, *redsk
 
 	out.Metrics = nil
 	for _, m := range in.Spec.Metrics {
-		out.Metrics = append(out.Metrics, redskyapi.Metric{
+		out.Metrics = append(out.Metrics, experimentsv1alpha1.Metric{
 			Name:     m.Name,
 			Minimize: m.Minimize,
 			Optimize: m.Optimize,
@@ -165,22 +165,22 @@ func FromCluster(in *redskyv1beta1.Experiment) (redskyapi.ExperimentName, *redsk
 		return nil, nil, nil, fmt.Errorf("baseline must be specified on all or none of the parameters")
 	}
 
-	n := redskyapi.NewExperimentName(in.Name)
+	n := experimentsv1alpha1.NewExperimentName(in.Name)
 	return n, out, baseline, nil
 }
 
 // ToCluster converts API state to cluster state
-func ToCluster(exp *redskyv1beta1.Experiment, ee *redskyapi.Experiment) {
+func ToCluster(exp *optimizev1beta1.Experiment, ee *experimentsv1alpha1.Experiment) {
 	if exp.GetAnnotations() == nil {
 		exp.SetAnnotations(make(map[string]string))
 	}
 
-	exp.GetAnnotations()[redskyv1beta1.AnnotationExperimentURL] = ee.SelfURL
-	exp.GetAnnotations()[redskyv1beta1.AnnotationNextTrialURL] = ee.NextTrialURL
+	exp.GetAnnotations()[optimizev1beta1.AnnotationExperimentURL] = ee.SelfURL
+	exp.GetAnnotations()[optimizev1beta1.AnnotationNextTrialURL] = ee.NextTrialURL
 
 	exp.Spec.Optimization = nil
 	for i := range ee.Optimization {
-		exp.Spec.Optimization = append(exp.Spec.Optimization, redskyv1beta1.Optimization{
+		exp.Spec.Optimization = append(exp.Spec.Optimization, optimizev1beta1.Optimization{
 			Name:  ee.Optimization[i].Name,
 			Value: ee.Optimization[i].Value,
 		})
@@ -190,8 +190,8 @@ func ToCluster(exp *redskyv1beta1.Experiment, ee *redskyapi.Experiment) {
 }
 
 // ToClusterTrial converts API state to cluster state
-func ToClusterTrial(t *redskyv1beta1.Trial, suggestion *redskyapi.TrialAssignments) {
-	t.GetAnnotations()[redskyv1beta1.AnnotationReportTrialURL] = suggestion.SelfURL
+func ToClusterTrial(t *optimizev1beta1.Trial, suggestion *experimentsv1alpha1.TrialAssignments) {
+	t.GetAnnotations()[optimizev1beta1.AnnotationReportTrialURL] = suggestion.SelfURL
 
 	// Try to make the cluster trial names match what is on the server
 	if t.Name == "" && t.GenerateName != "" && suggestion.SelfURL != "" {
@@ -221,7 +221,7 @@ func ToClusterTrial(t *redskyv1beta1.Trial, suggestion *redskyapi.TrialAssignmen
 			}
 		}
 
-		t.Spec.Assignments = append(t.Spec.Assignments, redskyv1beta1.Assignment{
+		t.Spec.Assignments = append(t.Spec.Assignments, optimizev1beta1.Assignment{
 			Name:  a.ParameterName,
 			Value: v,
 		})
@@ -246,8 +246,8 @@ func ToClusterTrial(t *redskyv1beta1.Trial, suggestion *redskyapi.TrialAssignmen
 }
 
 // FromClusterTrial converts cluster state to API state
-func FromClusterTrial(t *redskyv1beta1.Trial) *redskyapi.TrialValues {
-	out := &redskyapi.TrialValues{}
+func FromClusterTrial(t *optimizev1beta1.Trial) *experimentsv1alpha1.TrialValues {
+	out := &experimentsv1alpha1.TrialValues{}
 
 	// Set the trial timestamps
 	if t.Status.StartTime != nil {
@@ -259,7 +259,7 @@ func FromClusterTrial(t *redskyv1beta1.Trial) *redskyapi.TrialValues {
 
 	// Check to see if the trial failed
 	for _, c := range t.Status.Conditions {
-		if c.Type == redskyv1beta1.TrialFailed && c.Status == corev1.ConditionTrue {
+		if c.Type == optimizev1beta1.TrialFailed && c.Status == corev1.ConditionTrue {
 			out.Failed = true
 			out.FailureReason = c.Reason
 			out.FailureMessage = c.Message
@@ -271,7 +271,7 @@ func FromClusterTrial(t *redskyv1beta1.Trial) *redskyapi.TrialValues {
 	if !out.Failed {
 		for _, v := range t.Spec.Values {
 			if fv, err := strconv.ParseFloat(v.Value, 64); err == nil {
-				value := redskyapi.Value{
+				value := experimentsv1alpha1.Value{
 					MetricName: v.Name,
 					Value:      fv,
 				}
@@ -287,26 +287,26 @@ func FromClusterTrial(t *redskyv1beta1.Trial) *redskyapi.TrialValues {
 }
 
 // StopExperiment updates the experiment in the event that it should be paused or halted.
-func StopExperiment(exp *redskyv1beta1.Experiment, err error) bool {
-	if rse, ok := err.(*redskyapi.Error); ok && rse.Type == redskyapi.ErrExperimentStopped {
+func StopExperiment(exp *optimizev1beta1.Experiment, err error) bool {
+	if rse, ok := err.(*experimentsv1alpha1.Error); ok && rse.Type == experimentsv1alpha1.ErrExperimentStopped {
 		exp.SetReplicas(0)
-		delete(exp.GetAnnotations(), redskyv1beta1.AnnotationNextTrialURL)
-		experiment.ApplyCondition(&exp.Status, redskyv1beta1.ExperimentComplete, corev1.ConditionTrue, "Stopped", err.Error(), nil)
+		delete(exp.GetAnnotations(), optimizev1beta1.AnnotationNextTrialURL)
+		experiment.ApplyCondition(&exp.Status, optimizev1beta1.ExperimentComplete, corev1.ConditionTrue, "Stopped", err.Error(), nil)
 		return true
 	}
 	return false
 }
 
 // FailExperiment records a recognized error as an experiment failure.
-func FailExperiment(exp *redskyv1beta1.Experiment, reason string, err error) bool {
+func FailExperiment(exp *optimizev1beta1.Experiment, reason string, err error) bool {
 	exp.SetReplicas(0)
-	experiment.ApplyCondition(&exp.Status, redskyv1beta1.ExperimentFailed, corev1.ConditionTrue, reason, err.Error(), nil)
+	experiment.ApplyCondition(&exp.Status, optimizev1beta1.ExperimentFailed, corev1.ConditionTrue, reason, err.Error(), nil)
 	return true
 }
 
 // IsServerSyncEnabled checks to see if server synchronization is enabled.
-func IsServerSyncEnabled(exp *redskyv1beta1.Experiment) bool {
-	switch strings.ToLower(exp.GetAnnotations()[redskyv1beta1.AnnotationServerSync]) {
+func IsServerSyncEnabled(exp *optimizev1beta1.Experiment) bool {
+	switch strings.ToLower(exp.GetAnnotations()[optimizev1beta1.AnnotationServerSync]) {
 	case "disabled", "false":
 		return false
 	default:
@@ -323,7 +323,7 @@ func IsServerSyncEnabled(exp *redskyv1beta1.Experiment) bool {
 // server experiments means it won't be available to the UI anymore. We also
 // would not want a `reset` (which deletes the CRD) to wipe out all the data on
 // the server.
-func DeleteServerExperiment(exp *redskyv1beta1.Experiment) bool {
+func DeleteServerExperiment(exp *optimizev1beta1.Experiment) bool {
 	// As a special case, check to see if synchronization is disabled. This would
 	// be the case if someone tried disabling server synchronization mid-run,
 	// presumably with the intent of not having the server experiment at the end.
@@ -331,7 +331,7 @@ func DeleteServerExperiment(exp *redskyv1beta1.Experiment) bool {
 		return true
 	}
 
-	switch strings.ToLower(exp.GetAnnotations()[redskyv1beta1.AnnotationServerSync]) {
+	switch strings.ToLower(exp.GetAnnotations()[optimizev1beta1.AnnotationServerSync]) {
 	case "delete-completed", "delete":
 		// Allow the server representation of the experiment to be deleted, for
 		// example to facilitate debugging or with initial experiment setup.

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -25,8 +25,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
-	redskyapi "github.com/thestormforge/optimize-go/pkg/api/experiments/v1alpha1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	experimentsv1alpha1 "github.com/thestormforge/optimize-go/pkg/api/experiments/v1alpha1"
 	"github.com/thestormforge/optimize-go/pkg/api/experiments/v1alpha1/numstr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -41,27 +41,27 @@ func TestFromCluster(t *testing.T) {
 	now := time.Now()
 	cases := []struct {
 		desc     string
-		in       *redskyv1beta1.Experiment
-		out      *redskyapi.Experiment
-		name     redskyapi.ExperimentName
-		baseline *redskyapi.TrialAssignments
+		in       *optimizev1beta1.Experiment
+		out      *experimentsv1alpha1.Experiment
+		name     experimentsv1alpha1.ExperimentName
+		baseline *experimentsv1alpha1.TrialAssignments
 	}{
 		{
 			desc: "basic",
-			in: &redskyv1beta1.Experiment{
+			in: &optimizev1beta1.Experiment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "basic",
 					CreationTimestamp: metav1.Time{
 						Time: now,
 					},
 					Annotations: map[string]string{
-						redskyv1beta1.AnnotationExperimentURL: "self_111",
-						redskyv1beta1.AnnotationNextTrialURL:  "next_trial_111",
+						optimizev1beta1.AnnotationExperimentURL: "self_111",
+						optimizev1beta1.AnnotationNextTrialURL:  "next_trial_111",
 					},
 				},
 			},
-			out: &redskyapi.Experiment{
-				ExperimentMeta: redskyapi.ExperimentMeta{
+			out: &experimentsv1alpha1.Experiment{
+				ExperimentMeta: experimentsv1alpha1.ExperimentMeta{
 					LastModified: now,
 					SelfURL:      "self_111",
 					NextTrialURL: "next_trial_111",
@@ -70,17 +70,17 @@ func TestFromCluster(t *testing.T) {
 		},
 		{
 			desc: "optimization",
-			in: &redskyv1beta1.Experiment{
-				Spec: redskyv1beta1.ExperimentSpec{
-					Optimization: []redskyv1beta1.Optimization{
+			in: &optimizev1beta1.Experiment{
+				Spec: optimizev1beta1.ExperimentSpec{
+					Optimization: []optimizev1beta1.Optimization{
 						{Name: "one", Value: "111"},
 						{Name: "two", Value: "222"},
 						{Name: "three", Value: "333"},
 					},
 				},
 			},
-			out: &redskyapi.Experiment{
-				Optimization: []redskyapi.Optimization{
+			out: &experimentsv1alpha1.Experiment{
+				Optimization: []experimentsv1alpha1.Optimization{
 					{Name: "one", Value: "111"},
 					{Name: "two", Value: "222"},
 					{Name: "three", Value: "333"},
@@ -89,9 +89,9 @@ func TestFromCluster(t *testing.T) {
 		},
 		{
 			desc: "parameters",
-			in: &redskyv1beta1.Experiment{
-				Spec: redskyv1beta1.ExperimentSpec{
-					Parameters: []redskyv1beta1.Parameter{
+			in: &optimizev1beta1.Experiment{
+				Spec: optimizev1beta1.ExperimentSpec{
+					Parameters: []optimizev1beta1.Parameter{
 						{Name: "one", Min: 111, Max: 222},
 						{Name: "two", Min: 1111, Max: 2222},
 						{Name: "three", Min: 11111, Max: 22222},
@@ -99,28 +99,28 @@ func TestFromCluster(t *testing.T) {
 					},
 				},
 			},
-			out: &redskyapi.Experiment{
-				Parameters: []redskyapi.Parameter{
+			out: &experimentsv1alpha1.Experiment{
+				Parameters: []experimentsv1alpha1.Parameter{
 					{
-						Type: redskyapi.ParameterTypeInteger,
+						Type: experimentsv1alpha1.ParameterTypeInteger,
 						Name: "one",
-						Bounds: &redskyapi.Bounds{
+						Bounds: &experimentsv1alpha1.Bounds{
 							Min: json.Number(strconv.FormatInt(111, 10)),
 							Max: json.Number(strconv.FormatInt(222, 10)),
 						},
 					},
 					{
-						Type: redskyapi.ParameterTypeInteger,
+						Type: experimentsv1alpha1.ParameterTypeInteger,
 						Name: "two",
-						Bounds: &redskyapi.Bounds{
+						Bounds: &experimentsv1alpha1.Bounds{
 							Min: json.Number(strconv.FormatInt(1111, 10)),
 							Max: json.Number(strconv.FormatInt(2222, 10)),
 						},
 					},
 					{
-						Type: redskyapi.ParameterTypeInteger,
+						Type: experimentsv1alpha1.ParameterTypeInteger,
 						Name: "three",
-						Bounds: &redskyapi.Bounds{
+						Bounds: &experimentsv1alpha1.Bounds{
 							Min: json.Number(strconv.FormatInt(11111, 10)),
 							Max: json.Number(strconv.FormatInt(22222, 10)),
 						},
@@ -130,12 +130,12 @@ func TestFromCluster(t *testing.T) {
 		},
 		{
 			desc: "orderConstraints",
-			in: &redskyv1beta1.Experiment{
-				Spec: redskyv1beta1.ExperimentSpec{
-					Constraints: []redskyv1beta1.Constraint{
+			in: &optimizev1beta1.Experiment{
+				Spec: optimizev1beta1.ExperimentSpec{
+					Constraints: []optimizev1beta1.Constraint{
 						{
 							Name: "one-two",
-							Order: &redskyv1beta1.OrderConstraint{
+							Order: &optimizev1beta1.OrderConstraint{
 								LowerParameter: "one",
 								UpperParameter: "two",
 							},
@@ -143,26 +143,26 @@ func TestFromCluster(t *testing.T) {
 					},
 				},
 			},
-			out: &redskyapi.Experiment{
-				Constraints: []redskyapi.Constraint{
+			out: &experimentsv1alpha1.Experiment{
+				Constraints: []experimentsv1alpha1.Constraint{
 					{
-						ConstraintType:  redskyapi.ConstraintOrder,
+						ConstraintType:  experimentsv1alpha1.ConstraintOrder,
 						Name:            "one-two",
-						OrderConstraint: redskyapi.OrderConstraint{LowerParameter: "one", UpperParameter: "two"},
+						OrderConstraint: experimentsv1alpha1.OrderConstraint{LowerParameter: "one", UpperParameter: "two"},
 					},
 				},
 			},
 		},
 		{
 			desc: "sumConstraints",
-			in: &redskyv1beta1.Experiment{
-				Spec: redskyv1beta1.ExperimentSpec{
-					Constraints: []redskyv1beta1.Constraint{
+			in: &optimizev1beta1.Experiment{
+				Spec: optimizev1beta1.ExperimentSpec{
+					Constraints: []optimizev1beta1.Constraint{
 						{
 							Name: "one-two",
-							Sum: &redskyv1beta1.SumConstraint{
+							Sum: &optimizev1beta1.SumConstraint{
 								Bound: resource.MustParse("1"),
-								Parameters: []redskyv1beta1.SumConstraintParameter{
+								Parameters: []optimizev1beta1.SumConstraintParameter{
 									{
 										Name:   "one",
 										Weight: resource.MustParse("-1.0"),
@@ -185,14 +185,14 @@ func TestFromCluster(t *testing.T) {
 					},
 				},
 			},
-			out: &redskyapi.Experiment{
-				Constraints: []redskyapi.Constraint{
+			out: &experimentsv1alpha1.Experiment{
+				Constraints: []experimentsv1alpha1.Constraint{
 					{
 						Name:           "one-two",
-						ConstraintType: redskyapi.ConstraintSum,
-						SumConstraint: redskyapi.SumConstraint{
+						ConstraintType: experimentsv1alpha1.ConstraintSum,
+						SumConstraint: experimentsv1alpha1.SumConstraint{
 							Bound: 1,
-							Parameters: []redskyapi.SumConstraintParameter{
+							Parameters: []experimentsv1alpha1.SumConstraintParameter{
 								{Name: "one", Weight: -1.0},
 								{Name: "two", Weight: 1.0},
 								{Name: "three", Weight: 3.5},
@@ -205,17 +205,17 @@ func TestFromCluster(t *testing.T) {
 		},
 		{
 			desc: "metrics",
-			in: &redskyv1beta1.Experiment{
-				Spec: redskyv1beta1.ExperimentSpec{
-					Metrics: []redskyv1beta1.Metric{
+			in: &optimizev1beta1.Experiment{
+				Spec: optimizev1beta1.ExperimentSpec{
+					Metrics: []optimizev1beta1.Metric{
 						{Name: "one", Minimize: true},
 						{Name: "two", Minimize: false},
 						{Name: "three", Minimize: true},
 					},
 				},
 			},
-			out: &redskyapi.Experiment{
-				Metrics: []redskyapi.Metric{
+			out: &experimentsv1alpha1.Experiment{
+				Metrics: []experimentsv1alpha1.Metric{
 					{Name: "one", Minimize: true},
 					{Name: "two", Minimize: false},
 					{Name: "three", Minimize: true},
@@ -224,37 +224,37 @@ func TestFromCluster(t *testing.T) {
 		},
 		{
 			desc: "baseline",
-			in: &redskyv1beta1.Experiment{
-				Spec: redskyv1beta1.ExperimentSpec{
-					Parameters: []redskyv1beta1.Parameter{
+			in: &optimizev1beta1.Experiment{
+				Spec: optimizev1beta1.ExperimentSpec{
+					Parameters: []optimizev1beta1.Parameter{
 						{Name: "one", Min: 0, Max: 1, Baseline: &one},
 						{Name: "two", Min: 0, Max: 2, Baseline: &two},
 						{Name: "three", Values: []string{"three"}, Baseline: &three},
 					},
 				},
 			},
-			out: &redskyapi.Experiment{
-				Parameters: []redskyapi.Parameter{
+			out: &experimentsv1alpha1.Experiment{
+				Parameters: []experimentsv1alpha1.Parameter{
 					{
-						Type:   redskyapi.ParameterTypeInteger,
+						Type:   experimentsv1alpha1.ParameterTypeInteger,
 						Name:   "one",
-						Bounds: &redskyapi.Bounds{Min: "0", Max: "1"},
+						Bounds: &experimentsv1alpha1.Bounds{Min: "0", Max: "1"},
 					},
 					{
-						Type:   redskyapi.ParameterTypeInteger,
+						Type:   experimentsv1alpha1.ParameterTypeInteger,
 						Name:   "two",
-						Bounds: &redskyapi.Bounds{Min: "0", Max: "2"},
+						Bounds: &experimentsv1alpha1.Bounds{Min: "0", Max: "2"},
 					},
 					{
-						Type:   redskyapi.ParameterTypeCategorical,
+						Type:   experimentsv1alpha1.ParameterTypeCategorical,
 						Name:   "three",
 						Values: []string{"three"},
 					},
 				},
 			},
-			baseline: &redskyapi.TrialAssignments{
+			baseline: &experimentsv1alpha1.TrialAssignments{
 				Labels: map[string]string{"baseline": "true"},
-				Assignments: []redskyapi.Assignment{
+				Assignments: []experimentsv1alpha1.Assignment{
 					{ParameterName: "one", Value: numstr.FromInt64(1)},
 					{ParameterName: "two", Value: numstr.FromInt64(2)},
 					{ParameterName: "three", Value: numstr.FromString("three")},
@@ -277,40 +277,40 @@ func TestFromCluster(t *testing.T) {
 func TestToCluster(t *testing.T) {
 	cases := []struct {
 		desc   string
-		exp    *redskyv1beta1.Experiment
-		ee     *redskyapi.Experiment
-		expOut *redskyv1beta1.Experiment
+		exp    *optimizev1beta1.Experiment
+		ee     *experimentsv1alpha1.Experiment
+		expOut *optimizev1beta1.Experiment
 	}{
 		{
 			desc: "basic",
-			exp: &redskyv1beta1.Experiment{
+			exp: &optimizev1beta1.Experiment{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: nil,
 				},
 			},
-			ee: &redskyapi.Experiment{
-				ExperimentMeta: redskyapi.ExperimentMeta{
+			ee: &experimentsv1alpha1.Experiment{
+				ExperimentMeta: experimentsv1alpha1.ExperimentMeta{
 					SelfURL:      "self_111",
 					NextTrialURL: "next_trial_111",
 				},
-				Optimization: []redskyapi.Optimization{
+				Optimization: []experimentsv1alpha1.Optimization{
 					{Name: "one", Value: "111"},
 					{Name: "two", Value: "222"},
 					{Name: "three", Value: "333"},
 				},
 			},
-			expOut: &redskyv1beta1.Experiment{
+			expOut: &optimizev1beta1.Experiment{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						redskyv1beta1.AnnotationExperimentURL: "self_111",
-						redskyv1beta1.AnnotationNextTrialURL:  "next_trial_111",
+						optimizev1beta1.AnnotationExperimentURL: "self_111",
+						optimizev1beta1.AnnotationNextTrialURL:  "next_trial_111",
 					},
 					Finalizers: []string{
 						Finalizer,
 					},
 				},
-				Spec: redskyv1beta1.ExperimentSpec{
-					Optimization: []redskyv1beta1.Optimization{
+				Spec: optimizev1beta1.ExperimentSpec{
+					Optimization: []optimizev1beta1.Optimization{
 						{Name: "one", Value: "111"},
 						{Name: "two", Value: "222"},
 						{Name: "three", Value: "333"},
@@ -330,45 +330,45 @@ func TestToCluster(t *testing.T) {
 func TestToClusterTrial(t *testing.T) {
 	cases := []struct {
 		desc       string
-		trial      *redskyv1beta1.Trial
-		suggestion *redskyapi.TrialAssignments
-		trialOut   *redskyv1beta1.Trial
+		trial      *optimizev1beta1.Trial
+		suggestion *experimentsv1alpha1.TrialAssignments
+		trialOut   *optimizev1beta1.Trial
 	}{
 		{
 			desc: "empty name with generate name",
-			trial: &redskyv1beta1.Trial{
+			trial: &optimizev1beta1.Trial{
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "generate_name",
 					Annotations:  map[string]string{},
 				},
 			},
-			suggestion: &redskyapi.TrialAssignments{
-				TrialMeta: redskyapi.TrialMeta{
+			suggestion: &experimentsv1alpha1.TrialAssignments{
+				TrialMeta: experimentsv1alpha1.TrialMeta{
 					SelfURL: "some/path/1",
 				},
-				Assignments: []redskyapi.Assignment{
+				Assignments: []experimentsv1alpha1.Assignment{
 					{ParameterName: "one", Value: numstr.FromInt64(111)},
 					{ParameterName: "two", Value: numstr.FromInt64(222)},
 					{ParameterName: "three", Value: numstr.FromInt64(333)},
 				},
 			},
-			trialOut: &redskyv1beta1.Trial{
+			trialOut: &optimizev1beta1.Trial{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:         "generate_name001",
 					GenerateName: "generate_name",
 					Annotations: map[string]string{
-						redskyv1beta1.AnnotationReportTrialURL: "some/path/1",
+						optimizev1beta1.AnnotationReportTrialURL: "some/path/1",
 					},
 					Finalizers: []string{
 						Finalizer,
 					},
 				},
-				Status: redskyv1beta1.TrialStatus{
+				Status: optimizev1beta1.TrialStatus{
 					Phase:       "Created",
 					Assignments: "one=111, two=222, three=333",
 				},
-				Spec: redskyv1beta1.TrialSpec{
-					Assignments: []redskyv1beta1.Assignment{
+				Spec: optimizev1beta1.TrialSpec{
+					Assignments: []optimizev1beta1.Assignment{
 						{Name: "one", Value: intstr.FromInt(111)},
 						{Name: "two", Value: intstr.FromInt(222)},
 						{Name: "three", Value: intstr.FromInt(333)},
@@ -378,39 +378,39 @@ func TestToClusterTrial(t *testing.T) {
 		},
 		{
 			desc: "name with generate name",
-			trial: &redskyv1beta1.Trial{
+			trial: &optimizev1beta1.Trial{
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "generate_name",
 					Annotations:  map[string]string{},
 				},
 			},
-			suggestion: &redskyapi.TrialAssignments{
-				TrialMeta: redskyapi.TrialMeta{
+			suggestion: &experimentsv1alpha1.TrialAssignments{
+				TrialMeta: experimentsv1alpha1.TrialMeta{
 					SelfURL: "some/path/one",
 				},
-				Assignments: []redskyapi.Assignment{
+				Assignments: []experimentsv1alpha1.Assignment{
 					{ParameterName: "one", Value: numstr.FromInt64(111)},
 					{ParameterName: "two", Value: numstr.FromInt64(222)},
 					{ParameterName: "three", Value: numstr.FromInt64(333)},
 				},
 			},
-			trialOut: &redskyv1beta1.Trial{
+			trialOut: &optimizev1beta1.Trial{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:         "generate_nameone",
 					GenerateName: "generate_name",
 					Annotations: map[string]string{
-						redskyv1beta1.AnnotationReportTrialURL: "some/path/one",
+						optimizev1beta1.AnnotationReportTrialURL: "some/path/one",
 					},
 					Finalizers: []string{
 						Finalizer,
 					},
 				},
-				Status: redskyv1beta1.TrialStatus{
+				Status: optimizev1beta1.TrialStatus{
 					Phase:       "Created",
 					Assignments: "one=111, two=222, three=333",
 				},
-				Spec: redskyv1beta1.TrialSpec{
-					Assignments: []redskyv1beta1.Assignment{
+				Spec: optimizev1beta1.TrialSpec{
+					Assignments: []optimizev1beta1.Assignment{
 						{Name: "one", Value: intstr.FromInt(111)},
 						{Name: "two", Value: intstr.FromInt(222)},
 						{Name: "three", Value: intstr.FromInt(333)},
@@ -420,29 +420,29 @@ func TestToClusterTrial(t *testing.T) {
 		},
 		{
 			desc: "32bit overflow",
-			trial: &redskyv1beta1.Trial{
+			trial: &optimizev1beta1.Trial{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{},
 				},
 			},
-			suggestion: &redskyapi.TrialAssignments{
-				Assignments: []redskyapi.Assignment{
+			suggestion: &experimentsv1alpha1.TrialAssignments{
+				Assignments: []experimentsv1alpha1.Assignment{
 					{ParameterName: "overflow", Value: numstr.FromInt64(math.MaxInt64)},
 				},
 			},
-			trialOut: &redskyv1beta1.Trial{
+			trialOut: &optimizev1beta1.Trial{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						"redskyops.dev/report-trial-url": "",
 					},
 					Finalizers: []string{"serverFinalizer.redskyops.dev"},
 				},
-				Spec: redskyv1beta1.TrialSpec{
-					Assignments: []redskyv1beta1.Assignment{
+				Spec: optimizev1beta1.TrialSpec{
+					Assignments: []optimizev1beta1.Assignment{
 						{Name: "overflow", Value: intstr.FromInt(math.MaxInt32)},
 					},
 				},
-				Status: redskyv1beta1.TrialStatus{
+				Status: optimizev1beta1.TrialStatus{
 					Phase:       "Created",
 					Assignments: fmt.Sprintf("overflow=%d", math.MaxInt32),
 				},
@@ -460,37 +460,37 @@ func TestToClusterTrial(t *testing.T) {
 func TestFromClusterTrial(t *testing.T) {
 	cases := []struct {
 		desc        string
-		experiment  redskyv1beta1.Experiment
-		trial       redskyv1beta1.Trial
-		expectedOut *redskyapi.TrialValues
+		experiment  optimizev1beta1.Experiment
+		trial       optimizev1beta1.Trial
+		expectedOut *experimentsv1alpha1.TrialValues
 	}{
 		{
 			desc: "no conditions",
-			trial: redskyv1beta1.Trial{
-				Status: redskyv1beta1.TrialStatus{
-					Conditions: []redskyv1beta1.TrialCondition{},
+			trial: optimizev1beta1.Trial{
+				Status: optimizev1beta1.TrialStatus{
+					Conditions: []optimizev1beta1.TrialCondition{},
 				},
 			},
-			expectedOut: &redskyapi.TrialValues{},
+			expectedOut: &experimentsv1alpha1.TrialValues{},
 		},
 		{
 			desc: "not failed",
-			trial: redskyv1beta1.Trial{
-				Status: redskyv1beta1.TrialStatus{
-					Conditions: []redskyv1beta1.TrialCondition{
-						{Type: redskyv1beta1.TrialComplete, Status: corev1.ConditionTrue},
+			trial: optimizev1beta1.Trial{
+				Status: optimizev1beta1.TrialStatus{
+					Conditions: []optimizev1beta1.TrialCondition{
+						{Type: optimizev1beta1.TrialComplete, Status: corev1.ConditionTrue},
 					},
 				},
 			},
-			expectedOut: &redskyapi.TrialValues{},
+			expectedOut: &experimentsv1alpha1.TrialValues{},
 		},
 		{
 			desc: "failed",
-			trial: redskyv1beta1.Trial{
-				Status: redskyv1beta1.TrialStatus{
-					Conditions: []redskyv1beta1.TrialCondition{
+			trial: optimizev1beta1.Trial{
+				Status: optimizev1beta1.TrialStatus{
+					Conditions: []optimizev1beta1.TrialCondition{
 						{
-							Type:    redskyv1beta1.TrialFailed,
+							Type:    optimizev1beta1.TrialFailed,
 							Status:  corev1.ConditionTrue,
 							Reason:  corev1.PodReasonUnschedulable,
 							Message: "0/3 nodes are available: 3 Insufficient cpu.",
@@ -498,7 +498,7 @@ func TestFromClusterTrial(t *testing.T) {
 					},
 				},
 			},
-			expectedOut: &redskyapi.TrialValues{
+			expectedOut: &experimentsv1alpha1.TrialValues{
 				Failed:         true,
 				FailureReason:  corev1.PodReasonUnschedulable,
 				FailureMessage: "0/3 nodes are available: 3 Insufficient cpu.",
@@ -506,22 +506,22 @@ func TestFromClusterTrial(t *testing.T) {
 		},
 		{
 			desc: "conditions not failed",
-			trial: redskyv1beta1.Trial{
-				Status: redskyv1beta1.TrialStatus{
-					Conditions: []redskyv1beta1.TrialCondition{
-						{Type: redskyv1beta1.TrialComplete, Status: corev1.ConditionTrue},
+			trial: optimizev1beta1.Trial{
+				Status: optimizev1beta1.TrialStatus{
+					Conditions: []optimizev1beta1.TrialCondition{
+						{Type: optimizev1beta1.TrialComplete, Status: corev1.ConditionTrue},
 					},
 				},
-				Spec: redskyv1beta1.TrialSpec{
-					Values: []redskyv1beta1.Value{
+				Spec: optimizev1beta1.TrialSpec{
+					Values: []optimizev1beta1.Value{
 						{Name: "one", Value: "111.111", Error: "1111.1111"},
 						{Name: "two", Value: "222.222", Error: "2222.2222"},
 						{Name: "three", Value: "333.333", Error: "3333.3333"},
 					},
 				},
 			},
-			expectedOut: &redskyapi.TrialValues{
-				Values: []redskyapi.Value{
+			expectedOut: &experimentsv1alpha1.TrialValues{
+				Values: []experimentsv1alpha1.Value{
 					{MetricName: "one", Value: 111.111, Error: 1111.1111},
 					{MetricName: "two", Value: 222.222, Error: 2222.2222},
 					{MetricName: "three", Value: 333.333, Error: 3333.3333},
@@ -540,49 +540,49 @@ func TestFromClusterTrial(t *testing.T) {
 func TestStopExperiment(t *testing.T) {
 	cases := []struct {
 		desc        string
-		exp         *redskyv1beta1.Experiment
+		exp         *optimizev1beta1.Experiment
 		err         error
 		expectedOut bool
-		expectedExp *redskyv1beta1.Experiment
+		expectedExp *optimizev1beta1.Experiment
 	}{
 		{
 			desc: "no error",
-			exp: &redskyv1beta1.Experiment{
+			exp: &optimizev1beta1.Experiment{
 				ObjectMeta: metav1.ObjectMeta{},
 			},
 			err:         nil,
 			expectedOut: false,
-			expectedExp: &redskyv1beta1.Experiment{
+			expectedExp: &optimizev1beta1.Experiment{
 				ObjectMeta: metav1.ObjectMeta{},
 			},
 		},
 		{
 			desc: "error wrong type",
-			exp: &redskyv1beta1.Experiment{
+			exp: &optimizev1beta1.Experiment{
 				ObjectMeta: metav1.ObjectMeta{},
 			},
-			err: &redskyapi.Error{
-				Type: redskyapi.ErrExperimentNameInvalid,
+			err: &experimentsv1alpha1.Error{
+				Type: experimentsv1alpha1.ErrExperimentNameInvalid,
 			},
 			expectedOut: false,
-			expectedExp: &redskyv1beta1.Experiment{
+			expectedExp: &optimizev1beta1.Experiment{
 				ObjectMeta: metav1.ObjectMeta{},
 			},
 		},
 		{
 			desc: "error",
-			exp: &redskyv1beta1.Experiment{
+			exp: &optimizev1beta1.Experiment{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						redskyv1beta1.AnnotationNextTrialURL: "111",
+						optimizev1beta1.AnnotationNextTrialURL: "111",
 					},
 				},
 			},
-			err: &redskyapi.Error{
-				Type: redskyapi.ErrExperimentStopped,
+			err: &experimentsv1alpha1.Error{
+				Type: experimentsv1alpha1.ErrExperimentStopped,
 			},
 			expectedOut: true,
-			expectedExp: &redskyv1beta1.Experiment{
+			expectedExp: &optimizev1beta1.Experiment{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{},
 				},

--- a/internal/setup/job.go
+++ b/internal/setup/job.go
@@ -22,7 +22,7 @@ import (
 	"os"
 	"path"
 
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	"github.com/thestormforge/optimize-controller/v2/internal/template"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -48,20 +48,20 @@ var (
 // Finally, when using digests, the default of "IfNotPresent" is acceptable as it is unambiguous.
 
 // NewJob returns a new setup job for either create or delete
-func NewJob(t *redskyv1beta1.Trial, mode string) (*batchv1.Job, error) {
+func NewJob(t *optimizev1beta1.Trial, mode string) (*batchv1.Job, error) {
 	job := &batchv1.Job{}
 	job.Namespace = t.Namespace
 	job.Name = fmt.Sprintf("%s-%s", t.Name, mode)
 	job.Labels = map[string]string{
-		redskyv1beta1.LabelExperiment: t.ExperimentNamespacedName().Name,
-		redskyv1beta1.LabelTrial:      t.Name,
-		redskyv1beta1.LabelTrialRole:  "trialSetup",
+		optimizev1beta1.LabelExperiment: t.ExperimentNamespacedName().Name,
+		optimizev1beta1.LabelTrial:      t.Name,
+		optimizev1beta1.LabelTrialRole:  "trialSetup",
 	}
 	job.Spec.BackoffLimit = new(int32)
 	job.Spec.Template.Labels = map[string]string{
-		redskyv1beta1.LabelExperiment: t.ExperimentNamespacedName().Name,
-		redskyv1beta1.LabelTrial:      t.Name,
-		redskyv1beta1.LabelTrialRole:  "trialSetup",
+		optimizev1beta1.LabelExperiment: t.ExperimentNamespacedName().Name,
+		optimizev1beta1.LabelTrial:      t.Name,
+		optimizev1beta1.LabelTrialRole:  "trialSetup",
 	}
 	job.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyNever
 	job.Spec.Template.Spec.ServiceAccountName = t.Spec.SetupServiceAccountName
@@ -235,7 +235,7 @@ type helmGeneratorConfig struct {
 	Values            []helmGeneratorValue `json:"values"`
 }
 
-func newHelmGeneratorConfig(task *redskyv1beta1.SetupTask) *helmGeneratorConfig {
+func newHelmGeneratorConfig(task *optimizev1beta1.SetupTask) *helmGeneratorConfig {
 	if task.HelmChart == "" {
 		return nil
 	}

--- a/internal/setup/job_test.go
+++ b/internal/setup/job_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	redsky "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	"github.com/thestormforge/optimize-controller/v2/internal/setup"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -29,31 +29,31 @@ import (
 func TestNewJob(t *testing.T) {
 	testCases := []struct {
 		desc    string
-		trial   *redsky.Trial
+		trial   *optimizev1beta1.Trial
 		args    []string
 		command []string
 	}{
 		{
 			desc: "default",
-			trial: &redsky.Trial{
+			trial: &optimizev1beta1.Trial{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test",
 					Namespace: "default",
 				},
-				Spec: redsky.TrialSpec{
-					SetupTasks: []redsky.SetupTask{},
+				Spec: optimizev1beta1.TrialSpec{
+					SetupTasks: []optimizev1beta1.SetupTask{},
 				},
 			},
 		},
 		{
 			desc: "default with args",
-			trial: &redsky.Trial{
+			trial: &optimizev1beta1.Trial{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test",
 					Namespace: "default",
 				},
-				Spec: redsky.TrialSpec{
-					SetupTasks: []redsky.SetupTask{
+				Spec: optimizev1beta1.TrialSpec{
+					SetupTasks: []optimizev1beta1.SetupTask{
 						{
 							Args: []string{"fun", "setup"},
 						},
@@ -63,13 +63,13 @@ func TestNewJob(t *testing.T) {
 		},
 		{
 			desc: "default with command and image",
-			trial: &redsky.Trial{
+			trial: &optimizev1beta1.Trial{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test",
 					Namespace: "default",
 				},
-				Spec: redsky.TrialSpec{
-					SetupTasks: []redsky.SetupTask{
+				Spec: optimizev1beta1.TrialSpec{
+					SetupTasks: []optimizev1beta1.SetupTask{
 						{
 							Image:   "whyis6afraidof7:because789",
 							Command: []string{"fun", "setup"},

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strings"
 
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -39,7 +39,7 @@ const (
 )
 
 // UpdateStatus returns true if there are setup tasks
-func UpdateStatus(t *redskyv1beta1.Trial, probeTime *metav1.Time) bool {
+func UpdateStatus(t *optimizev1beta1.Trial, probeTime *metav1.Time) bool {
 	var needsCreate, needsDelete bool
 	for _, task := range t.Spec.SetupTasks {
 		needsCreate = needsCreate || !task.SkipCreate
@@ -54,18 +54,18 @@ func UpdateStatus(t *redskyv1beta1.Trial, probeTime *metav1.Time) bool {
 	// TODO Can we return false from this here as an optimization if both status are True?
 	for i := range t.Status.Conditions {
 		switch t.Status.Conditions[i].Type {
-		case redskyv1beta1.TrialSetupCreated:
+		case optimizev1beta1.TrialSetupCreated:
 			t.Status.Conditions[i].LastProbeTime = *probeTime
 			needsCreate = false
-		case redskyv1beta1.TrialSetupDeleted:
+		case optimizev1beta1.TrialSetupDeleted:
 			t.Status.Conditions[i].LastProbeTime = *probeTime
 			needsDelete = false
 		}
 	}
 
 	if needsCreate {
-		t.Status.Conditions = append(t.Status.Conditions, redskyv1beta1.TrialCondition{
-			Type:               redskyv1beta1.TrialSetupCreated,
+		t.Status.Conditions = append(t.Status.Conditions, optimizev1beta1.TrialCondition{
+			Type:               optimizev1beta1.TrialSetupCreated,
 			Status:             corev1.ConditionUnknown,
 			LastProbeTime:      *probeTime,
 			LastTransitionTime: *probeTime,
@@ -73,8 +73,8 @@ func UpdateStatus(t *redskyv1beta1.Trial, probeTime *metav1.Time) bool {
 	}
 
 	if needsDelete {
-		t.Status.Conditions = append(t.Status.Conditions, redskyv1beta1.TrialCondition{
-			Type:               redskyv1beta1.TrialSetupDeleted,
+		t.Status.Conditions = append(t.Status.Conditions, optimizev1beta1.TrialCondition{
+			Type:               optimizev1beta1.TrialSetupDeleted,
 			Status:             corev1.ConditionUnknown,
 			LastProbeTime:      *probeTime,
 			LastTransitionTime: *probeTime,
@@ -86,7 +86,7 @@ func UpdateStatus(t *redskyv1beta1.Trial, probeTime *metav1.Time) bool {
 }
 
 // GetTrialConditionType returns the trial condition type used to report status for the specified job
-func GetTrialConditionType(j *batchv1.Job) (redskyv1beta1.TrialConditionType, error) {
+func GetTrialConditionType(j *batchv1.Job) (optimizev1beta1.TrialConditionType, error) {
 	for _, c := range j.Spec.Template.Spec.Containers {
 		for _, env := range c.Env {
 			if env.Name != "MODE" {
@@ -95,9 +95,9 @@ func GetTrialConditionType(j *batchv1.Job) (redskyv1beta1.TrialConditionType, er
 
 			switch env.Value {
 			case ModeCreate:
-				return redskyv1beta1.TrialSetupCreated, nil
+				return optimizev1beta1.TrialSetupCreated, nil
 			case ModeDelete:
-				return redskyv1beta1.TrialSetupDeleted, nil
+				return optimizev1beta1.TrialSetupDeleted, nil
 			default:
 				return "", fmt.Errorf("unknown setup job container argument: %s", c.Args[0])
 			}
@@ -145,7 +145,7 @@ func GetConditionStatus(j *batchv1.Job) (corev1.ConditionStatus, string) {
 }
 
 // AppendAssignmentEnv appends an environment variable for each trial assignment
-func AppendAssignmentEnv(t *redskyv1beta1.Trial, env []corev1.EnvVar) []corev1.EnvVar {
+func AppendAssignmentEnv(t *optimizev1beta1.Trial, env []corev1.EnvVar) []corev1.EnvVar {
 	for _, a := range t.Spec.Assignments {
 		name := strings.ReplaceAll(strings.ToUpper(a.Name), ".", "_")
 		env = append(env, corev1.EnvVar{Name: name, Value: a.Value.String()})
@@ -155,7 +155,7 @@ func AppendAssignmentEnv(t *redskyv1beta1.Trial, env []corev1.EnvVar) []corev1.E
 }
 
 // AppendPrometheusEnv appends environment variables to help reference the built in Prometheus
-func AppendPrometheusEnv(t *redskyv1beta1.Trial, env []corev1.EnvVar) []corev1.EnvVar {
+func AppendPrometheusEnv(t *optimizev1beta1.Trial, env []corev1.EnvVar) []corev1.EnvVar {
 	for i := range t.Spec.SetupTasks {
 		if IsPrometheusSetupTask(&t.Spec.SetupTasks[i]) {
 			url := fmt.Sprintf("http://redsky-%s-prometheus:9091/metrics/job/%s/instance/%s", t.Namespace, "trialRun", t.Name)
@@ -167,7 +167,7 @@ func AppendPrometheusEnv(t *redskyv1beta1.Trial, env []corev1.EnvVar) []corev1.E
 }
 
 // IsPrometheusSetupTask checks to see if the supplied setup task is for the built-in Prometheus.
-func IsPrometheusSetupTask(st *redskyv1beta1.SetupTask) bool {
+func IsPrometheusSetupTask(st *optimizev1beta1.SetupTask) bool {
 	// Needs to be the default image
 	if st.Image != "" && st.Image != Image {
 		return false

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	redsky "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	"github.com/thestormforge/optimize-controller/v2/internal/setup"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -32,7 +32,7 @@ func TestGetTrialConditionType(t *testing.T) {
 		desc          string
 		job           *batchv1.Job
 		expectedError bool
-		conditionType redsky.TrialConditionType
+		conditionType optimizev1beta1.TrialConditionType
 	}{
 		{
 			desc: "no mode",
@@ -71,7 +71,7 @@ func TestGetTrialConditionType(t *testing.T) {
 					},
 				},
 			},
-			conditionType: redsky.TrialSetupCreated,
+			conditionType: optimizev1beta1.TrialSetupCreated,
 			expectedError: false,
 		},
 		{
@@ -94,7 +94,7 @@ func TestGetTrialConditionType(t *testing.T) {
 					},
 				},
 			},
-			conditionType: redsky.TrialSetupDeleted,
+			conditionType: optimizev1beta1.TrialSetupDeleted,
 			expectedError: false,
 		},
 	}

--- a/internal/sfio/migrate.go
+++ b/internal/sfio/migrate.go
@@ -21,8 +21,8 @@ import (
 	"strings"
 
 	"github.com/thestormforge/konjure/pkg/filters"
-	redskyv1alpha1 "github.com/thestormforge/optimize-controller/v2/api/v1alpha1"
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizev1alpha1 "github.com/thestormforge/optimize-controller/v2/api/v1alpha1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
@@ -37,8 +37,8 @@ func (f *ExperimentMigrationFilter) Filter(node *yaml.RNode) (*yaml.RNode, error
 	return node.Pipe(
 		yaml.Tee(
 			filters.FilterOne(&filters.ResourceMetaFilter{
-				Group:   redskyv1alpha1.GroupVersion.Group,
-				Version: redskyv1alpha1.GroupVersion.Version,
+				Group:   optimizev1alpha1.GroupVersion.Group,
+				Version: optimizev1alpha1.GroupVersion.Version,
 				Kind:    "Experiment",
 			}),
 			yaml.FilterFunc(f.MigrateExperimentV1alpha1),
@@ -46,8 +46,8 @@ func (f *ExperimentMigrationFilter) Filter(node *yaml.RNode) (*yaml.RNode, error
 
 		yaml.Tee(
 			filters.FilterOne(&filters.ResourceMetaFilter{
-				Group:   redskyv1beta1.GroupVersion.Group,
-				Version: redskyv1beta1.GroupVersion.Version,
+				Group:   optimizev1beta1.GroupVersion.Group,
+				Version: optimizev1beta1.GroupVersion.Version,
 				Kind:    "Experiment",
 			}),
 			yaml.FilterFunc(f.MigrateExperimentV1beta1),
@@ -88,7 +88,7 @@ func (f *ExperimentMigrationFilter) MigrateExperimentV1alpha1(node *yaml.RNode) 
 
 		// Finally, set the apiVersion
 		yaml.Tee(
-			yaml.SetField("apiVersion", yaml.NewStringRNode(redskyv1beta1.GroupVersion.String())),
+			yaml.SetField("apiVersion", yaml.NewStringRNode(optimizev1beta1.GroupVersion.String())),
 		),
 	)
 }
@@ -132,7 +132,7 @@ func (f *ExperimentMigrationFilter) migrateMetricsV1alpha1(node *yaml.RNode) (*y
 			// Change metric type "local" to "kubernetes"
 			yaml.Tee(
 				yaml.MatchField("type", "local"),
-				yaml.Set(yaml.NewStringRNode(string(redskyv1beta1.MetricKubernetes))),
+				yaml.Set(yaml.NewStringRNode(string(optimizev1beta1.MetricKubernetes))),
 			),
 
 			// Change type "pods" to "" and add "target: { kind: PodList }"
@@ -194,7 +194,7 @@ func (m *metric) setURLField(name string) yaml.Filter {
 
 	u := url.URL{
 		Scheme: m.Scheme,
-		Host:   redskyv1alpha1.LegacyHostnamePlaceholder,
+		Host:   optimizev1alpha1.LegacyHostnamePlaceholder,
 		Path:   m.Path,
 	}
 

--- a/internal/sfio/order.go
+++ b/internal/sfio/order.go
@@ -20,17 +20,17 @@ import (
 	"reflect"
 	"strings"
 
-	redskyappsv1alpha1 "github.com/thestormforge/optimize-controller/v2/api/apps/v1alpha1"
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizeappsv1alpha1 "github.com/thestormforge/optimize-controller/v2/api/apps/v1alpha1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
 func init() {
-	addFieldOrder(&redskyv1beta1.ExperimentSpec{}, 200)
-	addFieldOrder(&redskyv1beta1.Parameter{}, 300)
-	addFieldOrder(&redskyv1beta1.PatchTemplate{}, 400)
-	addFieldOrder(&redskyv1beta1.Metric{}, 500)
-	addFieldOrder(&redskyappsv1alpha1.Application{}, 600)
+	addFieldOrder(&optimizev1beta1.ExperimentSpec{}, 200)
+	addFieldOrder(&optimizev1beta1.Parameter{}, 300)
+	addFieldOrder(&optimizev1beta1.PatchTemplate{}, 400)
+	addFieldOrder(&optimizev1beta1.Metric{}, 500)
+	addFieldOrder(&optimizeappsv1alpha1.Application{}, 600)
 }
 
 // addFieldOrder use reflection to try and make the YAML sort order match the Go struct field order.

--- a/internal/sfio/runtime.go
+++ b/internal/sfio/runtime.go
@@ -17,9 +17,9 @@ limitations under the License.
 package sfio
 
 import (
-	redskyappsv1alpha1 "github.com/thestormforge/optimize-controller/v2/api/apps/v1alpha1"
-	redskyv1alpha1 "github.com/thestormforge/optimize-controller/v2/api/v1alpha1"
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizeappsv1alpha1 "github.com/thestormforge/optimize-controller/v2/api/apps/v1alpha1"
+	optimizev1alpha1 "github.com/thestormforge/optimize-controller/v2/api/v1alpha1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -43,9 +43,9 @@ var Scheme = runtime.NewScheme()
 
 func init() {
 	_ = clientgoscheme.AddToScheme(Scheme)
-	_ = redskyv1alpha1.AddToScheme(Scheme)
-	_ = redskyv1beta1.AddToScheme(Scheme)
-	_ = redskyappsv1alpha1.AddToScheme(Scheme)
+	_ = optimizev1alpha1.AddToScheme(Scheme)
+	_ = optimizev1beta1.AddToScheme(Scheme)
+	_ = optimizeappsv1alpha1.AddToScheme(Scheme)
 }
 
 // ObjectSlices allows a slice of object instances to be read as resource nodes.

--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -23,7 +23,7 @@ import (
 	"text/template"
 	"time"
 
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -41,7 +41,7 @@ type PatchData struct {
 // MetricData represents a trial during metric evaluation
 type MetricData struct {
 	// Trial is a copy of the trial being evaluated.
-	Trial *redskyv1beta1.Trial
+	Trial *optimizev1beta1.Trial
 	// Target is the object matched by the resource target of a Kubernetes metric.
 	Target runtime.Object
 
@@ -61,7 +61,7 @@ func (m *MetricData) Pods() runtime.Object {
 	return m.Target
 }
 
-func newPatchData(t *redskyv1beta1.Trial) *PatchData {
+func newPatchData(t *optimizev1beta1.Trial) *PatchData {
 	d := &PatchData{}
 
 	t.ObjectMeta.DeepCopyInto(&d.Trial)
@@ -78,7 +78,7 @@ func newPatchData(t *redskyv1beta1.Trial) *PatchData {
 	return d
 }
 
-func newMetricData(t *redskyv1beta1.Trial, target runtime.Object) *MetricData {
+func newMetricData(t *optimizev1beta1.Trial, target runtime.Object) *MetricData {
 	d := &MetricData{
 		Trial:  t.DeepCopy(),
 		Target: target,
@@ -123,7 +123,7 @@ func New() *Engine {
 // of patch templates or metrics (or the experiment itself, trial for HelmValues) and then render the individual values by template name?
 
 // RenderPatch returns the JSON representation of the supplied patch template (input can be a Go template that produces YAML)
-func (e *Engine) RenderPatch(patch *redskyv1beta1.PatchTemplate, trial *redskyv1beta1.Trial) ([]byte, error) {
+func (e *Engine) RenderPatch(patch *optimizev1beta1.PatchTemplate, trial *optimizev1beta1.Trial) ([]byte, error) {
 	data := newPatchData(trial)
 	b, err := e.render("patch", patch.Patch, data) // TODO What should we use for patch template names? Something from the targetRef?
 	if err != nil {
@@ -133,7 +133,7 @@ func (e *Engine) RenderPatch(patch *redskyv1beta1.PatchTemplate, trial *redskyv1
 }
 
 // RenderHelmValue returns a rendered string of the supplied Helm value
-func (e *Engine) RenderHelmValue(helmValue *redskyv1beta1.HelmValue, trial *redskyv1beta1.Trial) (string, error) {
+func (e *Engine) RenderHelmValue(helmValue *optimizev1beta1.HelmValue, trial *optimizev1beta1.Trial) (string, error) {
 	data := newPatchData(trial)
 	b, err := e.render(helmValue.Name, helmValue.Value.String(), data)
 	if err != nil {
@@ -143,7 +143,7 @@ func (e *Engine) RenderHelmValue(helmValue *redskyv1beta1.HelmValue, trial *reds
 }
 
 // RenderMetricQueries returns the metric query and the metric error query
-func (e *Engine) RenderMetricQueries(metric *redskyv1beta1.Metric, trial *redskyv1beta1.Trial, target runtime.Object) (string, string, error) {
+func (e *Engine) RenderMetricQueries(metric *optimizev1beta1.Metric, trial *optimizev1beta1.Trial, target runtime.Object) (string, string, error) {
 	data := newMetricData(trial, target)
 	b1, err := e.render(metric.Name, metric.Query, data)
 	if err != nil {

--- a/internal/template/template_test.go
+++ b/internal/template/template_test.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,13 +34,13 @@ func TestEngine_RenderPatch(t *testing.T) {
 
 	cases := []struct {
 		desc          string
-		patchTemplate redskyv1beta1.PatchTemplate
-		trial         redskyv1beta1.Trial
+		patchTemplate optimizev1beta1.PatchTemplate
+		trial         optimizev1beta1.Trial
 		expected      []byte
 	}{
 		{
 			desc: "static patch",
-			patchTemplate: redskyv1beta1.PatchTemplate{
+			patchTemplate: optimizev1beta1.PatchTemplate{
 				Patch: "metadata:\n  labels:\n    app: testApp\n",
 				TargetRef: &corev1.ObjectReference{
 					Kind:       "Pod",
@@ -54,12 +54,12 @@ func TestEngine_RenderPatch(t *testing.T) {
 
 		{
 			desc: "numeric assignment",
-			patchTemplate: redskyv1beta1.PatchTemplate{
+			patchTemplate: optimizev1beta1.PatchTemplate{
 				Patch: "spec:\n  replicas: {{ .Values.replicas }}\n",
 			},
-			trial: redskyv1beta1.Trial{
-				Spec: redskyv1beta1.TrialSpec{
-					Assignments: []redskyv1beta1.Assignment{
+			trial: optimizev1beta1.Trial{
+				Spec: optimizev1beta1.TrialSpec{
+					Assignments: []optimizev1beta1.Assignment{
 						{
 							Name:  "replicas",
 							Value: intstr.FromInt(2),
@@ -85,13 +85,13 @@ func TestEngine_RenderHelmValue(t *testing.T) {
 
 	cases := []struct {
 		desc      string
-		helmValue redskyv1beta1.HelmValue
-		trial     redskyv1beta1.Trial
+		helmValue optimizev1beta1.HelmValue
+		trial     optimizev1beta1.Trial
 		expected  string
 	}{
 		{
 			desc: "static string",
-			helmValue: redskyv1beta1.HelmValue{
+			helmValue: optimizev1beta1.HelmValue{
 				Value: intstr.FromString("testing"),
 			},
 			expected: "testing",
@@ -113,20 +113,20 @@ func TestEngine_RenderMetricQueries(t *testing.T) {
 
 	cases := []struct {
 		desc               string
-		metric             redskyv1beta1.Metric
-		trial              redskyv1beta1.Trial
+		metric             optimizev1beta1.Metric
+		trial              optimizev1beta1.Trial
 		target             runtime.Object
 		expectedQuery      string
 		expectedErrorQuery string
 	}{
 		{
 			desc: "function duration",
-			metric: redskyv1beta1.Metric{
+			metric: optimizev1beta1.Metric{
 				Name:  "testMetric",
 				Query: "{{duration .StartTime .CompletionTime}}",
 			},
-			trial: redskyv1beta1.Trial{
-				Status: redskyv1beta1.TrialStatus{
+			trial: optimizev1beta1.Trial{
+				Status: optimizev1beta1.TrialStatus{
 					StartTime:      &metav1.Time{Time: now.Add(-5 * time.Second)},
 					CompletionTime: &now,
 				},
@@ -137,13 +137,13 @@ func TestEngine_RenderMetricQueries(t *testing.T) {
 
 		{
 			desc: "function percent",
-			metric: redskyv1beta1.Metric{
+			metric: optimizev1beta1.Metric{
 				Name:  "testMetric",
 				Query: "{{percent .Values.test 5}}",
 			},
-			trial: redskyv1beta1.Trial{
-				Spec: redskyv1beta1.TrialSpec{
-					Assignments: []redskyv1beta1.Assignment{
+			trial: optimizev1beta1.Trial{
+				Spec: optimizev1beta1.TrialSpec{
+					Assignments: []optimizev1beta1.Assignment{
 						{
 							Name:  "test",
 							Value: intstr.FromInt(100),
@@ -157,7 +157,7 @@ func TestEngine_RenderMetricQueries(t *testing.T) {
 
 		{
 			desc: "function resourceRequests",
-			metric: redskyv1beta1.Metric{
+			metric: optimizev1beta1.Metric{
 				Name:  "testMetric",
 				Query: `{{resourceRequests .Pods "cpu=0.05,memory=0.005"}}`,
 			},
@@ -189,15 +189,15 @@ func TestEngine_RenderMetricQueries(t *testing.T) {
 
 		{
 			desc: "function cpuUtilization with parameters",
-			metric: redskyv1beta1.Metric{
+			metric: optimizev1beta1.Metric{
 				Name:  "testMetric",
 				Query: `{{cpuUtilization . "component=bob,component=tom"}}`,
 			},
-			trial: redskyv1beta1.Trial{
+			trial: optimizev1beta1.Trial{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
 				},
-				Status: redskyv1beta1.TrialStatus{
+				Status: optimizev1beta1.TrialStatus{
 					StartTime:      &metav1.Time{Time: now.Add(-5 * time.Second)},
 					CompletionTime: &now,
 				},
@@ -207,15 +207,15 @@ func TestEngine_RenderMetricQueries(t *testing.T) {
 
 		{
 			desc: "function cpuUtilization without parameters",
-			metric: redskyv1beta1.Metric{
+			metric: optimizev1beta1.Metric{
 				Name:  "testMetric",
 				Query: `{{cpuUtilization .}}`,
 			},
-			trial: redskyv1beta1.Trial{
+			trial: optimizev1beta1.Trial{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
 				},
-				Status: redskyv1beta1.TrialStatus{
+				Status: optimizev1beta1.TrialStatus{
 					StartTime:      &metav1.Time{Time: now.Add(-5 * time.Second)},
 					CompletionTime: &now,
 				},
@@ -225,15 +225,15 @@ func TestEngine_RenderMetricQueries(t *testing.T) {
 
 		{
 			desc: "function memoryUtilization with parameters",
-			metric: redskyv1beta1.Metric{
+			metric: optimizev1beta1.Metric{
 				Name:  "testMetric",
 				Query: `{{memoryUtilization . "component=bob,component=tom"}}`,
 			},
-			trial: redskyv1beta1.Trial{
+			trial: optimizev1beta1.Trial{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
 				},
-				Status: redskyv1beta1.TrialStatus{
+				Status: optimizev1beta1.TrialStatus{
 					StartTime:      &metav1.Time{Time: now.Add(-5 * time.Second)},
 					CompletionTime: &now,
 				},
@@ -243,15 +243,15 @@ func TestEngine_RenderMetricQueries(t *testing.T) {
 
 		{
 			desc: "function memoryUtilization without parameters",
-			metric: redskyv1beta1.Metric{
+			metric: optimizev1beta1.Metric{
 				Name:  "testMetric",
 				Query: `{{memoryUtilization .}}`,
 			},
-			trial: redskyv1beta1.Trial{
+			trial: optimizev1beta1.Trial{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
 				},
-				Status: redskyv1beta1.TrialStatus{
+				Status: optimizev1beta1.TrialStatus{
 					StartTime:      &metav1.Time{Time: now.Add(-5 * time.Second)},
 					CompletionTime: &now,
 				},
@@ -261,15 +261,15 @@ func TestEngine_RenderMetricQueries(t *testing.T) {
 
 		{
 			desc: "function cpuRequests with parameters",
-			metric: redskyv1beta1.Metric{
+			metric: optimizev1beta1.Metric{
 				Name:  "testMetric",
 				Query: `{{cpuRequests . "component=bob,component=tom"}}`,
 			},
-			trial: redskyv1beta1.Trial{
+			trial: optimizev1beta1.Trial{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
 				},
-				Status: redskyv1beta1.TrialStatus{
+				Status: optimizev1beta1.TrialStatus{
 					StartTime:      &metav1.Time{Time: now.Add(-5 * time.Second)},
 					CompletionTime: &now,
 				},
@@ -279,15 +279,15 @@ func TestEngine_RenderMetricQueries(t *testing.T) {
 
 		{
 			desc: "function memoryRequests with parameters",
-			metric: redskyv1beta1.Metric{
+			metric: optimizev1beta1.Metric{
 				Name:  "testMetric",
 				Query: `{{memoryRequests . "component=bob,component=tom"}}`,
 			},
-			trial: redskyv1beta1.Trial{
+			trial: optimizev1beta1.Trial{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
 				},
-				Status: redskyv1beta1.TrialStatus{
+				Status: optimizev1beta1.TrialStatus{
 					StartTime:      &metav1.Time{Time: now.Add(-5 * time.Second)},
 					CompletionTime: &now,
 				},
@@ -297,15 +297,15 @@ func TestEngine_RenderMetricQueries(t *testing.T) {
 
 		{
 			desc: "function gb",
-			metric: redskyv1beta1.Metric{
+			metric: optimizev1beta1.Metric{
 				Name:  "testMetric",
 				Query: `{{ "1234" | GB }}`,
 			},
-			trial: redskyv1beta1.Trial{
+			trial: optimizev1beta1.Trial{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
 				},
-				Status: redskyv1beta1.TrialStatus{
+				Status: optimizev1beta1.TrialStatus{
 					StartTime:      &metav1.Time{Time: now.Add(-5 * time.Second)},
 					CompletionTime: &now,
 				},
@@ -315,15 +315,15 @@ func TestEngine_RenderMetricQueries(t *testing.T) {
 
 		{
 			desc: "function gib",
-			metric: redskyv1beta1.Metric{
+			metric: optimizev1beta1.Metric{
 				Name:  "testMetric",
 				Query: `{{ "1234" | GiB }}`,
 			},
-			trial: redskyv1beta1.Trial{
+			trial: optimizev1beta1.Trial{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
 				},
-				Status: redskyv1beta1.TrialStatus{
+				Status: optimizev1beta1.TrialStatus{
 					StartTime:      &metav1.Time{Time: now.Add(-5 * time.Second)},
 					CompletionTime: &now,
 				},
@@ -348,21 +348,21 @@ func TestEngine_RenderMetricQueriesFailures(t *testing.T) {
 
 	cases := []struct {
 		desc   string
-		metric redskyv1beta1.Metric
-		trial  redskyv1beta1.Trial
+		metric optimizev1beta1.Metric
+		trial  optimizev1beta1.Trial
 		target runtime.Object
 	}{
 		{
 			desc: "prometheus label key sanitize",
-			metric: redskyv1beta1.Metric{
+			metric: optimizev1beta1.Metric{
 				Name:  "testMetric",
 				Query: `{{memoryRequests . "my/super.cool.label-with-fluffy/bunnies=789"}}`,
 			},
-			trial: redskyv1beta1.Trial{
+			trial: optimizev1beta1.Trial{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
 				},
-				Status: redskyv1beta1.TrialStatus{
+				Status: optimizev1beta1.TrialStatus{
 					StartTime:      &metav1.Time{Time: now.Add(-5 * time.Second)},
 					CompletionTime: &now,
 				},

--- a/internal/trial/job.go
+++ b/internal/trial/job.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"time"
 
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	"github.com/thestormforge/optimize-controller/v2/internal/meta"
 	"github.com/thestormforge/optimize-controller/v2/internal/setup"
 	batchv1 "k8s.io/api/batch/v1"
@@ -32,7 +32,7 @@ import (
 )
 
 // NewJob returns a new trial run job from the template on the trial
-func NewJob(t *redskyv1beta1.Trial) *batchv1.Job {
+func NewJob(t *optimizev1beta1.Trial) *batchv1.Job {
 	job := &batchv1.Job{}
 
 	// Start with the job template
@@ -42,14 +42,14 @@ func NewJob(t *redskyv1beta1.Trial) *batchv1.Job {
 	}
 
 	// Apply labels to the job itself
-	meta.AddLabel(job, redskyv1beta1.LabelExperiment, t.ExperimentNamespacedName().Name)
-	meta.AddLabel(job, redskyv1beta1.LabelTrial, t.Name)
-	meta.AddLabel(job, redskyv1beta1.LabelTrialRole, "trialRun")
+	meta.AddLabel(job, optimizev1beta1.LabelExperiment, t.ExperimentNamespacedName().Name)
+	meta.AddLabel(job, optimizev1beta1.LabelTrial, t.Name)
+	meta.AddLabel(job, optimizev1beta1.LabelTrialRole, "trialRun")
 
 	// Apply labels to the pod template
-	meta.AddLabel(&job.Spec.Template, redskyv1beta1.LabelExperiment, t.ExperimentNamespacedName().Name)
-	meta.AddLabel(&job.Spec.Template, redskyv1beta1.LabelTrial, t.Name)
-	meta.AddLabel(&job.Spec.Template, redskyv1beta1.LabelTrialRole, "trialRun")
+	meta.AddLabel(&job.Spec.Template, optimizev1beta1.LabelExperiment, t.ExperimentNamespacedName().Name)
+	meta.AddLabel(&job.Spec.Template, optimizev1beta1.LabelTrial, t.Name)
+	meta.AddLabel(&job.Spec.Template, optimizev1beta1.LabelTrialRole, "trialRun")
 
 	// Provide default metadata
 	job.Namespace = t.Namespace
@@ -85,7 +85,7 @@ func NewJob(t *redskyv1beta1.Trial) *batchv1.Job {
 	return job
 }
 
-func addDefaultContainer(t *redskyv1beta1.Trial, job *batchv1.Job) {
+func addDefaultContainer(t *optimizev1beta1.Trial, job *batchv1.Job) {
 	// Determine the sleep time
 	s := t.Spec.ApproximateRuntime
 	if s == nil || s.Duration == 0 {
@@ -106,7 +106,7 @@ func addDefaultContainer(t *redskyv1beta1.Trial, job *batchv1.Job) {
 	}
 }
 
-func patchSelf(t *redskyv1beta1.Trial, job *batchv1.Job) *batchv1.Job {
+func patchSelf(t *optimizev1beta1.Trial, job *batchv1.Job) *batchv1.Job {
 	// Look for patch operations that match this trial and apply them
 	for i := range t.Status.PatchOperations {
 		po := &t.Status.PatchOperations[i]

--- a/internal/trial/job_test.go
+++ b/internal/trial/job_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	batchv1 "k8s.io/api/batch/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -31,17 +31,17 @@ import (
 func TestNewJob(t *testing.T) {
 	testCases := []struct {
 		desc               string
-		trial              *redskyv1beta1.Trial
+		trial              *optimizev1beta1.Trial
 		expectedContainers int
 	}{
 		{
 			desc: "no containers",
-			trial: &redskyv1beta1.Trial{
+			trial: &optimizev1beta1.Trial{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "default",
 					Namespace: "default",
 				},
-				Spec: redskyv1beta1.TrialSpec{
+				Spec: optimizev1beta1.TrialSpec{
 					JobTemplate: &batchv1beta1.JobTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "trial-job",
@@ -55,12 +55,12 @@ func TestNewJob(t *testing.T) {
 		},
 		{
 			desc: "two containers",
-			trial: &redskyv1beta1.Trial{
+			trial: &optimizev1beta1.Trial{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "default",
 					Namespace: "default",
 				},
-				Spec: redskyv1beta1.TrialSpec{
+				Spec: optimizev1beta1.TrialSpec{
 					JobTemplate: &batchv1beta1.JobTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "trial-job",

--- a/internal/trial/metadata.go
+++ b/internal/trial/metadata.go
@@ -19,13 +19,13 @@ package trial
 import (
 	"strings"
 
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 )
 
 // GetInitializers returns the initializers for the specified trial
-func GetInitializers(t *redskyv1beta1.Trial) []string {
+func GetInitializers(t *optimizev1beta1.Trial) []string {
 	var initializers []string
-	for _, e := range strings.Split(t.GetAnnotations()[redskyv1beta1.AnnotationInitializer], ",") {
+	for _, e := range strings.Split(t.GetAnnotations()[optimizev1beta1.AnnotationInitializer], ",") {
 		e = strings.TrimSpace(e)
 		if e != "" {
 			initializers = append(initializers, e)
@@ -35,21 +35,21 @@ func GetInitializers(t *redskyv1beta1.Trial) []string {
 }
 
 // SetInitializers sets the supplied initializers on the trial
-func SetInitializers(t *redskyv1beta1.Trial, initializers []string) {
+func SetInitializers(t *optimizev1beta1.Trial, initializers []string) {
 	a := t.GetAnnotations()
 	if a == nil {
 		a = make(map[string]string, 1)
 	}
 	if len(initializers) > 0 {
-		a[redskyv1beta1.AnnotationInitializer] = strings.Join(initializers, ",")
+		a[optimizev1beta1.AnnotationInitializer] = strings.Join(initializers, ",")
 	} else {
-		delete(a, redskyv1beta1.AnnotationInitializer)
+		delete(a, optimizev1beta1.AnnotationInitializer)
 	}
 	t.SetAnnotations(a)
 }
 
 // AddInitializer adds an initializer to the trial; returns true only if the trial is changed
-func AddInitializer(t *redskyv1beta1.Trial, initializer string) bool {
+func AddInitializer(t *optimizev1beta1.Trial, initializer string) bool {
 	init := GetInitializers(t)
 	for _, e := range init {
 		if e == initializer {
@@ -61,7 +61,7 @@ func AddInitializer(t *redskyv1beta1.Trial, initializer string) bool {
 }
 
 // RemoveInitializer removes the first occurrence of an initializer from the trial; returns true only if the trial is changed
-func RemoveInitializer(t *redskyv1beta1.Trial, initializer string) bool {
+func RemoveInitializer(t *optimizev1beta1.Trial, initializer string) bool {
 	init := GetInitializers(t)
 	for i, e := range init {
 		if e == initializer {

--- a/internal/trial/status.go
+++ b/internal/trial/status.go
@@ -21,7 +21,7 @@ import (
 	"sort"
 	"strings"
 
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -46,19 +46,19 @@ const (
 )
 
 var (
-	trialConditionTypeOrder = []redskyv1beta1.TrialConditionType{
-		redskyv1beta1.TrialSetupCreated,
-		redskyv1beta1.TrialSetupDeleted,
-		redskyv1beta1.TrialPatched,
-		redskyv1beta1.TrialReady,
-		redskyv1beta1.TrialObserved,
-		redskyv1beta1.TrialComplete,
-		redskyv1beta1.TrialFailed,
+	trialConditionTypeOrder = []optimizev1beta1.TrialConditionType{
+		optimizev1beta1.TrialSetupCreated,
+		optimizev1beta1.TrialSetupDeleted,
+		optimizev1beta1.TrialPatched,
+		optimizev1beta1.TrialReady,
+		optimizev1beta1.TrialObserved,
+		optimizev1beta1.TrialComplete,
+		optimizev1beta1.TrialFailed,
 	}
 )
 
 // UpdateStatus will make sure the trial status matches the current state of the trial; returns true only if changes were necessary
-func UpdateStatus(t *redskyv1beta1.Trial) bool {
+func UpdateStatus(t *optimizev1beta1.Trial) bool {
 	phase := summarize(t)
 	assignments := assignments(t)
 	values := values(t)
@@ -79,7 +79,7 @@ func UpdateStatus(t *redskyv1beta1.Trial) bool {
 	return dirty
 }
 
-func summarize(t *redskyv1beta1.Trial) string {
+func summarize(t *optimizev1beta1.Trial) string {
 	// If there is an initializer we are in the "setting up" phase
 	if t.HasInitializer() {
 		return settingUp
@@ -104,7 +104,7 @@ func summarize(t *redskyv1beta1.Trial) string {
 		c := t.Status.Conditions[i]
 		switch c.Type {
 
-		case redskyv1beta1.TrialSetupCreated:
+		case optimizev1beta1.TrialSetupCreated:
 			switch c.Status {
 			case corev1.ConditionTrue:
 				phase = setupCreated
@@ -114,7 +114,7 @@ func summarize(t *redskyv1beta1.Trial) string {
 				phase = settingUp
 			}
 
-		case redskyv1beta1.TrialSetupDeleted:
+		case optimizev1beta1.TrialSetupDeleted:
 			switch c.Status {
 			case corev1.ConditionTrue:
 				phase = setupDeleted
@@ -122,7 +122,7 @@ func summarize(t *redskyv1beta1.Trial) string {
 				phase = tearingDown
 			}
 
-		case redskyv1beta1.TrialPatched:
+		case optimizev1beta1.TrialPatched:
 			switch c.Status {
 			case corev1.ConditionTrue:
 				phase = patched
@@ -132,7 +132,7 @@ func summarize(t *redskyv1beta1.Trial) string {
 				phase = patching
 			}
 
-		case redskyv1beta1.TrialReady:
+		case optimizev1beta1.TrialReady:
 			switch c.Status {
 			case corev1.ConditionTrue:
 				if t.Status.StartTime != nil {
@@ -146,7 +146,7 @@ func summarize(t *redskyv1beta1.Trial) string {
 				phase = waiting
 			}
 
-		case redskyv1beta1.TrialObserved:
+		case optimizev1beta1.TrialObserved:
 			switch c.Status {
 			case corev1.ConditionTrue:
 				phase = captured
@@ -156,13 +156,13 @@ func summarize(t *redskyv1beta1.Trial) string {
 				phase = capturing
 			}
 
-		case redskyv1beta1.TrialComplete:
+		case optimizev1beta1.TrialComplete:
 			switch c.Status {
 			case corev1.ConditionTrue:
 				return completed
 			}
 
-		case redskyv1beta1.TrialFailed:
+		case optimizev1beta1.TrialFailed:
 			switch c.Status {
 			case corev1.ConditionTrue:
 				return failed
@@ -172,7 +172,7 @@ func summarize(t *redskyv1beta1.Trial) string {
 	return phase
 }
 
-func assignments(t *redskyv1beta1.Trial) string {
+func assignments(t *optimizev1beta1.Trial) string {
 	assignments := make([]string, len(t.Spec.Assignments))
 	for i := range t.Spec.Assignments {
 		assignments[i] = fmt.Sprintf("%s=%s", t.Spec.Assignments[i].Name, t.Spec.Assignments[i].Value.String())
@@ -180,10 +180,10 @@ func assignments(t *redskyv1beta1.Trial) string {
 	return strings.Join(assignments, ", ")
 }
 
-func values(t *redskyv1beta1.Trial) string {
+func values(t *optimizev1beta1.Trial) string {
 	for i := range t.Status.Conditions {
 		c := &t.Status.Conditions[i]
-		if c.Type == redskyv1beta1.TrialFailed && c.Status == corev1.ConditionTrue {
+		if c.Type == optimizev1beta1.TrialFailed && c.Status == corev1.ConditionTrue {
 			return c.Message
 		}
 	}
@@ -198,7 +198,7 @@ func values(t *redskyv1beta1.Trial) string {
 }
 
 // ApplyCondition updates a the status of an existing condition or adds it if it does not exist
-func ApplyCondition(status *redskyv1beta1.TrialStatus, conditionType redskyv1beta1.TrialConditionType, conditionStatus corev1.ConditionStatus, reason, message string, time *metav1.Time) {
+func ApplyCondition(status *optimizev1beta1.TrialStatus, conditionType optimizev1beta1.TrialConditionType, conditionStatus corev1.ConditionStatus, reason, message string, time *metav1.Time) {
 	// Make sure we have a time
 	if time == nil {
 		now := metav1.Now()
@@ -228,7 +228,7 @@ func ApplyCondition(status *redskyv1beta1.TrialStatus, conditionType redskyv1bet
 	}
 
 	// Condition does not exist
-	status.Conditions = append(status.Conditions, redskyv1beta1.TrialCondition{
+	status.Conditions = append(status.Conditions, optimizev1beta1.TrialCondition{
 		Type:               conditionType,
 		Status:             conditionStatus,
 		Reason:             reason,
@@ -239,7 +239,7 @@ func ApplyCondition(status *redskyv1beta1.TrialStatus, conditionType redskyv1bet
 }
 
 // CheckCondition checks to see if a condition has a specific status
-func CheckCondition(status *redskyv1beta1.TrialStatus, conditionType redskyv1beta1.TrialConditionType, conditionStatus corev1.ConditionStatus) bool {
+func CheckCondition(status *optimizev1beta1.TrialStatus, conditionType optimizev1beta1.TrialConditionType, conditionStatus corev1.ConditionStatus) bool {
 	for i := range status.Conditions {
 		if status.Conditions[i].Type == conditionType {
 			return status.Conditions[i].Status == conditionStatus

--- a/internal/trial/status_test.go
+++ b/internal/trial/status_test.go
@@ -20,14 +20,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 )
 
 func TestUpdateStatus_Summarize(t *testing.T) {
 	cases := []struct {
 		desc       string
-		conditions []redskyv1beta1.TrialCondition
+		conditions []optimizev1beta1.TrialCondition
 		phase      string
 	}{
 		{
@@ -36,13 +36,13 @@ func TestUpdateStatus_Summarize(t *testing.T) {
 		},
 		{
 			desc: "HasSetupTasks",
-			conditions: []redskyv1beta1.TrialCondition{
+			conditions: []optimizev1beta1.TrialCondition{
 				{
-					Type:   redskyv1beta1.TrialSetupCreated,
+					Type:   optimizev1beta1.TrialSetupCreated,
 					Status: corev1.ConditionUnknown,
 				},
 				{
-					Type:   redskyv1beta1.TrialSetupDeleted,
+					Type:   optimizev1beta1.TrialSetupDeleted,
 					Status: corev1.ConditionUnknown,
 				},
 			},
@@ -50,13 +50,13 @@ func TestUpdateStatus_Summarize(t *testing.T) {
 		},
 		{
 			desc: "SettingUp",
-			conditions: []redskyv1beta1.TrialCondition{
+			conditions: []optimizev1beta1.TrialCondition{
 				{
-					Type:   redskyv1beta1.TrialSetupCreated,
+					Type:   optimizev1beta1.TrialSetupCreated,
 					Status: corev1.ConditionFalse,
 				},
 				{
-					Type:   redskyv1beta1.TrialSetupDeleted,
+					Type:   optimizev1beta1.TrialSetupDeleted,
 					Status: corev1.ConditionUnknown,
 				},
 			},
@@ -64,13 +64,13 @@ func TestUpdateStatus_Summarize(t *testing.T) {
 		},
 		{
 			desc: "SetupCreated",
-			conditions: []redskyv1beta1.TrialCondition{
+			conditions: []optimizev1beta1.TrialCondition{
 				{
-					Type:   redskyv1beta1.TrialSetupCreated,
+					Type:   optimizev1beta1.TrialSetupCreated,
 					Status: corev1.ConditionTrue,
 				},
 				{
-					Type:   redskyv1beta1.TrialSetupDeleted,
+					Type:   optimizev1beta1.TrialSetupDeleted,
 					Status: corev1.ConditionUnknown,
 				},
 			},
@@ -78,17 +78,17 @@ func TestUpdateStatus_Summarize(t *testing.T) {
 		},
 		{
 			desc: "SetupCreateFailure",
-			conditions: []redskyv1beta1.TrialCondition{
+			conditions: []optimizev1beta1.TrialCondition{
 				{
-					Type:   redskyv1beta1.TrialSetupCreated,
+					Type:   optimizev1beta1.TrialSetupCreated,
 					Status: corev1.ConditionFalse,
 				},
 				{
-					Type:   redskyv1beta1.TrialSetupDeleted,
+					Type:   optimizev1beta1.TrialSetupDeleted,
 					Status: corev1.ConditionUnknown,
 				},
 				{
-					Type:   redskyv1beta1.TrialFailed,
+					Type:   optimizev1beta1.TrialFailed,
 					Status: corev1.ConditionTrue,
 				},
 			},
@@ -96,17 +96,17 @@ func TestUpdateStatus_Summarize(t *testing.T) {
 		},
 		{
 			desc: "SetupCreateUnexpectedFailure",
-			conditions: []redskyv1beta1.TrialCondition{
+			conditions: []optimizev1beta1.TrialCondition{
 				{
-					Type:   redskyv1beta1.TrialSetupCreated,
+					Type:   optimizev1beta1.TrialSetupCreated,
 					Status: corev1.ConditionTrue,
 				},
 				{
-					Type:   redskyv1beta1.TrialSetupDeleted,
+					Type:   optimizev1beta1.TrialSetupDeleted,
 					Status: corev1.ConditionUnknown,
 				},
 				{
-					Type:   redskyv1beta1.TrialFailed,
+					Type:   optimizev1beta1.TrialFailed,
 					Status: corev1.ConditionTrue,
 				},
 			},
@@ -115,7 +115,7 @@ func TestUpdateStatus_Summarize(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.desc, func(t *testing.T) {
-			tt := &redskyv1beta1.Trial{Status: redskyv1beta1.TrialStatus{Conditions: c.conditions}}
+			tt := &optimizev1beta1.Trial{Status: optimizev1beta1.TrialStatus{Conditions: c.conditions}}
 			UpdateStatus(tt)
 			assert.Equal(t, c.phase, tt.Status.Phase)
 		})
@@ -125,13 +125,13 @@ func TestUpdateStatus_Summarize(t *testing.T) {
 func TestUpdateStatus_Values(t *testing.T) {
 	cases := []struct {
 		desc       string
-		conditions []redskyv1beta1.TrialCondition
-		values     []redskyv1beta1.Value
+		conditions []optimizev1beta1.TrialCondition
+		values     []optimizev1beta1.Value
 		value      string
 	}{
 		{
 			desc: "OneValue",
-			values: []redskyv1beta1.Value{
+			values: []optimizev1beta1.Value{
 				{
 					Name:  "foo",
 					Value: "1.0",
@@ -141,7 +141,7 @@ func TestUpdateStatus_Values(t *testing.T) {
 		},
 		{
 			desc: "TwoValues",
-			values: []redskyv1beta1.Value{
+			values: []optimizev1beta1.Value{
 				{
 					Name:  "foo",
 					Value: "1.0",
@@ -155,7 +155,7 @@ func TestUpdateStatus_Values(t *testing.T) {
 		},
 		{
 			desc: "NotReady",
-			values: []redskyv1beta1.Value{
+			values: []optimizev1beta1.Value{
 				{
 					Name:              "foo",
 					Value:             "1.0",
@@ -170,7 +170,7 @@ func TestUpdateStatus_Values(t *testing.T) {
 		},
 		{
 			desc: "NoneReady",
-			values: []redskyv1beta1.Value{
+			values: []optimizev1beta1.Value{
 				{
 					Name:              "foo",
 					Value:             "1.0",
@@ -186,9 +186,9 @@ func TestUpdateStatus_Values(t *testing.T) {
 		},
 		{
 			desc: "Failed",
-			conditions: []redskyv1beta1.TrialCondition{
+			conditions: []optimizev1beta1.TrialCondition{
 				{
-					Type:    redskyv1beta1.TrialFailed,
+					Type:    optimizev1beta1.TrialFailed,
 					Status:  corev1.ConditionTrue,
 					Message: "test failure message",
 				},
@@ -198,9 +198,9 @@ func TestUpdateStatus_Values(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.desc, func(t *testing.T) {
-			tt := &redskyv1beta1.Trial{
-				Spec:   redskyv1beta1.TrialSpec{Values: c.values},
-				Status: redskyv1beta1.TrialStatus{Conditions: c.conditions},
+			tt := &optimizev1beta1.Trial{
+				Spec:   optimizev1beta1.TrialSpec{Values: c.values},
+				Status: optimizev1beta1.TrialStatus{Conditions: c.conditions},
 			}
 			UpdateStatus(tt)
 			assert.Equal(t, c.value, tt.Status.Values)

--- a/internal/trial/trial.go
+++ b/internal/trial/trial.go
@@ -20,17 +20,17 @@ import (
 	"strings"
 	"time"
 
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 // IsFinished checks to see if the specified trial is finished
-func IsFinished(t *redskyv1beta1.Trial) bool {
+func IsFinished(t *optimizev1beta1.Trial) bool {
 	for _, c := range t.Status.Conditions {
 		if c.Status == corev1.ConditionTrue {
-			if c.Type == redskyv1beta1.TrialComplete || c.Type == redskyv1beta1.TrialFailed {
+			if c.Type == optimizev1beta1.TrialComplete || c.Type == optimizev1beta1.TrialFailed {
 				return true
 			}
 		}
@@ -39,12 +39,12 @@ func IsFinished(t *redskyv1beta1.Trial) bool {
 }
 
 // IsAbandoned checks to see if the specified trial is abandoned
-func IsAbandoned(t *redskyv1beta1.Trial) bool {
+func IsAbandoned(t *optimizev1beta1.Trial) bool {
 	return !IsFinished(t) && !t.GetDeletionTimestamp().IsZero()
 }
 
 // IsActive checks to see if the specified trial and any setup delete tasks are NOT finished
-func IsActive(t *redskyv1beta1.Trial) bool {
+func IsActive(t *optimizev1beta1.Trial) bool {
 	// Not finished, definitely active
 	if !IsFinished(t) {
 		return true
@@ -52,7 +52,7 @@ func IsActive(t *redskyv1beta1.Trial) bool {
 
 	// Check if a setup delete task exists and has not yet completed (remember the TrialSetupDeleted status is optional!)
 	for _, c := range t.Status.Conditions {
-		if c.Type == redskyv1beta1.TrialSetupDeleted && c.Status != corev1.ConditionTrue {
+		if c.Type == optimizev1beta1.TrialSetupDeleted && c.Status != corev1.ConditionTrue {
 			return true
 		}
 	}
@@ -62,7 +62,7 @@ func IsActive(t *redskyv1beta1.Trial) bool {
 
 // IsTrialJobReference checks to see if the supplied reference likely points to the job of a trial. This is
 // used primarily to give special handling to patch operations so they can refer to trial job before it exists.
-func IsTrialJobReference(t *redskyv1beta1.Trial, ref *corev1.ObjectReference) bool {
+func IsTrialJobReference(t *optimizev1beta1.Trial, ref *corev1.ObjectReference) bool {
 	// Kind _must_ be job
 	if ref.Kind != "Job" {
 		return false
@@ -92,7 +92,7 @@ func IsTrialJobReference(t *redskyv1beta1.Trial, ref *corev1.ObjectReference) bo
 }
 
 // IsBaseline checks to see if the supplied trial is a baseline for an experiment.
-func IsBaseline(t *redskyv1beta1.Trial, exp *redskyv1beta1.Experiment) bool {
+func IsBaseline(t *optimizev1beta1.Trial, exp *optimizev1beta1.Experiment) bool {
 	// Trials that were created as baselines should be labeled as such
 	if t.Labels["baseline"] == "true" {
 		return true
@@ -124,7 +124,7 @@ func IsBaseline(t *redskyv1beta1.Trial, exp *redskyv1beta1.Experiment) bool {
 }
 
 // NeedsCleanup checks to see if a trial's TTL has expired
-func NeedsCleanup(t *redskyv1beta1.Trial) bool {
+func NeedsCleanup(t *optimizev1beta1.Trial) bool {
 	// Already deleted or still active, no cleanup necessary
 	if !t.GetDeletionTimestamp().IsZero() || IsActive(t) {
 		return false
@@ -136,7 +136,7 @@ func NeedsCleanup(t *redskyv1beta1.Trial) bool {
 	for _, c := range t.Status.Conditions {
 		if isFinishTimeCondition(&c) {
 			// Adjust the TTL if specified separately for failures
-			if c.Type == redskyv1beta1.TrialFailed && t.Spec.TTLSecondsAfterFailure != nil {
+			if c.Type == optimizev1beta1.TrialFailed && t.Spec.TTLSecondsAfterFailure != nil {
 				ttlSeconds = t.Spec.TTLSecondsAfterFailure
 			}
 
@@ -158,9 +158,9 @@ func NeedsCleanup(t *redskyv1beta1.Trial) bool {
 }
 
 // isFinishTimeCondition returns true if the condition is relevant to the "finish time"
-func isFinishTimeCondition(c *redskyv1beta1.TrialCondition) bool {
+func isFinishTimeCondition(c *optimizev1beta1.TrialCondition) bool {
 	switch c.Type {
-	case redskyv1beta1.TrialComplete, redskyv1beta1.TrialFailed, redskyv1beta1.TrialSetupDeleted:
+	case optimizev1beta1.TrialComplete, optimizev1beta1.TrialFailed, optimizev1beta1.TrialSetupDeleted:
 		return c.Status == corev1.ConditionTrue
 	default:
 		return false

--- a/internal/validation/assignments.go
+++ b/internal/validation/assignments.go
@@ -17,7 +17,7 @@ limitations under the License.
 package validation
 
 import (
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -40,7 +40,7 @@ func (e *AssignmentError) Error() string {
 }
 
 // CheckAssignments ensures the trial assignments match the definitions on the experiment
-func CheckAssignments(t *redskyv1beta1.Trial, exp *redskyv1beta1.Experiment) error {
+func CheckAssignments(t *optimizev1beta1.Trial, exp *optimizev1beta1.Experiment) error {
 	err := &AssignmentError{}
 
 	// Index the assignments, checking for duplicates
@@ -76,7 +76,7 @@ func CheckAssignments(t *redskyv1beta1.Trial, exp *redskyv1beta1.Experiment) err
 }
 
 // CheckParameterValue ensures the supplied value in range for the parameter.
-func CheckParameterValue(p *redskyv1beta1.Parameter, v intstr.IntOrString) bool {
+func CheckParameterValue(p *optimizev1beta1.Parameter, v intstr.IntOrString) bool {
 	if v.Type == intstr.String {
 		return contains(p.Values, v.StrVal)
 	}

--- a/internal/validation/definition.go
+++ b/internal/validation/definition.go
@@ -19,12 +19,12 @@ package validation
 import (
 	"fmt"
 
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
-	redskyapi "github.com/thestormforge/optimize-go/pkg/api/experiments/v1alpha1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	experimentsv1alpha1 "github.com/thestormforge/optimize-go/pkg/api/experiments/v1alpha1"
 )
 
 // CheckDefinition will make sure the cluster and API experiment definitions are compatible
-func CheckDefinition(exp *redskyv1beta1.Experiment, ee *redskyapi.Experiment) error {
+func CheckDefinition(exp *optimizev1beta1.Experiment, ee *experimentsv1alpha1.Experiment) error {
 	if len(exp.Spec.Parameters) == len(ee.Parameters) {
 		parameters := make(map[string]bool, len(exp.Spec.Parameters))
 		for i := range exp.Spec.Parameters {

--- a/internal/validation/values.go
+++ b/internal/validation/values.go
@@ -20,12 +20,12 @@ import (
 	"fmt"
 	"strconv"
 
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 // CheckMetricBounds ensures the specified
-func CheckMetricBounds(m *redskyv1beta1.Metric, v *redskyv1beta1.Value) error {
+func CheckMetricBounds(m *optimizev1beta1.Metric, v *optimizev1beta1.Value) error {
 	// If the value isn't a valid number, ignore the bounds check
 	value, err := strconv.ParseFloat(v.Value, 64)
 	if err != nil {

--- a/internal/validation/values_test.go
+++ b/internal/validation/values_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
@@ -32,8 +32,8 @@ func mustQuantity(str string) *resource.Quantity {
 func TestCheckMetricBounds(t *testing.T) {
 	cases := []struct {
 		desc     string
-		metric   redskyv1beta1.Metric
-		value    redskyv1beta1.Value
+		metric   optimizev1beta1.Metric
+		value    optimizev1beta1.Value
 		hasError bool
 	}{
 		{
@@ -41,44 +41,44 @@ func TestCheckMetricBounds(t *testing.T) {
 		},
 		{
 			desc:  "no bounds",
-			value: redskyv1beta1.Value{Value: "1.0"},
+			value: optimizev1beta1.Value{Value: "1.0"},
 		},
 
 		{
 			desc:     "value too low",
-			metric:   redskyv1beta1.Metric{Min: mustQuantity("2.0")},
-			value:    redskyv1beta1.Value{Value: "1.0"},
+			metric:   optimizev1beta1.Metric{Min: mustQuantity("2.0")},
+			value:    optimizev1beta1.Value{Value: "1.0"},
 			hasError: true,
 		},
 		{
 			desc:     "value too high",
-			metric:   redskyv1beta1.Metric{Max: mustQuantity("1.0")},
-			value:    redskyv1beta1.Value{Value: "2.0"},
+			metric:   optimizev1beta1.Metric{Max: mustQuantity("1.0")},
+			value:    optimizev1beta1.Value{Value: "2.0"},
 			hasError: true,
 		},
 
 		{
 			desc:   "value above less precise min",
-			metric: redskyv1beta1.Metric{Min: mustQuantity("1.2345")},
-			value:  redskyv1beta1.Value{Value: "1.23456789"},
+			metric: optimizev1beta1.Metric{Min: mustQuantity("1.2345")},
+			value:  optimizev1beta1.Value{Value: "1.23456789"},
 		},
 		{
 			desc:     "value above less precise max ",
-			metric:   redskyv1beta1.Metric{Max: mustQuantity("1.2345")},
-			value:    redskyv1beta1.Value{Value: "1.23456789"},
+			metric:   optimizev1beta1.Metric{Max: mustQuantity("1.2345")},
+			value:    optimizev1beta1.Value{Value: "1.23456789"},
 			hasError: true,
 		},
 
 		{
 			desc:     "suffix max",
-			metric:   redskyv1beta1.Metric{Max: mustQuantity("100m")},
-			value:    redskyv1beta1.Value{Value: "0.2"},
+			metric:   optimizev1beta1.Metric{Max: mustQuantity("100m")},
+			value:    optimizev1beta1.Value{Value: "0.2"},
 			hasError: true,
 		},
 		{
 			desc:   "suffix min",
-			metric: redskyv1beta1.Metric{Min: mustQuantity("100m")},
-			value:  redskyv1beta1.Value{Value: "0.2"},
+			metric: optimizev1beta1.Metric{Min: mustQuantity("100m")},
+			value:  optimizev1beta1.Value{Value: "0.2"},
 		},
 	}
 	for _, c := range cases {

--- a/main.go
+++ b/main.go
@@ -22,8 +22,8 @@ import (
 	"fmt"
 	"os"
 
-	redskyv1alpha1 "github.com/thestormforge/optimize-controller/v2/api/v1alpha1"
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizev1alpha1 "github.com/thestormforge/optimize-controller/v2/api/v1alpha1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	"github.com/thestormforge/optimize-controller/v2/controllers"
 	"github.com/thestormforge/optimize-controller/v2/internal/controller"
 	"github.com/thestormforge/optimize-controller/v2/internal/version"
@@ -44,8 +44,8 @@ var (
 func init() {
 	_ = clientgoscheme.AddToScheme(scheme)
 
-	_ = redskyv1alpha1.AddToScheme(scheme)
-	_ = redskyv1beta1.AddToScheme(scheme)
+	_ = optimizev1alpha1.AddToScheme(scheme)
+	_ = optimizev1beta1.AddToScheme(scheme)
 	// +kubebuilder:scaffold:scheme
 }
 

--- a/redskyctl/internal/commander/commander.go
+++ b/redskyctl/internal/commander/commander.go
@@ -27,8 +27,8 @@ import (
 	"sync"
 
 	"github.com/spf13/cobra"
-	redskyv1alpha1 "github.com/thestormforge/optimize-controller/v2/api/v1alpha1"
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizev1alpha1 "github.com/thestormforge/optimize-controller/v2/api/v1alpha1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	"github.com/thestormforge/optimize-go/pkg/api"
 	experimentsv1alpha1 "github.com/thestormforge/optimize-go/pkg/api/experiments/v1alpha1"
 	internalconfig "github.com/thestormforge/optimize-go/pkg/config"
@@ -180,8 +180,8 @@ func SetPrinter(meta TableMeta, printer *ResourcePrinter, cmd *cobra.Command, ad
 func SetKubePrinter(printer *ResourcePrinter, cmd *cobra.Command, additionalFormats map[string]AdditionalFormat) {
 	kp := &kubePrinter{scheme: runtime.NewScheme()}
 	_ = clientgoscheme.AddToScheme(kp.scheme)
-	_ = redskyv1alpha1.AddToScheme(kp.scheme)
-	_ = redskyv1beta1.AddToScheme(kp.scheme)
+	_ = optimizev1alpha1.AddToScheme(kp.scheme)
+	_ = optimizev1beta1.AddToScheme(kp.scheme)
 	pf := newPrintFlags(kp, cmd.Annotations, additionalFormats)
 	pf.addFlags(cmd)
 	AddPreRunE(cmd, func(*cobra.Command, []string) error {

--- a/redskyctl/internal/commander/reader.go
+++ b/redskyctl/internal/commander/reader.go
@@ -23,9 +23,9 @@ import (
 	"os"
 	"path/filepath"
 
-	redskyappsv1alpha1 "github.com/thestormforge/optimize-controller/v2/api/apps/v1alpha1"
-	redskyv1alpha1 "github.com/thestormforge/optimize-controller/v2/api/v1alpha1"
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizeappsv1alpha1 "github.com/thestormforge/optimize-controller/v2/api/apps/v1alpha1"
+	optimizev1alpha1 "github.com/thestormforge/optimize-controller/v2/api/v1alpha1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	"github.com/thestormforge/optimize-controller/v2/internal/controller"
 	"k8s.io/apimachinery/pkg/conversion"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -47,9 +47,9 @@ func NewResourceReader() *ResourceReader {
 	}
 
 	// Always add our types
-	_ = redskyv1beta1.AddToScheme(rr.Scheme)
-	_ = redskyv1alpha1.AddToScheme(rr.Scheme)
-	_ = redskyappsv1alpha1.AddToScheme(rr.Scheme)
+	_ = optimizev1beta1.AddToScheme(rr.Scheme)
+	_ = optimizev1alpha1.AddToScheme(rr.Scheme)
+	_ = optimizeappsv1alpha1.AddToScheme(rr.Scheme)
 
 	// Allow single experiments to target an experiment list
 	_ = addExperimentListConversions(rr.Scheme)
@@ -159,17 +159,17 @@ func (onlyVersion) KindForGroupVersionKinds(kinds []schema.GroupVersionKind) (sc
 // when a command can handle a list but the user only supplies a single experiment.
 func addExperimentListConversions(s *runtime.Scheme) error {
 	// Convert from a single experiment to a list of experiments
-	if err := s.AddConversionFunc((*redskyv1beta1.Experiment)(nil), (*redskyv1beta1.ExperimentList)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		b.(*redskyv1beta1.ExperimentList).Items = []redskyv1beta1.Experiment{*a.(*redskyv1beta1.Experiment)}
+	if err := s.AddConversionFunc((*optimizev1beta1.Experiment)(nil), (*optimizev1beta1.ExperimentList)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		b.(*optimizev1beta1.ExperimentList).Items = []optimizev1beta1.Experiment{*a.(*optimizev1beta1.Experiment)}
 		return nil
 	}); err != nil {
 		return err
 	}
 
 	// Convert from a single v1alpha1 experiment to a list of experiments
-	if err := s.AddConversionFunc((*redskyv1alpha1.Experiment)(nil), (*redskyv1beta1.ExperimentList)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		l := b.(*redskyv1beta1.ExperimentList)
-		l.Items = make([]redskyv1beta1.Experiment, 1)
+	if err := s.AddConversionFunc((*optimizev1alpha1.Experiment)(nil), (*optimizev1beta1.ExperimentList)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		l := b.(*optimizev1beta1.ExperimentList)
+		l.Items = make([]optimizev1beta1.Experiment, 1)
 		return scope.Convert(a, &l.Items[0], scope.Flags())
 	}); err != nil {
 		return err

--- a/redskyctl/internal/commands/authorize_cluster/generator.go
+++ b/redskyctl/internal/commands/authorize_cluster/generator.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/thestormforge/optimize-controller/v2/redskyctl/internal/commander"
-	redskyapi "github.com/thestormforge/optimize-go/pkg/api/experiments/v1alpha1"
+	experimentsv1alpha1 "github.com/thestormforge/optimize-go/pkg/api/experiments/v1alpha1"
 	"github.com/thestormforge/optimize-go/pkg/config"
 	"github.com/thestormforge/optimize-go/pkg/oauth2/registration"
 	"golang.org/x/oauth2"
@@ -128,7 +128,7 @@ func (o *GeneratorOptions) generate(ctx context.Context) error {
 
 	// Get the client information (either read or register)
 	info, err := o.clientInfo(ctx, ctrl)
-	if o.AllowUnauthorized && redskyapi.IsUnauthorized(err) {
+	if o.AllowUnauthorized && experimentsv1alpha1.IsUnauthorized(err) {
 		// Ignore the error (but do not save the changes)
 		info = &registration.ClientInformationResponse{}
 	} else if err != nil {

--- a/redskyctl/internal/commands/debug/metric.go
+++ b/redskyctl/internal/commands/debug/metric.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	"github.com/thestormforge/optimize-controller/v2/internal/experiment"
 	"github.com/thestormforge/optimize-controller/v2/internal/template"
 	"github.com/thestormforge/optimize-controller/v2/redskyctl/internal/commander"
@@ -78,14 +78,14 @@ func (o *MetricQueryOptions) Debug() error {
 		return err
 	}
 
-	exp := &redskyv1beta1.Experiment{}
+	exp := &optimizev1beta1.Experiment{}
 	rr := commander.NewResourceReader()
 	if err := rr.ReadInto(r, exp); err != nil {
 		return err
 	}
 
 	// Create a new trial object
-	t := &redskyv1beta1.Trial{}
+	t := &optimizev1beta1.Trial{}
 	t.Name = o.TrialName
 
 	// Fill out information from the experiment
@@ -127,7 +127,7 @@ func (o *MetricQueryOptions) Debug() error {
 		}
 
 		// Not Prometheus, just add a comment to the header
-		if m.Type != redskyv1beta1.MetricPrometheus {
+		if m.Type != optimizev1beta1.MetricPrometheus {
 			pt.addQueryComment(m, q)
 			continue
 		}
@@ -142,7 +142,7 @@ func (o *MetricQueryOptions) Debug() error {
 	return pt.writeTo(o.YAMLWriter())
 }
 
-func (o *MetricQueryOptions) populateTrialTime(exp *redskyv1beta1.Experiment, t *redskyv1beta1.Trial) error {
+func (o *MetricQueryOptions) populateTrialTime(exp *optimizev1beta1.Experiment, t *optimizev1beta1.Trial) error {
 	startTime, err := parseTime(o.StartTime, time.Now())
 	if err != nil {
 		return err
@@ -232,7 +232,7 @@ func (p *promTest) addHeadComment(pattern string, args ...interface{}) {
 	p.document.YNode().HeadComment = prefix + fmt.Sprintf(pattern, args...) + "\n"
 }
 
-func (p *promTest) addTest(t *redskyv1beta1.Trial) error {
+func (p *promTest) addTest(t *optimizev1beta1.Trial) error {
 	seriesName := fmt.Sprintf(`up{job="prometheus-pushgateway", instance="redsky-%s-prometheus:9090"}`, t.Namespace)
 	seriesValues := fmt.Sprintf(`0+0x%d`, (t.Status.CompletionTime.Sub(t.Status.StartTime.Time)/(5*time.Second))+2)
 	return p.document.PipeE(
@@ -270,7 +270,7 @@ func (p *promTest) addTest(t *redskyv1beta1.Trial) error {
 	)
 }
 
-func (p *promTest) addPromqlExprTest(t *redskyv1beta1.Trial, m *redskyv1beta1.Metric, q string) error {
+func (p *promTest) addPromqlExprTest(t *optimizev1beta1.Trial, m *optimizev1beta1.Metric, q string) error {
 	return p.document.PipeE(
 		yaml.Lookup("tests", "[name="+t.Name+"]", "promql_expr_test"),
 		yaml.Append(&yaml.Node{
@@ -303,15 +303,15 @@ func (p *promTest) addPromqlExprTest(t *redskyv1beta1.Trial, m *redskyv1beta1.Me
 	)
 }
 
-func (p *promTest) addQueryComment(m *redskyv1beta1.Metric, q string) {
+func (p *promTest) addQueryComment(m *optimizev1beta1.Metric, q string) {
 	switch m.Type {
-	case redskyv1beta1.MetricJSONPath:
+	case optimizev1beta1.MetricJSONPath:
 		p.addHeadComment("%s: url=%s jsonpath=%s", m.Name, m.URL, q)
 	default:
 		p.addHeadComment("%s: %s", m.Name, q)
 	}
 }
 
-func (p *promTest) addErrorComment(m *redskyv1beta1.Metric, err error) {
+func (p *promTest) addErrorComment(m *optimizev1beta1.Metric, err error) {
 	p.addHeadComment("%s: Error: %s", m.Name, err.Error())
 }

--- a/redskyctl/internal/commands/export/export_api_test.go
+++ b/redskyctl/internal/commands/export/export_api_test.go
@@ -19,14 +19,14 @@ package export_test
 import (
 	"context"
 
-	experimentsapi "github.com/thestormforge/optimize-go/pkg/api/experiments/v1alpha1"
+	experimentsv1alpha1 "github.com/thestormforge/optimize-go/pkg/api/experiments/v1alpha1"
 	"github.com/thestormforge/optimize-go/pkg/api/experiments/v1alpha1/numstr"
 )
 
-var wannabeTrial = experimentsapi.TrialItem{
+var wannabeTrial = experimentsv1alpha1.TrialItem{
 	// This is our target trial
-	TrialAssignments: experimentsapi.TrialAssignments{
-		Assignments: []experimentsapi.Assignment{
+	TrialAssignments: experimentsv1alpha1.TrialAssignments{
+		Assignments: []experimentsv1alpha1.Assignment{
 			{
 				ParameterName: "cpu",
 				Value:         numstr.FromInt64(100),
@@ -38,27 +38,27 @@ var wannabeTrial = experimentsapi.TrialItem{
 		},
 	},
 	Number: 1234,
-	Status: experimentsapi.TrialCompleted,
+	Status: experimentsv1alpha1.TrialCompleted,
 }
 
 // Implement the api interface
 type fakeRedSkyServer struct{}
 
-func (f *fakeRedSkyServer) Options(ctx context.Context) (experimentsapi.ServerMeta, error) {
-	return experimentsapi.ServerMeta{}, nil
+func (f *fakeRedSkyServer) Options(ctx context.Context) (experimentsv1alpha1.ServerMeta, error) {
+	return experimentsv1alpha1.ServerMeta{}, nil
 }
 
-func (f *fakeRedSkyServer) GetAllExperiments(ctx context.Context, query *experimentsapi.ExperimentListQuery) (experimentsapi.ExperimentList, error) {
-	return experimentsapi.ExperimentList{}, nil
+func (f *fakeRedSkyServer) GetAllExperiments(ctx context.Context, query *experimentsv1alpha1.ExperimentListQuery) (experimentsv1alpha1.ExperimentList, error) {
+	return experimentsv1alpha1.ExperimentList{}, nil
 }
 
-func (f *fakeRedSkyServer) GetAllExperimentsByPage(ctx context.Context, notsure string) (experimentsapi.ExperimentList, error) {
-	return experimentsapi.ExperimentList{}, nil
+func (f *fakeRedSkyServer) GetAllExperimentsByPage(ctx context.Context, notsure string) (experimentsv1alpha1.ExperimentList, error) {
+	return experimentsv1alpha1.ExperimentList{}, nil
 }
 
-func (f *fakeRedSkyServer) GetExperimentByName(ctx context.Context, name experimentsapi.ExperimentName) (experimentsapi.Experiment, error) {
-	exp := experimentsapi.Experiment{
-		ExperimentMeta: experimentsapi.ExperimentMeta{
+func (f *fakeRedSkyServer) GetExperimentByName(ctx context.Context, name experimentsv1alpha1.ExperimentName) (experimentsv1alpha1.Experiment, error) {
+	exp := experimentsv1alpha1.Experiment{
+		ExperimentMeta: experimentsv1alpha1.ExperimentMeta{
 			TrialsURL: "http://sometrial",
 		},
 		DisplayName: "postgres-example",
@@ -67,7 +67,7 @@ func (f *fakeRedSkyServer) GetExperimentByName(ctx context.Context, name experim
 			"application": "sampleApplication",
 			"scenario":    "how-do-you-make-a-tissue-dance",
 		},
-		Metrics: []experimentsapi.Metric{
+		Metrics: []experimentsv1alpha1.Metric{
 			{
 				Name:     "cost",
 				Minimize: true,
@@ -78,20 +78,20 @@ func (f *fakeRedSkyServer) GetExperimentByName(ctx context.Context, name experim
 			},
 		},
 		Observations: 320,
-		Optimization: []experimentsapi.Optimization{},
-		Parameters: []experimentsapi.Parameter{
+		Optimization: []experimentsv1alpha1.Optimization{},
+		Parameters: []experimentsv1alpha1.Parameter{
 			{
 				Name: "cpu",
-				Type: experimentsapi.ParameterTypeInteger,
-				Bounds: &experimentsapi.Bounds{
+				Type: experimentsv1alpha1.ParameterTypeInteger,
+				Bounds: &experimentsv1alpha1.Bounds{
 					Max: "4000",
 					Min: "100",
 				},
 			},
 			{
 				Name: "memory",
-				Type: experimentsapi.ParameterTypeInteger,
-				Bounds: &experimentsapi.Bounds{
+				Type: experimentsv1alpha1.ParameterTypeInteger,
+				Bounds: &experimentsv1alpha1.Bounds{
 					Max: "4000",
 					Min: "500",
 				},
@@ -102,32 +102,32 @@ func (f *fakeRedSkyServer) GetExperimentByName(ctx context.Context, name experim
 	return exp, nil
 }
 
-func (f *fakeRedSkyServer) GetExperiment(ctx context.Context, name string) (experimentsapi.Experiment, error) {
-	return experimentsapi.Experiment{}, nil
+func (f *fakeRedSkyServer) GetExperiment(ctx context.Context, name string) (experimentsv1alpha1.Experiment, error) {
+	return experimentsv1alpha1.Experiment{}, nil
 }
 
-func (f *fakeRedSkyServer) CreateExperimentByName(ctx context.Context, name experimentsapi.ExperimentName, experiment experimentsapi.Experiment) (experimentsapi.Experiment, error) {
-	return experimentsapi.Experiment{}, nil
+func (f *fakeRedSkyServer) CreateExperimentByName(ctx context.Context, name experimentsv1alpha1.ExperimentName, experiment experimentsv1alpha1.Experiment) (experimentsv1alpha1.Experiment, error) {
+	return experimentsv1alpha1.Experiment{}, nil
 }
 
-func (f *fakeRedSkyServer) CreateExperiment(ctx context.Context, s string, experiment experimentsapi.Experiment) (experimentsapi.Experiment, error) {
-	return experimentsapi.Experiment{}, nil
+func (f *fakeRedSkyServer) CreateExperiment(ctx context.Context, s string, experiment experimentsv1alpha1.Experiment) (experimentsv1alpha1.Experiment, error) {
+	return experimentsv1alpha1.Experiment{}, nil
 }
 
 func (f *fakeRedSkyServer) DeleteExperiment(ctx context.Context, name string) error {
 	return nil
 }
 
-func (f *fakeRedSkyServer) GetAllTrials(ctx context.Context, name string, query *experimentsapi.TrialListQuery) (experimentsapi.TrialList, error) {
+func (f *fakeRedSkyServer) GetAllTrials(ctx context.Context, name string, query *experimentsv1alpha1.TrialListQuery) (experimentsv1alpha1.TrialList, error) {
 	// TODO implement some query filter magic if we really want to.
 	// Otherwise, we should clean this up to mimic just the necessary output
-	tl := experimentsapi.TrialList{
-		Trials: []experimentsapi.TrialItem{
+	tl := experimentsv1alpha1.TrialList{
+		Trials: []experimentsv1alpha1.TrialItem{
 			wannabeTrial,
 			// This one should not be used because number doesnt match up
 			{
-				TrialAssignments: experimentsapi.TrialAssignments{
-					Assignments: []experimentsapi.Assignment{
+				TrialAssignments: experimentsv1alpha1.TrialAssignments{
+					Assignments: []experimentsv1alpha1.Assignment{
 						{
 							ParameterName: "cpu",
 							Value:         numstr.FromInt64(999),
@@ -139,12 +139,12 @@ func (f *fakeRedSkyServer) GetAllTrials(ctx context.Context, name string, query 
 					},
 				},
 				Number: 319,
-				Status: experimentsapi.TrialCompleted,
+				Status: experimentsv1alpha1.TrialCompleted,
 			},
 			// This one should not be used because status is not completed
 			{
-				TrialAssignments: experimentsapi.TrialAssignments{
-					Assignments: []experimentsapi.Assignment{
+				TrialAssignments: experimentsv1alpha1.TrialAssignments{
+					Assignments: []experimentsv1alpha1.Assignment{
 						{
 							ParameterName: "cpu",
 							Value:         numstr.FromInt64(999),
@@ -156,22 +156,22 @@ func (f *fakeRedSkyServer) GetAllTrials(ctx context.Context, name string, query 
 					},
 				},
 				Number: 320,
-				Status: experimentsapi.TrialFailed,
+				Status: experimentsv1alpha1.TrialFailed,
 			},
 		},
 	}
 	return tl, nil
 }
 
-func (f *fakeRedSkyServer) CreateTrial(ctx context.Context, name string, assignments experimentsapi.TrialAssignments) (experimentsapi.TrialAssignments, error) {
-	return experimentsapi.TrialAssignments{}, nil
+func (f *fakeRedSkyServer) CreateTrial(ctx context.Context, name string, assignments experimentsv1alpha1.TrialAssignments) (experimentsv1alpha1.TrialAssignments, error) {
+	return experimentsv1alpha1.TrialAssignments{}, nil
 }
 
-func (f *fakeRedSkyServer) NextTrial(ctx context.Context, name string) (experimentsapi.TrialAssignments, error) {
-	return experimentsapi.TrialAssignments{}, nil
+func (f *fakeRedSkyServer) NextTrial(ctx context.Context, name string) (experimentsv1alpha1.TrialAssignments, error) {
+	return experimentsv1alpha1.TrialAssignments{}, nil
 }
 
-func (f *fakeRedSkyServer) ReportTrial(ctx context.Context, name string, values experimentsapi.TrialValues) error {
+func (f *fakeRedSkyServer) ReportTrial(ctx context.Context, name string, values experimentsv1alpha1.TrialValues) error {
 	return nil
 }
 
@@ -179,10 +179,10 @@ func (f *fakeRedSkyServer) AbandonRunningTrial(ctx context.Context, name string)
 	return nil
 }
 
-func (f *fakeRedSkyServer) LabelExperiment(ctx context.Context, name string, labels experimentsapi.ExperimentLabels) error {
+func (f *fakeRedSkyServer) LabelExperiment(ctx context.Context, name string, labels experimentsv1alpha1.ExperimentLabels) error {
 	return nil
 }
 
-func (f *fakeRedSkyServer) LabelTrial(ctx context.Context, name string, labels experimentsapi.TrialLabels) error {
+func (f *fakeRedSkyServer) LabelTrial(ctx context.Context, name string, labels experimentsv1alpha1.TrialLabels) error {
 	return nil
 }

--- a/redskyctl/internal/commands/export/export_util_test.go
+++ b/redskyctl/internal/commands/export/export_util_test.go
@@ -23,15 +23,15 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/thestormforge/konjure/pkg/konjure"
-	app "github.com/thestormforge/optimize-controller/v2/api/apps/v1alpha1"
-	redsky "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizeappsv1alpha1 "github.com/thestormforge/optimize-controller/v2/api/apps/v1alpha1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 )
 
-func createTempExperimentFile(t *testing.T) (*redsky.Experiment, []byte, *os.File) {
+func createTempExperimentFile(t *testing.T) (*optimizev1beta1.Experiment, []byte, *os.File) {
 	samplePatch := `spec:
    template:
      spec:
@@ -46,23 +46,23 @@ func createTempExperimentFile(t *testing.T) (*redsky.Experiment, []byte, *os.Fil
                memory: "{{ .Values.memory }}Mi"`
 
 	tm := &metav1.TypeMeta{}
-	tm.SetGroupVersionKind(redsky.GroupVersion.WithKind("Experiment"))
-	sampleExperiment := &redsky.Experiment{
+	tm.SetGroupVersionKind(optimizev1beta1.GroupVersion.WithKind("Experiment"))
+	sampleExperiment := &optimizev1beta1.Experiment{
 		TypeMeta: *tm,
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "sampleExperiment",
 			Namespace: "default",
 		},
-		Spec: redsky.ExperimentSpec{
-			Parameters: []redsky.Parameter{
+		Spec: optimizev1beta1.ExperimentSpec{
+			Parameters: []optimizev1beta1.Parameter{
 				{
 					Name: "myparam",
 					Min:  100,
 					Max:  1000,
 				},
 			},
-			Metrics: []redsky.Metric{},
-			Patches: []redsky.PatchTemplate{
+			Metrics: []optimizev1beta1.Metric{},
+			Patches: []optimizev1beta1.PatchTemplate{
 				{
 					TargetRef: &corev1.ObjectReference{
 						Kind:       "Deployment",
@@ -72,9 +72,9 @@ func createTempExperimentFile(t *testing.T) (*redsky.Experiment, []byte, *os.Fil
 					Patch: samplePatch,
 				},
 			},
-			TrialTemplate: redsky.TrialTemplateSpec{},
+			TrialTemplate: optimizev1beta1.TrialTemplateSpec{},
 		},
-		Status: redsky.ExperimentStatus{},
+		Status: optimizev1beta1.ExperimentStatus{},
 	}
 
 	tmpfile, err := ioutil.TempFile("", "experiment-*.yaml")
@@ -99,44 +99,44 @@ func createTempManifests(t *testing.T) *os.File {
 	return tmpfile
 }
 
-func createTempApplication(t *testing.T, filename string) (*app.Application, []byte, *os.File) {
+func createTempApplication(t *testing.T, filename string) (*optimizeappsv1alpha1.Application, []byte, *os.File) {
 	tm := &metav1.TypeMeta{}
-	tm.SetGroupVersionKind(app.GroupVersion.WithKind("Application"))
-	sampleApplication := &app.Application{
+	tm.SetGroupVersionKind(optimizeappsv1alpha1.GroupVersion.WithKind("Application"))
+	sampleApplication := &optimizeappsv1alpha1.Application{
 		TypeMeta: *tm,
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "sampleApplication",
 			Namespace: "default",
 		},
 		Resources: konjure.Resources{konjure.NewResource(filename)},
-		Parameters: []app.Parameter{
+		Parameters: []optimizeappsv1alpha1.Parameter{
 			{
-				ContainerResources: &app.ContainerResources{
+				ContainerResources: &optimizeappsv1alpha1.ContainerResources{
 					Selector: "component=postgres",
 				},
 			},
 		},
-		Scenarios: []app.Scenario{
+		Scenarios: []optimizeappsv1alpha1.Scenario{
 			{
 				Name: "how-do-you-make-a-tissue-dance",
-				StormForger: &app.StormForgerScenario{
+				StormForger: &optimizeappsv1alpha1.StormForgerScenario{
 					TestCase: "tissue-box",
 				},
 			},
 			{
 				Name: "put-a-little-boogie-in-it",
-				StormForger: &app.StormForgerScenario{
+				StormForger: &optimizeappsv1alpha1.StormForgerScenario{
 					TestCase: "boogie",
 				},
 			},
 		},
-		Objectives: []app.Objective{
+		Objectives: []optimizeappsv1alpha1.Objective{
 			{
-				Goals: []app.Goal{
+				Goals: []optimizeappsv1alpha1.Goal{
 					{
 						Name: "cost",
 						Max:  resource.NewQuantity(100, resource.DecimalExponent),
-						Requests: &app.RequestsGoal{
+						Requests: &optimizeappsv1alpha1.RequestsGoal{
 							Selector: "everybody=yes",
 							Weights: corev1.ResourceList{
 								corev1.ResourceCPU:    resource.MustParse("100m"),
@@ -150,14 +150,14 @@ func createTempApplication(t *testing.T, filename string) (*app.Application, []b
 			// {
 			// 	Name: "latency",
 			// 	Max:  resource.NewQuantity(50, resource.DecimalExponent),
-			// 	Latency: &app.LatencyObjective{
-			// 		LatencyType: app.LatencyPercentile99,
+			// 	Latency: &optimizeappsv1alpha1.LatencyObjective{
+			// 		LatencyType: optimizeappsv1alpha1.LatencyPercentile99,
 			// 	},
 			// },
 		},
-		StormForger: &app.StormForger{
+		StormForger: &optimizeappsv1alpha1.StormForger{
 			Organization: "gotta",
-			AccessToken: &app.StormForgerAccessToken{
+			AccessToken: &optimizeappsv1alpha1.StormForgerAccessToken{
 				Literal: "get down!",
 			},
 		},

--- a/redskyctl/internal/commands/generate/experiment.go
+++ b/redskyctl/internal/commands/generate/experiment.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/thestormforge/konjure/pkg/konjure"
-	redskyappsv1alpha1 "github.com/thestormforge/optimize-controller/v2/api/apps/v1alpha1"
+	optimizeappsv1alpha1 "github.com/thestormforge/optimize-controller/v2/api/apps/v1alpha1"
 	"github.com/thestormforge/optimize-controller/v2/internal/experiment"
 	"github.com/thestormforge/optimize-controller/v2/redskyctl/internal/commander"
 	"github.com/thestormforge/optimize-go/pkg/config"
@@ -115,7 +115,7 @@ func (o *ExperimentOptions) generate() error {
 	return o.Generator.Execute(o.YAMLWriter())
 }
 
-func (o *ExperimentOptions) filterResources(app *redskyappsv1alpha1.Application) error {
+func (o *ExperimentOptions) filterResources(app *optimizeappsv1alpha1.Application) error {
 	// Add additional resources (this allows addition manifests to be added when invoking the CLI)
 	if len(o.Resources) > 0 {
 		app.Resources = append(app.Resources, konjure.NewResource(o.Resources...))

--- a/redskyctl/internal/commands/generate/rbac.go
+++ b/redskyctl/internal/commands/generate/rbac.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	"github.com/thestormforge/optimize-controller/v2/redskyctl/internal/commander"
 	"github.com/thestormforge/optimize-go/pkg/config"
 	corev1 "k8s.io/api/core/v1"
@@ -132,7 +132,7 @@ func (o *RBACOptions) generate() error {
 	}
 
 	// Read the experiments
-	experimentList := &redskyv1beta1.ExperimentList{}
+	experimentList := &optimizev1beta1.ExperimentList{}
 	rr := commander.NewResourceReader()
 	if err := rr.ReadInto(r, experimentList); err != nil {
 		return err
@@ -162,7 +162,7 @@ func (o *RBACOptions) generate() error {
 	return o.Printer.PrintObj(rbac, o.Out)
 }
 
-func (o *RBACOptions) bindingTargets(experimentList *redskyv1beta1.ExperimentList) (*rbacv1.RoleRef, *rbacv1.Subject, []string, error) {
+func (o *RBACOptions) bindingTargets(experimentList *optimizev1beta1.ExperimentList) (*rbacv1.RoleRef, *rbacv1.Subject, []string, error) {
 	// Read the configuration objects we need
 	r := o.Config.Reader()
 	ctrl, err := config.CurrentController(r)
@@ -272,7 +272,7 @@ func buildRBAC(roleRef *rbacv1.RoleRef, subject *rbacv1.Subject, rules []rbacv1.
 }
 
 // appendRules finds the patch and readiness targets from an experiment
-func (o *RBACOptions) appendRules(rules []*rbacv1.PolicyRule, exp *redskyv1beta1.Experiment) []*rbacv1.PolicyRule {
+func (o *RBACOptions) appendRules(rules []*rbacv1.PolicyRule, exp *optimizev1beta1.Experiment) []*rbacv1.PolicyRule {
 	// Patches require "get" and "patch" permissions
 	for i := range exp.Spec.Patches {
 		// TODO This needs to use patch_controller.go `renderTemplate` to get the correct reference (e.g. SMP may have the ref in the payload)
@@ -334,7 +334,7 @@ func (o *RBACOptions) newPolicyRule(ref *corev1.ObjectReference, verbs ...string
 }
 
 // roleName attempts to generate a semi-unique role name
-func roleName(filename string, experimentList *redskyv1beta1.ExperimentList) string {
+func roleName(filename string, experimentList *optimizev1beta1.ExperimentList) string {
 	// If there is a single experiment, incorporate it's name into the role name
 	if len(experimentList.Items) == 1 && experimentList.Items[0].Name != "" {
 		return fmt.Sprintf("redsky-patching-%s-role", experimentList.Items[0].Name)

--- a/redskyctl/internal/commands/generate/trial.go
+++ b/redskyctl/internal/commands/generate/trial.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	"github.com/thestormforge/optimize-controller/v2/internal/experiment"
 	"github.com/thestormforge/optimize-controller/v2/internal/server"
 	"github.com/thestormforge/optimize-controller/v2/internal/setup"
@@ -89,7 +89,7 @@ func (o *TrialOptions) generate() error {
 	}
 
 	// Read the experiment
-	exp := &redskyv1beta1.Experiment{}
+	exp := &optimizev1beta1.Experiment{}
 	rr := commander.NewResourceReader()
 	if err := rr.ReadInto(r, exp); err != nil {
 		return err
@@ -119,7 +119,7 @@ func (o *TrialOptions) generate() error {
 	}
 
 	// Build the trial
-	t := &redskyv1beta1.Trial{}
+	t := &optimizev1beta1.Trial{}
 	experiment.PopulateTrialFromTemplate(exp, t)
 	server.ToClusterTrial(t, &ta)
 
@@ -143,7 +143,7 @@ func (o *TrialOptions) generate() error {
 	return o.Printer.PrintObj(job, o.Out)
 }
 
-func newJob(t *redskyv1beta1.Trial, mode string, trialNumber int) (*batchv1.Job, error) {
+func newJob(t *optimizev1beta1.Trial, mode string, trialNumber int) (*batchv1.Job, error) {
 	// Make sure the trial has a name when generating the jobs or we produce invalid output
 	if t.Name == "" {
 		t.Name = fmt.Sprintf("%s%d", t.GenerateName, trialNumber)

--- a/redskyctl/internal/commands/run/command.go
+++ b/redskyctl/internal/commands/run/command.go
@@ -30,7 +30,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/muesli/termenv"
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	"github.com/thestormforge/optimize-controller/v2/redskyctl/internal/commander"
 	"github.com/thestormforge/optimize-controller/v2/redskyctl/internal/commands/check"
 	"github.com/thestormforge/optimize-controller/v2/redskyctl/internal/commands/initialize"
@@ -293,9 +293,9 @@ func (o *Options) refreshTrials() tea.Msg {
 	}
 	for _, node := range expNodes {
 		switch {
-		case conditionStatus(node, redskyv1beta1.ExperimentComplete) == corev1.ConditionTrue:
+		case conditionStatus(node, optimizev1beta1.ExperimentComplete) == corev1.ConditionTrue:
 			return internal.ExperimentFinishedMsg{}
-		case conditionStatus(node, redskyv1beta1.ExperimentFailed) == corev1.ConditionTrue:
+		case conditionStatus(node, optimizev1beta1.ExperimentFailed) == corev1.ConditionTrue:
 			return internal.ExperimentFinishedMsg{Failed: true}
 		}
 	}
@@ -393,7 +393,7 @@ func (r *execReader) Read() ([]*yaml.RNode, error) {
 }
 
 // conditionStatus looks for experiment conditions given a YAML representation of the experiment.
-func conditionStatus(n *yaml.RNode, t redskyv1beta1.ExperimentConditionType) corev1.ConditionStatus {
+func conditionStatus(n *yaml.RNode, t optimizev1beta1.ExperimentConditionType) corev1.ConditionStatus {
 	v, err := n.Pipe(yaml.Lookup("status", "conditions", fmt.Sprintf("[type=%s]", t), "status"))
 	if err == nil && v != nil {
 		return corev1.ConditionStatus(v.YNode().Value)

--- a/redskyctl/internal/commands/run/model.go
+++ b/redskyctl/internal/commands/run/model.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
-	redskyv1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
+	optimizev1beta1 "github.com/thestormforge/optimize-controller/v2/api/v1beta1"
 	"github.com/thestormforge/optimize-controller/v2/internal/sfio"
 	"github.com/thestormforge/optimize-controller/v2/redskyctl/internal/commands/run/form"
 	"github.com/thestormforge/optimize-controller/v2/redskyctl/internal/commands/run/internal"
@@ -244,7 +244,7 @@ func (m *generatorModel) updateLabelSelectorInputs() {
 }
 
 type previewModel struct {
-	Experiment  *redskyv1beta1.Experiment
+	Experiment  *optimizev1beta1.Experiment
 	Destination form.ChoiceField
 	Create      bool
 	Filename    form.TextField
@@ -274,7 +274,7 @@ func (m previewModel) Update(msg tea.Msg) (previewModel, tea.Cmd) {
 			return m, internal.Error(err)
 		}
 		for i := range obj.Items {
-			if exp, ok := obj.Items[i].Object.(*redskyv1beta1.Experiment); ok {
+			if exp, ok := obj.Items[i].Object.(*optimizev1beta1.Experiment); ok {
 				m.Experiment = exp
 			}
 		}

--- a/redskyctl/internal/commands/run/run.go
+++ b/redskyctl/internal/commands/run/run.go
@@ -29,7 +29,7 @@ import (
 	"github.com/spf13/cobra"
 	konjurev1beta2 "github.com/thestormforge/konjure/pkg/api/core/v1beta2"
 	"github.com/thestormforge/konjure/pkg/konjure"
-	redskyappsv1alpha1 "github.com/thestormforge/optimize-controller/v2/api/apps/v1alpha1"
+	optimizeappsv1alpha1 "github.com/thestormforge/optimize-controller/v2/api/apps/v1alpha1"
 	"github.com/thestormforge/optimize-controller/v2/internal/experiment"
 	"github.com/thestormforge/optimize-controller/v2/internal/version"
 	"github.com/thestormforge/optimize-controller/v2/redskyctl/internal/commander"
@@ -271,7 +271,7 @@ func (o *Options) ReadApplication(args []string) error {
 }
 
 // applyToApp takes all of the what is on the model and applies it to an application.
-func (m generatorModel) applyToApp(app *redskyappsv1alpha1.Application) {
+func (m generatorModel) applyToApp(app *optimizeappsv1alpha1.Application) {
 	if m.NamespaceInput.Enabled() {
 
 		// TODO We need a better way to set the name/namespace of the application
@@ -292,8 +292,8 @@ func (m generatorModel) applyToApp(app *redskyappsv1alpha1.Application) {
 
 	if m.StormForgerTestCaseInput.Enabled() {
 		if testCase := m.StormForgerTestCaseInput.Value(); testCase != "" {
-			app.Scenarios = append(app.Scenarios, redskyappsv1alpha1.Scenario{
-				StormForger: &redskyappsv1alpha1.StormForgerScenario{
+			app.Scenarios = append(app.Scenarios, optimizeappsv1alpha1.Scenario{
+				StormForger: &optimizeappsv1alpha1.StormForgerScenario{
 					TestCase: testCase,
 				},
 			})
@@ -302,8 +302,8 @@ func (m generatorModel) applyToApp(app *redskyappsv1alpha1.Application) {
 
 	if m.LocustfileInput.Enabled() {
 		if locustfile := m.LocustfileInput.Value(); locustfile != "" {
-			app.Scenarios = append(app.Scenarios, redskyappsv1alpha1.Scenario{
-				Locust: &redskyappsv1alpha1.LocustScenario{
+			app.Scenarios = append(app.Scenarios, optimizeappsv1alpha1.Scenario{
+				Locust: &optimizeappsv1alpha1.LocustScenario{
 					Locustfile: locustfile,
 				},
 			})
@@ -312,7 +312,7 @@ func (m generatorModel) applyToApp(app *redskyappsv1alpha1.Application) {
 
 	if m.IngressURLInput.Enabled() {
 		if u := m.IngressURLInput.Value(); u != "" {
-			app.Ingress = &redskyappsv1alpha1.Ingress{
+			app.Ingress = &optimizeappsv1alpha1.Ingress{
 				URL: u,
 			}
 		}
@@ -323,8 +323,8 @@ func (m generatorModel) applyToApp(app *redskyappsv1alpha1.Application) {
 		// that empty matches everything (even if other parameters have been specified).
 		// We CANNOT rely on the default behavior of the generator for this, since
 		// the presence of any parameter bypasses the default inclusion of container resources.
-		app.Parameters = append(app.Parameters, redskyappsv1alpha1.Parameter{
-			ContainerResources: &redskyappsv1alpha1.ContainerResources{
+		app.Parameters = append(app.Parameters, optimizeappsv1alpha1.Parameter{
+			ContainerResources: &optimizeappsv1alpha1.ContainerResources{
 				Selector: m.ContainerResourcesSelectorInput.Value(),
 			},
 		})
@@ -332,8 +332,8 @@ func (m generatorModel) applyToApp(app *redskyappsv1alpha1.Application) {
 
 	if m.ReplicasSelectorInput.Enabled() {
 		if sel := m.ReplicasSelectorInput.Value(); sel != "" {
-			app.Parameters = append(app.Parameters, redskyappsv1alpha1.Parameter{
-				Replicas: &redskyappsv1alpha1.Replicas{
+			app.Parameters = append(app.Parameters, optimizeappsv1alpha1.Parameter{
+				Replicas: &optimizeappsv1alpha1.Replicas{
 					Selector: sel,
 				},
 			})
@@ -341,16 +341,16 @@ func (m generatorModel) applyToApp(app *redskyappsv1alpha1.Application) {
 	}
 
 	if m.ObjectiveInput.Enabled() {
-		app.Objectives = append(app.Objectives, redskyappsv1alpha1.Objective{})
+		app.Objectives = append(app.Objectives, optimizeappsv1alpha1.Objective{})
 		for _, goal := range m.ObjectiveInput.Values() {
-			app.Objectives[0].Goals = append(app.Objectives[0].Goals, redskyappsv1alpha1.Goal{Name: goal})
+			app.Objectives[0].Goals = append(app.Objectives[0].Goals, optimizeappsv1alpha1.Goal{Name: goal})
 		}
 	}
 
 }
 
 // readIntoApplication reads the supplied source relative to a working directory.
-func readIntoApplication(src, wd string, app *redskyappsv1alpha1.Application) (string, error) {
+func readIntoApplication(src, wd string, app *optimizeappsv1alpha1.Application) (string, error) {
 	path := filepath.Join(wd, src)
 
 	// Try to use go-getter to support non-file inputs

--- a/redskyctl/internal/commands/run/view.go
+++ b/redskyctl/internal/commands/run/view.go
@@ -23,7 +23,7 @@ import (
 	"text/tabwriter"
 
 	tea "github.com/charmbracelet/bubbletea"
-	redskyappsv1alpha1 "github.com/thestormforge/optimize-controller/v2/api/apps/v1alpha1"
+	optimizeappsv1alpha1 "github.com/thestormforge/optimize-controller/v2/api/apps/v1alpha1"
 	"github.com/thestormforge/optimize-controller/v2/redskyctl/internal/commands/run/form"
 	"github.com/thestormforge/optimize-controller/v2/redskyctl/internal/commands/run/internal"
 	"github.com/thestormforge/optimize-controller/v2/redskyctl/internal/commands/run/out"
@@ -360,7 +360,7 @@ func (m previewModel) View() string {
 	view.Step(out.Ready, "Your experiment is ready to run!")
 
 	view.Newline()
-	view.Step(out.Preview, "Application Name: %s", m.Experiment.Labels[redskyappsv1alpha1.LabelApplication])
+	view.Step(out.Preview, "Application Name: %s", m.Experiment.Labels[optimizeappsv1alpha1.LabelApplication])
 	view.Step(out.Preview, "Experiment Name: %s", m.Experiment.Name)
 	view.Step(out.Preview, "Parameters:")
 	for i := range m.Experiment.Spec.Parameters {


### PR DESCRIPTION
This PR updates the import aliases to remove "redsky" references. There was some inconsistencies with import alias usage that was normalized as well.

This one was painful but it accounts for the largest number of "Red Sky" textual matches in the project.