### PR TITLE
Update conditions to stormforge.io

### DIFF
--- a/api/v1alpha1/experiment_types.go
+++ b/api/v1alpha1/experiment_types.go
@@ -134,7 +134,7 @@ type PatchTemplate struct {
 	// ReadinessGates will be evaluated for patch target readiness. A patch target is ready if all conditions specified
 	// in the readiness gates have a status equal to "True". If no readiness gates are specified, some target types may
 	// have default gates assigned to them. Some condition checks may result in errors, e.g. a condition type of "Ready"
-	// is not allowed for a ConfigMap. Condition types starting with "redskyops.dev/" may not appear in the patched
+	// is not allowed for a ConfigMap. Condition types starting with "stormforge.io/" may not appear in the patched
 	// target's condition list, but are still evaluated against the resource's state.
 	ReadinessGates []PatchReadinessGate `json:"readinessGates,omitempty"`
 }

--- a/api/v1alpha1/trial_types.go
+++ b/api/v1alpha1/trial_types.go
@@ -150,7 +150,7 @@ type ReadinessCheck struct {
 	// in particular "list" permissions are required
 	Selector *metav1.LabelSelector `json:"selector,omitempty"`
 	// ConditionTypes are the status conditions that must be "True"; in addition to conditions that appear in the
-	// status of the target object, additional special conditions starting with "redskyops.dev/" can be tested
+	// status of the target object, additional special conditions starting with "stormforge.io/" can be tested
 	ConditionTypes []string `json:"conditionTypes,omitempty"`
 	// InitialDelaySeconds is the approximate number of seconds after all of the patches have been applied to start
 	// evaluating this check
@@ -183,7 +183,7 @@ type TrialConditionType string
 
 // TrialCondition represents an observed condition of a trial
 type TrialCondition struct {
-	// The condition type, e.g. "redskyops.dev/trial-complete"
+	// The condition type, e.g. "stormforge.io/trial-complete"
 	Type TrialConditionType `json:"type"`
 	// The status of the condition, one of "True", "False", or "Unknown
 	Status corev1.ConditionStatus `json:"status"`

--- a/api/v1beta1/experiment_types.go
+++ b/api/v1beta1/experiment_types.go
@@ -194,7 +194,7 @@ type PatchTemplate struct {
 	// ReadinessGates will be evaluated for patch target readiness. A patch target is ready if all conditions specified
 	// in the readiness gates have a status equal to "True". If no readiness gates are specified, some target types may
 	// have default gates assigned to them. Some condition checks may result in errors, e.g. a condition type of "Ready"
-	// is not allowed for a ConfigMap. Condition types starting with "redskyops.dev/" may not appear in the patched
+	// is not allowed for a ConfigMap. Condition types starting with "stormforge.io/" may not appear in the patched
 	// target's condition list, but are still evaluated against the resource's state.
 	ReadinessGates []PatchReadinessGate `json:"readinessGates,omitempty"`
 }
@@ -220,9 +220,9 @@ type ExperimentConditionType string
 
 const (
 	// ExperimentComplete is a condition that indicates the experiment completed successfully
-	ExperimentComplete ExperimentConditionType = "redskyops.dev/experiment-complete"
+	ExperimentComplete ExperimentConditionType = "stormforge.io/experiment-complete"
 	// ExperimentFailed is a condition that indicates an experiment failed
-	ExperimentFailed ExperimentConditionType = "redskyops.dev/experiment-failed"
+	ExperimentFailed ExperimentConditionType = "stormforge.io/experiment-failed"
 )
 
 // ExperimentCondition represents an observed condition of an experiment

--- a/api/v1beta1/trial_types.go
+++ b/api/v1beta1/trial_types.go
@@ -150,7 +150,7 @@ type ReadinessCheck struct {
 	// in particular "list" permissions are required
 	Selector *metav1.LabelSelector `json:"selector,omitempty"`
 	// ConditionTypes are the status conditions that must be "True"; in addition to conditions that appear in the
-	// status of the target object, additional special conditions starting with "redskyops.dev/" can be tested
+	// status of the target object, additional special conditions starting with "stormforge.io/" can be tested
 	ConditionTypes []string `json:"conditionTypes,omitempty"`
 	// InitialDelaySeconds is the approximate number of seconds after all of the patches have been applied to start
 	// evaluating this check
@@ -183,24 +183,24 @@ type TrialConditionType string
 
 const (
 	// TrialComplete is a condition that indicates a successful trial run
-	TrialComplete TrialConditionType = "redskyops.dev/trial-complete"
+	TrialComplete TrialConditionType = "stormforge.io/trial-complete"
 	// TrialFailed is a condition that indicates a failed trial run
-	TrialFailed TrialConditionType = "redskyops.dev/trial-failed"
+	TrialFailed TrialConditionType = "stormforge.io/trial-failed"
 	// TrialSetupCreated is a condition that indicates all "create" setup tasks have finished
-	TrialSetupCreated TrialConditionType = "redskyops.dev/trial-setup-created"
+	TrialSetupCreated TrialConditionType = "stormforge.io/trial-setup-created"
 	// TrialSetupDeleted is a condition that indicates all "delete" setup tasks have finished
-	TrialSetupDeleted TrialConditionType = "redskyops.dev/trial-setup-deleted"
+	TrialSetupDeleted TrialConditionType = "stormforge.io/trial-setup-deleted"
 	// TrialPatched is a condition that indicates patches have been applied for a trial
-	TrialPatched TrialConditionType = "redskyops.dev/trial-patched"
+	TrialPatched TrialConditionType = "stormforge.io/trial-patched"
 	// TrialReady is a condition that indicates the application is ready after patches were applied
-	TrialReady TrialConditionType = "redskyops.dev/trial-ready"
+	TrialReady TrialConditionType = "stormforge.io/trial-ready"
 	// TrialObserved is a condition that indicates a trial has had metrics collected
-	TrialObserved TrialConditionType = "redskyops.dev/trial-observed"
+	TrialObserved TrialConditionType = "stormforge.io/trial-observed"
 )
 
 // TrialCondition represents an observed condition of a trial
 type TrialCondition struct {
-	// The condition type, e.g. "redskyops.dev/trial-complete"
+	// The condition type, e.g. "stormforge.io/trial-complete"
 	Type TrialConditionType `json:"type"`
 	// The status of the condition, one of "True", "False", or "Unknown
 	Status corev1.ConditionStatus `json:"status"`

--- a/hack/integration.sh
+++ b/hack/integration.sh
@@ -42,7 +42,7 @@ generateAndWait() {
   echo "Wait for trial to complete (${waitTime} timeout)"
   kubectl wait trial \
     -l stormforge.io/application=ci \
-    --for condition=redskyops.dev/trial-complete \
+    --for condition=stormforge.io/trial-complete \
     --timeout ${waitTime}
 
   echo "Wait for trial deletion tasks to finish running"

--- a/internal/ready/ready.go
+++ b/internal/ready/ready.go
@@ -34,22 +34,22 @@ import (
 
 const (
 	// ConditionTypeAlwaysTrue is a special condition type whose status is always "True"
-	ConditionTypeAlwaysTrue = "redskyops.dev/always-true"
+	ConditionTypeAlwaysTrue = "stormforge.io/always-true"
 	// ConditionTypePodReady is a special condition type whose status is determined by fetching the pods associated
 	// with the target object and checking that they all have a condition type of "Ready" with a status of "True".
-	ConditionTypePodReady = "redskyops.dev/pod-ready"
+	ConditionTypePodReady = "stormforge.io/pod-ready"
 	// ConditionTypeRolloutStatus is a special condition type whose status is determined using the equivalent of a
 	// `kubectl rollout status` call on the target object. This condition will return "True" when evaluated against
 	// an object whose "update strategy" is not "RollingUpdate"; use the "app ready" check to perform a rollout
 	// status that falls back to a pod readiness check in cases where the rollout status cannot be determined.
-	ConditionTypeRolloutStatus = "redskyops.dev/rollout-status"
+	ConditionTypeRolloutStatus = "stormforge.io/rollout-status"
 	// ConditionTypeAppReady is a special condition type that combines the efficiency of the rollout status check,
 	// the compatibility of the pod ready check.
-	ConditionTypeAppReady = "redskyops.dev/app-ready"
+	ConditionTypeAppReady = "stormforge.io/app-ready"
 	// ConditionTypeStatus is a special condition type that can be used to check an arbitrary string on the status
 	// of the target object. The name of the status field and the expected value (indicating a ready state) should
-	// be appended to this constant, e.g. `"redskyops.dev/status-phase-running"` to check for a running pod.
-	ConditionTypeStatus = "redskyops.dev/status-"
+	// be appended to this constant, e.g. `"stormforge.io/status-phase-running"` to check for a running pod.
+	ConditionTypeStatus = "stormforge.io/status-"
 )
 
 // ReadinessChecker is used to check the conditions of runtime objects
@@ -79,7 +79,7 @@ func (e *ReadinessError) Error() string {
 
 // CheckConditions checks to see that all of the listed conditions have a status of true on the specified object. Note
 // that in addition to generically checking in the `status.conditions` field, special conditions are also supported. The
-// special conditions are prefixed with "redskyops.dev/".
+// special conditions are prefixed with "stormforge.io/".
 func (r *ReadinessChecker) CheckConditions(ctx context.Context, obj *unstructured.Unstructured, conditionTypes []string) (string, bool, error) {
 	for _, c := range conditionTypes {
 		var msg string
@@ -166,7 +166,7 @@ func (r *ReadinessChecker) unstructuredConditionStatus(obj *unstructured.Unstruc
 
 // statusField inspects a single top level field on the status
 func (r *ReadinessChecker) statusField(obj *unstructured.Unstructured, conditionType string) (string, corev1.ConditionStatus, error) {
-	// In this case the condition type is "redskyops.dev/status-<FIELD>-<VALUE>" so we must parse out the field and value
+	// In this case the condition type is "stormforge.io/status-<FIELD>-<VALUE>" so we must parse out the field and value
 	kv := strings.SplitN(strings.TrimPrefix(conditionType, ConditionTypeStatus), "-", 2)
 	if len(kv) != 2 {
 		return "", corev1.ConditionFalse, fmt.Errorf("invalid status field condition: %s", conditionType)

--- a/internal/sfio/fns.go
+++ b/internal/sfio/fns.go
@@ -166,7 +166,7 @@ func (f TeeMatchedFilter) visitMatched(node *yaml.RNode) error {
 	matches := f.PathMatcher.Matches[node.YNode()]
 	matchIndex := len(matches)
 	for _, p := range f.PathMatcher.Path {
-		if yaml.IsListIndex(p) && matchIndex >= 0 {
+		if yaml.IsListIndex(p) && matchIndex > 0 {
 			matchIndex--
 			name, _, _ := yaml.SplitIndexNameValue(p)
 			p = fmt.Sprintf("[%s=%s]", name, matches[matchIndex])

--- a/internal/sfio/fns.go
+++ b/internal/sfio/fns.go
@@ -18,7 +18,6 @@ package sfio
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
 
 	"sigs.k8s.io/kustomize/kyaml/yaml"
@@ -185,7 +184,7 @@ func (f TeeMatchedFilter) visitMatched(node *yaml.RNode) error {
 		if yaml.IsListIndex(p) && matchIndex > 0 {
 			matchIndex--
 			name, _, _ := yaml.SplitIndexNameValue(p)
-			p = fmt.Sprintf("[%s=%s]", name, regexp.QuoteMeta(matches[matchIndex]))
+			p = fmt.Sprintf("[%s=%s]", name, matches[matchIndex])
 		}
 		node.AppendToFieldPath(p)
 	}

--- a/internal/sfio/fns.go
+++ b/internal/sfio/fns.go
@@ -18,6 +18,7 @@ package sfio
 
 import (
 	"fmt"
+	"regexp"
 
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
@@ -169,7 +170,7 @@ func (f TeeMatchedFilter) visitMatched(node *yaml.RNode) error {
 		if yaml.IsListIndex(p) && matchIndex > 0 {
 			matchIndex--
 			name, _, _ := yaml.SplitIndexNameValue(p)
-			p = fmt.Sprintf("[%s=%s]", name, matches[matchIndex])
+			p = fmt.Sprintf("[%s=%s]", name, regexp.QuoteMeta(matches[matchIndex]))
 		}
 		node.AppendToFieldPath(p)
 	}

--- a/internal/sfio/fns.go
+++ b/internal/sfio/fns.go
@@ -19,6 +19,7 @@ package sfio
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
@@ -63,6 +64,20 @@ func (f FieldRenamer) Filter(rn *yaml.RNode) (*yaml.RNode, error) {
 		}
 	}
 
+	return nil, nil
+}
+
+// PrefixClearer removes a prefix from a node value.
+type PrefixClearer struct {
+	Value string
+}
+
+// Filter removes the prefix from the node value or returns a nil node.
+func (f *PrefixClearer) Filter(rn *yaml.RNode) (*yaml.RNode, error) {
+	if strings.HasPrefix(rn.YNode().Value, f.Value) {
+		rn.YNode().Value = strings.TrimPrefix(rn.YNode().Value, f.Value)
+		return rn, nil
+	}
 	return nil, nil
 }
 

--- a/internal/sfio/migrate.go
+++ b/internal/sfio/migrate.go
@@ -36,25 +36,19 @@ type MetadataMigrationFilter struct {
 func (f *MetadataMigrationFilter) Filter(node *yaml.RNode) (*yaml.RNode, error) {
 	// NOTE: We are not migrating state that used at runtime, e.g. finalizers or the special "initializers" annotation.
 
+	replaceFieldPrefix := yaml.FilterFunc(func(rn *yaml.RNode) (*yaml.RNode, error) {
+		return nil, rn.VisitFields(func(node *yaml.MapNode) error {
+			return node.Key.PipeE(
+				&PrefixClearer{Value: "redskyops.dev/"},
+				&yaml.PrefixSetter{Value: "stormforge.io/"},
+			)
+		})
+	})
+
 	return node.Pipe(
-		yaml.Tee(yaml.Lookup(yaml.MetadataField, yaml.LabelsField), yaml.FilterFunc(f.renamePrefix)),
-		yaml.Tee(yaml.Lookup(yaml.MetadataField, yaml.AnnotationsField), yaml.FilterFunc(f.renamePrefix)),
+		yaml.Tee(yaml.Lookup(yaml.MetadataField, yaml.LabelsField), replaceFieldPrefix),
+		yaml.Tee(yaml.Lookup(yaml.MetadataField, yaml.AnnotationsField), replaceFieldPrefix),
 	)
-}
-
-func (f *MetadataMigrationFilter) renamePrefix(rn *yaml.RNode) (*yaml.RNode, error) {
-	if err := yaml.ErrorIfInvalid(rn, yaml.MappingNode); err != nil {
-		return nil, err
-	}
-
-	node := rn.YNode()
-	for i := 0; i < len(node.Content); i = yaml.IncrementFieldIndex(i) {
-		if strings.HasPrefix(node.Content[i].Value, "redskyops.dev/") {
-			node.Content[i].Value = "stormforge.io/" + strings.TrimPrefix(node.Content[i].Value, "redskyops.dev/")
-		}
-	}
-
-	return nil, nil
 }
 
 // ExperimentMigrationFilter is a KYAML filter for performing experiment migration.

--- a/internal/sfio/migrate.go
+++ b/internal/sfio/migrate.go
@@ -87,6 +87,18 @@ func (f *ExperimentMigrationFilter) MigrateExperimentV1beta1(node *yaml.RNode) (
 			yaml.Lookup("spec", "jobTemplate"), &MetadataMigrationFilter{},
 			yaml.Lookup("spec", "template"), &MetadataMigrationFilter{},
 		),
+
+		// Replace the prefix on any readiness gates
+		TeeMatched(
+			yaml.PathMatcher{Path: []string{"spec", "patches", "[patch=]", "readinessGates", "[conditionType=redskyops\\.dev/.*]", "conditionType"}},
+			&PrefixClearer{Value: "redskyops.dev/"},
+			&yaml.PrefixSetter{Value: "stormforge.io/"},
+		),
+		TeeMatched(
+			yaml.PathMatcher{Path: []string{"spec", "trialTemplate", "spec", "readinessGates", "[kind=]", "conditionTypes", "[=redskyops\\.dev/.*]"}},
+			&PrefixClearer{Value: "redskyops.dev/"},
+			&yaml.PrefixSetter{Value: "stormforge.io/"},
+		),
 	)
 }
 


### PR DESCRIPTION
This PR updates the condition values (those used in trial and experiment status, and those used in readiness gates) to reflect the new domain prefix.

In working on the migration code, I discovered a couple more edge case bugs in the `TeeMatcher` which have been resolved. It turns out the `PathMatcher` also allows for matching scalar values in which case the match is not recorded (this was used to match the `conditionTypes` field and uncovered an off-by-one bug).