### PR TITLE
Add a Red Hat UBI based image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 **
 !/manager
+!/LICENSE

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -71,18 +71,20 @@ jobs:
             echo "VERSION=v${DOCKER_TAG}" >> $GITHUB_ENV
             echo "AC_USERNAME=${{ secrets.AC_USERNAME }}" >> $GITHUB_ENV
             echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
+            echo "${{ secrets.REDHATCONNECT_KEY }}" | docker login "scan.connect.redhat.com" -u "unused" --password-stdin
           else
             DOCKER_REGISTRY="ghcr.io/thestormforge"
             DOCKER_TAG="sha-$(git rev-parse --short HEAD)"
             echo "IMAGE_TAG=edge" >> $GITHUB_ENV
           fi
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login "ghcr.io" -u "${{ github.actor }}" --password-stdin
           echo "IMG=${DOCKER_REGISTRY}/optimize-controller:${DOCKER_TAG}" >> $GITHUB_ENV
           echo "REDSKYCTL_IMG=${DOCKER_REGISTRY}/redskyctl:${DOCKER_TAG}" >> $GITHUB_ENV
           echo "SETUPTOOLS_IMG=${DOCKER_REGISTRY}/setuptools:${DOCKER_TAG}" >> $GITHUB_ENV
           echo "PULL_POLICY=" >> $GITHUB_ENV
       - name: Build controller
         run: |
-          make docker-build-ci
+          make -o test docker-build
       - name: Build tool
         uses: goreleaser/goreleaser-action@v2
         with:
@@ -93,7 +95,6 @@ jobs:
           AC_IDENTITY_P12: ${{ secrets.AC_IDENTITY_P12 }}
       - name: Push Docker images
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login "ghcr.io" -u "${{ github.actor }}" --password-stdin
           make docker-push
           docker-push() {
             docker tag "$1" "$2"
@@ -106,6 +107,7 @@ jobs:
             docker-push "${IMG}" "ghcr.io/${IMG}"
             docker-push "${REDSKYCTL_IMG}" "ghcr.io/${REDSKYCTL_IMG}"
             docker-push "${SETUPTOOLS_IMG}" "ghcr.io/${SETUPTOOLS_IMG}"
+            docker-push "${IMG}-ubi8" "scan.connect.redhat.com/${IMG%%:*}-ubi8:${IMG##*:}-1"
           fi
       - name: Upload macOS binary
         uses: actions/upload-artifact@v1

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -71,6 +71,7 @@ jobs:
         run: |
           DOCKER_REGISTRY="ghcr.io/thestormforge"
           DOCKER_TAG="sha-$(git rev-parse --short HEAD)"
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login "ghcr.io" -u "${{ github.actor }}" --password-stdin
           echo "IMAGE_TAG=pr-${{ github.event.number }}" >> $GITHUB_ENV
           echo "IMG=${DOCKER_REGISTRY}/optimize-controller:${DOCKER_TAG}" >> $GITHUB_ENV
           echo "REDSKYCTL_IMG=${DOCKER_REGISTRY}/redskyctl:${DOCKER_TAG}" >> $GITHUB_ENV
@@ -79,7 +80,7 @@ jobs:
       - name: Build controller
         run: |
           hack/install_kustomize.sh
-          make docker-build-ci
+          make -o test docker-build
       - name: Build tool
         uses: goreleaser/goreleaser-action@v2
         with:
@@ -87,7 +88,6 @@ jobs:
       - name: Push Docker images
         if: github.event.pull_request.head.repo.fork == false
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login "ghcr.io" -u "${{ github.actor }}" --password-stdin
           make docker-push
           docker-push() {
             docker tag "$1" "$2"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+ARG BASE_IMAGE=gcr.io/distroless/static:nonroot
+FROM ${BASE_IMAGE} AS base
 WORKDIR /
-COPY ./manager .
-USER nonroot:nonroot
+COPY ./manager /usr/local/bin/
+COPY ./LICENSE /licenses/
+USER nobody:nobody
 
-ENTRYPOINT ["/manager"]
+ENTRYPOINT ["manager"]

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
         - command:
-            - /manager
+            - manager
           image: controller:latest
           name: manager
           resources:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -35,8 +35,8 @@ spec:
               cpu: 100m
               memory: 250Mi
           securityContext:
-            runAsUser: 65532
-            runAsGroup: 65532
+            runAsUser: 65534
+            runAsGroup: 65534
             runAsNonRoot: true
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false


### PR DESCRIPTION
This replaces #329 with a slightly different approach; we only update the main controller image and there are a few more tweaks after reviewing submission guidelines (e.g. the license). Other minor differences are that I added OCI labels to the default image and the equivalent Red Hat labels on the UBI image and adjusted the run IDs in the manifests. This PR also includes publication to Red Hat's registry.