### PR TITLE
Remove legacy selector to host migration

### DIFF
--- a/redskyctl/internal/commands/check/experiment.go
+++ b/redskyctl/internal/commands/check/experiment.go
@@ -208,7 +208,7 @@ func (l *linter) Visit(ctx context.Context, obj interface{}) experiment.Visitor 
 		if u, err := url.Parse(o.URL); err != nil {
 			lint.V(vError).Info("Metric has invalid URL")
 		} else if u.Hostname() == "redskyops.dev" {
-			lint.V(vWarn).Info("Metric requires manual conversion to latest version for URL")
+			lint.V(vError).Info("Metric requires manual conversion to latest version for URL")
 		}
 
 	case *optimizev1beta1.PatchTemplate:


### PR DESCRIPTION
This PR removes the runtime component of the v1alpha1 to v1beta1 migration and adjusts the offline migration logic accordingly.

The backstory is that in v1alpha1 metrics were configured to use a `Service` selector: when it was time to collect metrics we would search for matching services in the cluster and build an appropriate URL. In v1beta1 we switched to having metrics configured using a URL. To ease the transition, we injected a placeholder host name (`redskyops.dev`) to v1beta1 metrics that triggered a subset of the original v1alpha1 behavior (i.e. if the URL host name is "redskyops.dev" then look up the `Service` using the selector instead). With v1alpha1 gone, we no longer need to worry about that transition so it can be removed; any experiments which were relying on the transition will simply fail to migrate.