### PR TITLE
Remove more "Red Sky" references

### DIFF
--- a/hack/integration.sh
+++ b/hack/integration.sh
@@ -8,7 +8,7 @@ echo "Upload image to KinD"
 [[ -n "${IMG}" ]] && kind load docker-image "${IMG}" --name chart-testing
 [[ -n "${SETUPTOOLS_IMG}" ]] && kind load docker-image "${SETUPTOOLS_IMG}" --name chart-testing
 
-echo "Init redskyops"
+echo "Initialize Controller"
 ${REDSKYCTL_BIN} init
 
 echo "Wait for controller"

--- a/internal/controller/errors_test.go
+++ b/internal/controller/errors_test.go
@@ -129,7 +129,7 @@ func TestIgnoreReportError(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
-			desc: "redskyapi error trial already reported",
+			desc: "trial already reported",
 			in: &experimentsv1alpha1.Error{
 				Type: experimentsv1alpha1.ErrTrialAlreadyReported,
 			},

--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -34,14 +34,14 @@ var (
 	// ExperimentTrials is a Prometheus gauge metric which holds the total number
 	// of trials for an experiment (trial counts can go down when they are cleaned up)
 	ExperimentTrials = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "redsky_experiment_trials_total",
+		Name: "optimize_experiment_trials_total",
 		Help: "Total number of trials present for an experiment",
 	}, []string{"experiment"})
 
 	// ExperimentActiveTrials is a Prometheus gauge metric which holds the total number
 	// of active trials for an experiment
 	ExperimentActiveTrials = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "redsky_experiment_active_trials_total",
+		Name: "optimize_experiment_active_trials_total",
 		Help: "Total number of active trials present for an experiment",
 	}, []string{"experiment"})
 )

--- a/redskyctl/internal/commands/kustomize/config.go
+++ b/redskyctl/internal/commands/kustomize/config.go
@@ -69,7 +69,7 @@ func (o *ConfigOptions) config() error {
 		// Adjust the filename to point to where our configuration should go
 		root := filepath.Dir(o.Kustomize)
 		if o.Filename == "" {
-			o.Filename = filepath.Join(root, "kustomizeconfig", "redskyops.yaml")
+			o.Filename = filepath.Join(root, "kustomizeconfig", "stormforge-optimize.yaml")
 		} else if filepath.IsAbs(o.Filename) {
 			if rel, err := filepath.Rel(root, o.Filename); err != nil || rel == o.Filename {
 				return fmt.Errorf("filename must relative or inside the Kustomization root")
@@ -86,12 +86,12 @@ func (o *ConfigOptions) config() error {
 
 	// If there is no file name, just dump to the output stream
 	if o.Filename == "" {
-		_, err := o.Out.Write(consts.GetRedSkyFieldSpecs())
+		_, err := o.Out.Write(consts.GetOptimizeFieldSpecs())
 		return err
 	}
 
 	// Write the file
-	if err := ioutil.WriteFile(o.Filename, consts.GetRedSkyFieldSpecs(), 0644); err != nil {
+	if err := ioutil.WriteFile(o.Filename, consts.GetOptimizeFieldSpecs(), 0644); err != nil {
 		return err
 	}
 

--- a/redskyctl/internal/commands/kustomize/consts/redskyconfig.go
+++ b/redskyctl/internal/commands/kustomize/consts/redskyconfig.go
@@ -18,7 +18,7 @@ package consts
 
 import "bytes"
 
-func GetRedSkyFieldSpecs() []byte {
+func GetOptimizeFieldSpecs() []byte {
 	configData := [][]byte{
 		[]byte(commonAnnotationFieldSpecs),
 		[]byte(commonLabelFieldSpecs),


### PR DESCRIPTION
This PR removes a few dangling Red Sky references that do not fall into a larger group of refactorings, e.g.:
1. Prometheus metric names (note that we do not expose the metrics endpoint on the controller except in local debugging)
2. Test case names
3. The Kustomize transformer configuration code (which should probably be removed anyway)
