### PR TITLE
Rename labels, annotations, and finalizers

### DIFF
--- a/.github/workflows/kubematrix.yaml
+++ b/.github/workflows/kubematrix.yaml
@@ -66,4 +66,4 @@ jobs:
         if: ${{ failure() }}
         run: |
           kubectl get trial,experiment,svc,pod -o wide
-          kubectl get pods -o wide -l redskyops.dev/experiment=postgres-example
+          kubectl get pods -o wide -l stormforge.io/experiment=postgres-example

--- a/api/apps/v1alpha1/well_known_labels.go
+++ b/api/apps/v1alpha1/well_known_labels.go
@@ -20,13 +20,13 @@ package v1alpha1
 
 const (
 	// LabelApplication is the name of the application associated with an object.
-	LabelApplication = "redskyops.dev/application"
+	LabelApplication = "stormforge.io/application"
 
 	// LabelScenario is the application scenario associated with an object.
-	LabelScenario = "redskyops.dev/scenario"
+	LabelScenario = "stormforge.io/scenario"
 
 	// LabelObjective is the application objective associated with an object.
-	LabelObjective = "redskyops.dev/objective"
+	LabelObjective = "stormforge.io/objective"
 
 	// AnnotationLastScanned is the timestamp of the last application scan.
 	AnnotationLastScanned = "apps.stormforge.io/last-scanned"

--- a/api/v1beta1/well_known_labels.go
+++ b/api/v1beta1/well_known_labels.go
@@ -20,16 +20,16 @@ package v1beta1
 
 const (
 	// AnnotationExperimentURL is the URL of the experiment on the remote server
-	AnnotationExperimentURL = "redskyops.dev/experiment-url"
+	AnnotationExperimentURL = "stormforge.io/experiment-url"
 	// AnnotationNextTrialURL is the URL used to obtain the next trial suggestion
-	AnnotationNextTrialURL = "redskyops.dev/next-trial-url"
+	AnnotationNextTrialURL = "stormforge.io/next-trial-url"
 	// AnnotationReportTrialURL is the URL used to report trial observations
-	AnnotationReportTrialURL = "redskyops.dev/report-trial-url"
+	AnnotationReportTrialURL = "stormforge.io/report-trial-url"
 	// AnnotationServerSync controls additional behavior around synchronizing the experiment remotely
-	AnnotationServerSync = "redskyops.dev/server-sync"
+	AnnotationServerSync = "stormforge.io/server-sync"
 
 	// LabelExperiment is the name of the experiment associated with an object
-	LabelExperiment = "redskyops.dev/experiment"
+	LabelExperiment = "stormforge.io/experiment"
 )
 
 // Trial labels and annotations
@@ -37,10 +37,10 @@ const (
 const (
 	// AnnotationInitializer is a comma-delimited list of initializing processes. Similar to a "finalizer", the trial
 	// will not start executing until the initializer is empty.
-	AnnotationInitializer = "redskyops.dev/initializer"
+	AnnotationInitializer = "stormforge.io/initializer"
 
 	// LabelTrial contains the name of the trial associated with an object
-	LabelTrial = "redskyops.dev/trial"
+	LabelTrial = "stormforge.io/trial"
 	// LabelTrialRole contains the role in trial execution
-	LabelTrialRole = "redskyops.dev/trial-role"
+	LabelTrialRole = "stormforge.io/trial-role"
 )

--- a/config/docker-entrypoint.sh
+++ b/config/docker-entrypoint.sh
@@ -53,8 +53,8 @@ if [ -n "$TRIAL" ]; then
 		metadata:
 		  name: trial-labels
 		labels:
-		  "redskyops.dev/trial": $TRIAL
-		  "redskyops.dev/trial-role": trialResource
+		  "stormforge.io/trial": $TRIAL
+		  "stormforge.io/trial-role": trialResource
 		EOF
     konjure kustomize edit add transformer trial_labels.yaml
 fi
@@ -68,7 +68,7 @@ while [ "$#" != "0" ] ; do
             # Note, this *must* be create for `generateName` to work properly
             kubectl create -f -
             #if [ -n "$TRIAL" ] && [ -n "$NAMESPACE" ] ; then
-            #    kubectl get sts,deploy,ds --namespace "$NAMESPACE" --selector "redskyops.dev/trial=$TRIAL,redskyops.dev/trial-role=trialResource" -o name | xargs -n 1 kubectl rollout status --namespace "$NAMESPACE"
+            #    kubectl get sts,deploy,ds --namespace "$NAMESPACE" --selector "stormforge.io/trial=$TRIAL,stormforge.io/trial-role=trialResource" -o name | xargs -n 1 kubectl rollout status --namespace "$NAMESPACE"
             #fi
         }
         shift
@@ -77,7 +77,7 @@ while [ "$#" != "0" ] ; do
         handle () {
             kubectl delete -f -
             if [ -n "$TRIAL" ] && [ -n "$NAMESPACE" ] ; then
-                kubectl wait pods --for=delete --namespace "$NAMESPACE" --selector "redskyops.dev/trial=$TRIAL,redskyops.dev/trial-role=trialResource"
+                kubectl wait pods --for=delete --namespace "$NAMESPACE" --selector "stormforge.io/trial=$TRIAL,stormforge.io/trial-role=trialResource"
             fi
         }
         waitFn () { :; }

--- a/hack/integration.sh
+++ b/hack/integration.sh
@@ -41,7 +41,7 @@ generateAndWait() {
   waitTime=300s
   echo "Wait for trial to complete (${waitTime} timeout)"
   kubectl wait trial \
-    -l redskyops.dev/application=ci \
+    -l stormforge.io/application=ci \
     --for condition=redskyops.dev/trial-complete \
     --timeout ${waitTime}
 
@@ -51,7 +51,7 @@ generateAndWait() {
     --for=delete \
     --timeout ${waitTime}
   kubectl wait job \
-    -l redskyops.dev/trial-role=trialSetup \
+    -l stormforge.io/trial-role=trialSetup \
     --for condition=complete \
     --timeout ${waitTime}
 

--- a/internal/experiment/experiment.go
+++ b/internal/experiment/experiment.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	// HasTrialFinalizer is a finalizer that indicates an experiment has at least one trial
-	HasTrialFinalizer = "hasTrialFinalizer.redskyops.dev"
+	HasTrialFinalizer = "hasTrialFinalizer.stormforge.io"
 )
 
 // TODO Make the constant names better reflect the code, not the text

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -36,7 +36,7 @@ import (
 
 const (
 	// Finalizer is used to ensure synchronization with the server
-	Finalizer = "serverFinalizer.redskyops.dev"
+	Finalizer = "serverFinalizer.stormforge.io"
 )
 
 // TODO Split this into trial.go and experiment.go ?
@@ -53,7 +53,7 @@ func FromCluster(in *optimizev1beta1.Experiment) (experimentsv1alpha1.Experiment
 	if l := len(in.ObjectMeta.Labels); l > 0 {
 		out.Labels = make(map[string]string, l)
 		for k, v := range in.ObjectMeta.Labels {
-			k = strings.TrimPrefix(k, "redskyops.dev/")
+			k = strings.TrimPrefix(k, "stormforge.io/")
 			out.Labels[k] = v
 		}
 	}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -433,9 +433,9 @@ func TestToClusterTrial(t *testing.T) {
 			trialOut: &optimizev1beta1.Trial{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						"redskyops.dev/report-trial-url": "",
+						"stormforge.io/report-trial-url": "",
 					},
-					Finalizers: []string{"serverFinalizer.redskyops.dev"},
+					Finalizers: []string{"serverFinalizer.stormforge.io"},
 				},
 				Spec: optimizev1beta1.TrialSpec{
 					Assignments: []optimizev1beta1.Assignment{

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -33,9 +33,9 @@ const (
 	ModeDelete = "delete"
 
 	// Initializer is used to paused the trial initialization for setup tasks
-	Initializer = "setupInitializer.redskyops.dev"
+	Initializer = "setupInitializer.stormforge.io"
 	// Finalizer is used to prevent the trial deletion for setup tasks
-	Finalizer = "setupFinalizer.redskyops.dev"
+	Finalizer = "setupFinalizer.stormforge.io"
 )
 
 // UpdateStatus returns true if there are setup tasks

--- a/redskyctl/internal/commands/authorize_cluster/authorize_cluster.go
+++ b/redskyctl/internal/commands/authorize_cluster/authorize_cluster.go
@@ -144,7 +144,7 @@ spec:
   template:
     metadata:
       annotations:
-        "redskyops.dev/secretHash": "{{ .SecretHash }}"
+        "stormforge.io/secretHash": "{{ .SecretHash }}"
     spec:
       containers:
       - name: manager

--- a/redskyctl/internal/commands/fix/fix.go
+++ b/redskyctl/internal/commands/fix/fix.go
@@ -57,7 +57,7 @@ func (o *Options) Fix() error {
 	p := kio.Pipeline{
 		Filters: []kio.Filter{
 			kio.FilterAll(&sfio.ExperimentMigrationFilter{}),
-			// TODO LabelMigrationFilter for things like `redskyops.dev/application: votingapp` on non-CRD resources (and CRD resources!)
+			kio.FilterAll(&sfio.MetadataMigrationFilter{}),
 			filters.FormatFilter{},
 		},
 	}


### PR DESCRIPTION
This PR changes the prefix from our metadata keys from `redskyops.dev` to `stormforge.io` (same for finalizers).

The necessary migrations have been added to the `fix` command as well.