### PR TITLE
Build (and sign) a darwin-arm64 version of the CLI

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -108,12 +108,17 @@ jobs:
             docker-push "${SETUPTOOLS_IMG}" "ghcr.io/${SETUPTOOLS_IMG}"
           fi
       - name: Upload macOS binary
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: stormforge_darwin_amd64
           path: dist/stormforge-darwin-amd64.tar.gz
+      - name: Upload macOS ARM binary
+        uses: actions/upload-artifact@v2
+        with:
+          name: stormforge_darwin_arm64
+          path: dist/stormforge-darwin-arm64.tar.gz
       - name: Upload Linux binary
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: stormforge_linux_amd64
           path: dist/stormforge-linux-amd64.tar.gz

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -101,6 +101,11 @@ jobs:
         with:
           name: stormforge_darwin_amd64
           path: dist/stormforge-darwin-amd64.tar.gz
+      - name: Upload macOS ARM binary
+        uses: actions/upload-artifact@v2
+        with:
+          name: stormforge_darwin_arm64
+          path: dist/stormforge-darwin-arm64.tar.gz
       - name: Upload Linux binary
         uses: actions/upload-artifact@v2
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,6 +8,10 @@ builds:
       - CGO_ENABLED=0
     goarch:
       - amd64
+      - arm64
+    ignore:
+    - goos: linux
+      goarch: arm64
     ldflags:
       - '-s -w'
       - '-X github.com/thestormforge/optimize-controller/v2/internal/version.Version=v{{ .Version }}'

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ LDFLAGS += -X github.com/thestormforge/optimize-controller/v2/internal/setup.Ima
 LDFLAGS += -X github.com/thestormforge/optimize-controller/v2/internal/setup.ImagePullPolicy=${PULL_POLICY}
 LDFLAGS += -X github.com/thestormforge/optimize-controller/v2/cli/internal/kustomize.BuildImage=${IMG}
 
-all: manager tool
+all: manager cli
 
 # Run tests
 test: generate manifests fmt vet
@@ -37,14 +37,14 @@ test: generate manifests fmt vet
 manager: generate fmt vet
 	go build -ldflags '$(LDFLAGS)' -o bin/manager main.go
 
-# Build tool binary using GoReleaser in a local dev environment (in CI we just invoke GoReleaser directly)
-tool: manifests
+# Build the CLI binary using GoReleaser in a local dev environment (in CI we just invoke GoReleaser directly)
+cli: manifests
 	BUILD_METADATA=${BUILD_METADATA} \
 	SETUPTOOLS_IMG=${SETUPTOOLS_IMG} \
 	PULL_POLICY=${PULL_POLICY} \
 	CLI_IMG=${CLI_IMG} \
 	IMG=${IMG} \
-	goreleaser release --snapshot --skip-sign --rm-dist
+	goreleaser build --snapshot --rm-dist
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: generate manifests fmt vet

--- a/hack/codesign.sh
+++ b/hack/codesign.sh
@@ -11,7 +11,7 @@ set -eu
 
 # Verify, but exit normally to ensure the conditional nature of the checks
 FILE="${1:?missing file argument}"
-[ "$(basename "$(dirname "$FILE")")" == "stormforge_darwin_amd64" ] || { echo >&2 "skipping code signing on file '$1'"; exit; }
+[[ "$(basename "$(dirname "$FILE")")" == stormforge_darwin_* ]] || { echo >&2 "skipping code signing on file '$1'"; exit; }
 command -v security >/dev/null 2>&1 || { echo >&2 "skipping code signing, security not present"; exit; }
 command -v codesign >/dev/null 2>&1 || { echo >&2 "skipping code signing, codesign not present"; exit; }
 [ -n "${AC_IDENTITY_P12:-}" ] || { echo >&2 "skipping code signing, no signing identity"; exit; }

--- a/hack/notarize.sh
+++ b/hack/notarize.sh
@@ -10,7 +10,7 @@ OUTPUT="${2:?missing output argument}"
 
 # This script MUST produce an output file or fail.
 case "$(basename "$FILE")" in
-  "stormforge-darwin-amd64.tar.gz")
+  stormforge-darwin-*)
     # If there are no credentials, just produce an empty file (otherwise fall through)
     if [ -z "${AC_USERNAME:-}" ] || [ -z "${AC_PASSWORD:-}" ] ; then
       echo "Not empty" > "${OUTPUT}"


### PR DESCRIPTION
The PR adds an additional cross platform build for the CLI on darwin-arm64. It is included in the code signing and notarization dance so you should be able to run it without first taking it out of quarantine.

This _does not_ impact the controller: this basically just lets you run ~`redskyctl`~ `stormforge` on your M1 laptop.