### PR TITLE
Upgrade Optimize Go

### DIFF
--- a/cli/internal/commands/authorize_cluster/generator.go
+++ b/cli/internal/commands/authorize_cluster/generator.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/thestormforge/optimize-controller/v2/cli/internal/commander"
-	experimentsv1alpha1 "github.com/thestormforge/optimize-go/pkg/api/experiments/v1alpha1"
+	"github.com/thestormforge/optimize-go/pkg/api"
 	"github.com/thestormforge/optimize-go/pkg/config"
 	"github.com/thestormforge/optimize-go/pkg/oauth2/registration"
 	"golang.org/x/oauth2"
@@ -128,7 +128,7 @@ func (o *GeneratorOptions) generate(ctx context.Context) error {
 
 	// Get the client information (either read or register)
 	info, err := o.clientInfo(ctx, ctrl)
-	if o.AllowUnauthorized && experimentsv1alpha1.IsUnauthorized(err) {
+	if o.AllowUnauthorized && api.IsUnauthorized(err) {
 		// Ignore the error (but do not save the changes)
 		info = &registration.ClientInformationResponse{}
 	} else if err != nil {

--- a/cli/internal/commands/commands.go
+++ b/cli/internal/commands/commands.go
@@ -43,7 +43,7 @@ import (
 	"github.com/thestormforge/optimize-controller/v2/cli/internal/commands/revoke"
 	"github.com/thestormforge/optimize-controller/v2/cli/internal/commands/run"
 	"github.com/thestormforge/optimize-controller/v2/cli/internal/commands/version"
-	experimentsv1alpha1 "github.com/thestormforge/optimize-go/pkg/api/experiments/v1alpha1"
+	"github.com/thestormforge/optimize-go/pkg/api"
 	"github.com/thestormforge/optimize-go/pkg/config"
 )
 
@@ -62,6 +62,9 @@ func NewRootCommand() *cobra.Command {
 
 	// Establish OAuth client identity
 	cfg.ClientIdentity = authorizationIdentity
+	cfg.AuthorizationParameters = map[string][]string{
+		"audience": {"https://api.carbonrelay.io/v1/"},
+	}
 
 	// Kubernetes Commands
 	rootCmd.AddCommand(initialize.NewCommand(&initialize.Options{GeneratorOptions: initialize.GeneratorOptions{Config: cfg, IncludeBootstrapRole: true}}))
@@ -101,9 +104,9 @@ func NewRootCommand() *cobra.Command {
 
 // mapError intercepts errors returned by commands before they are reported.
 func mapError(err error) error {
-	if experimentsv1alpha1.IsUnauthorized(err) {
+	if api.IsUnauthorized(err) {
 		// Trust the error message we get from the experiments API
-		if _, ok := err.(*experimentsv1alpha1.Error); ok {
+		if _, ok := err.(*api.Error); ok {
 			return fmt.Errorf("%w, try running 'stormforge login'", err)
 		}
 		return fmt.Errorf("unauthorized, try running 'stormforge login'")

--- a/cli/internal/commands/experiments/delete.go
+++ b/cli/internal/commands/experiments/delete.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/thestormforge/optimize-controller/v2/cli/internal/commander"
 	"github.com/thestormforge/optimize-controller/v2/internal/controller"
+	"github.com/thestormforge/optimize-go/pkg/api"
 	experimentsv1alpha1 "github.com/thestormforge/optimize-go/pkg/api/experiments/v1alpha1"
 )
 
@@ -88,11 +89,15 @@ func (o *DeleteOptions) ignoreDeleteError(err error) error {
 //noinspection GoNilness
 func (o *DeleteOptions) deleteExperiment(ctx context.Context, name experimentsv1alpha1.ExperimentName) error {
 	exp, err := o.ExperimentsAPI.GetExperimentByName(ctx, name)
-	if err != nil && exp.SelfURL == "" {
+	if err != nil {
 		return err
 	}
+	selfURL := exp.Link(api.RelationSelf)
+	if selfURL == "" {
+		return nil
+	}
 
-	if err := o.ExperimentsAPI.DeleteExperiment(ctx, exp.SelfURL); err != nil {
+	if err := o.ExperimentsAPI.DeleteExperiment(ctx, selfURL); err != nil {
 		return err
 	}
 

--- a/cli/internal/commands/experiments/get.go
+++ b/cli/internal/commands/experiments/get.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/thestormforge/optimize-controller/v2/cli/internal/commander"
+	"github.com/thestormforge/optimize-go/pkg/api"
 	experimentsv1alpha1 "github.com/thestormforge/optimize-go/pkg/api/experiments/v1alpha1"
 	"k8s.io/apimachinery/pkg/labels"
 )
@@ -75,9 +76,8 @@ func (o *GetOptions) get(ctx context.Context) error {
 
 		case typeExperiment:
 			if n.Name == "" {
-				q := &experimentsv1alpha1.ExperimentListQuery{
-					Limit: o.ChunkSize,
-				}
+				q := experimentsv1alpha1.ExperimentListQuery{}
+				q.SetLimit(o.ChunkSize)
 				return o.getExperimentList(ctx, q)
 			}
 			e = append(e, n.experimentName())
@@ -105,12 +105,11 @@ func (o *GetOptions) get(ctx context.Context) error {
 	return nil
 }
 
-func (o *GetOptions) trialListQuery() *experimentsv1alpha1.TrialListQuery {
-	q := &experimentsv1alpha1.TrialListQuery{
-		Status: []experimentsv1alpha1.TrialStatus{experimentsv1alpha1.TrialActive, experimentsv1alpha1.TrialCompleted, experimentsv1alpha1.TrialFailed},
-	}
+func (o *GetOptions) trialListQuery() experimentsv1alpha1.TrialListQuery {
+	q := experimentsv1alpha1.TrialListQuery{IndexQuery: api.IndexQuery{}}
+	q.SetStatus(experimentsv1alpha1.TrialActive, experimentsv1alpha1.TrialCompleted, experimentsv1alpha1.TrialFailed)
 	if o.All {
-		q.Status = append(q.Status, experimentsv1alpha1.TrialStaged)
+		q.AddStatus(experimentsv1alpha1.TrialStaged)
 	}
 	return q
 }
@@ -138,19 +137,20 @@ func (o *GetOptions) getExperiments(ctx context.Context, names []experimentsv1al
 	return o.Printer.PrintObj(l, o.Out)
 }
 
-func (o *GetOptions) getExperimentList(ctx context.Context, q *experimentsv1alpha1.ExperimentListQuery) error {
+func (o *GetOptions) getExperimentList(ctx context.Context, q experimentsv1alpha1.ExperimentListQuery) error {
 	// Get all the experiments one page at a time
 	l, err := o.ExperimentsAPI.GetAllExperiments(ctx, q)
 	if err != nil {
 		return err
 	}
 
-	for l.Next != "" {
-		n, err := o.ExperimentsAPI.GetAllExperimentsByPage(ctx, l.Next)
+	next := l.Link(api.RelationNext)
+	for next != "" {
+		n, err := o.ExperimentsAPI.GetAllExperimentsByPage(ctx, next)
 		if err != nil {
 			return err
 		}
-		l.Next = n.Next
+		next = n.Link(api.RelationNext)
 		l.Experiments = append(l.Experiments, n.Experiments...)
 	}
 
@@ -172,7 +172,7 @@ func (o *GetOptions) getTrials(ctx context.Context, numbers map[experimentsv1alp
 		}
 
 		// Get the trials
-		tl, err := o.ExperimentsAPI.GetAllTrials(ctx, exp.TrialsURL, o.trialListQuery())
+		tl, err := o.ExperimentsAPI.GetAllTrials(ctx, exp.Link(api.RelationTrials), o.trialListQuery())
 		if err != nil {
 			return err
 		}
@@ -198,7 +198,7 @@ func (o *GetOptions) getTrials(ctx context.Context, numbers map[experimentsv1alp
 	return o.Printer.PrintObj(l, o.Out)
 }
 
-func (o *GetOptions) getTrialList(ctx context.Context, name experimentsv1alpha1.ExperimentName, q *experimentsv1alpha1.TrialListQuery) error {
+func (o *GetOptions) getTrialList(ctx context.Context, name experimentsv1alpha1.ExperimentName, q experimentsv1alpha1.TrialListQuery) error {
 	// Get the experiment
 	exp, err := o.ExperimentsAPI.GetExperimentByName(ctx, name)
 	if err != nil {
@@ -207,8 +207,8 @@ func (o *GetOptions) getTrialList(ctx context.Context, name experimentsv1alpha1.
 
 	// Fetch the trial data
 	var l experimentsv1alpha1.TrialList
-	if exp.TrialsURL != "" {
-		l, err = o.ExperimentsAPI.GetAllTrials(ctx, exp.TrialsURL, q)
+	if trialsURL := exp.Link(api.RelationTrials); trialsURL != "" {
+		l, err = o.ExperimentsAPI.GetAllTrials(ctx, trialsURL, q)
 		if err != nil {
 			return err
 		}

--- a/cli/internal/commands/experiments/get.go
+++ b/cli/internal/commands/experiments/get.go
@@ -76,7 +76,7 @@ func (o *GetOptions) get(ctx context.Context) error {
 
 		case typeExperiment:
 			if n.Name == "" {
-				q := experimentsv1alpha1.ExperimentListQuery{}
+				q := experimentsv1alpha1.ExperimentListQuery{IndexQuery: api.IndexQuery{}}
 				q.SetLimit(o.ChunkSize)
 				return o.getExperimentList(ctx, q)
 			}

--- a/cli/internal/commands/experiments/label.go
+++ b/cli/internal/commands/experiments/label.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/thestormforge/optimize-controller/v2/cli/internal/commander"
+	"github.com/thestormforge/optimize-go/pkg/api"
 	experimentsv1alpha1 "github.com/thestormforge/optimize-go/pkg/api/experiments/v1alpha1"
 )
 
@@ -110,7 +111,7 @@ func (o *LabelOptions) labelExperiments(ctx context.Context, names []experiments
 			return err
 		}
 
-		if err := o.ExperimentsAPI.LabelExperiment(ctx, exp.LabelsURL, experimentsv1alpha1.ExperimentLabels{Labels: o.Labels}); err != nil {
+		if err := o.ExperimentsAPI.LabelExperiment(ctx, exp.Link(api.RelationLabels), experimentsv1alpha1.ExperimentLabels{Labels: o.Labels}); err != nil {
 			return err
 		}
 
@@ -129,8 +130,9 @@ func (o *LabelOptions) labelTrials(ctx context.Context, numbers map[experimentsv
 		}
 
 		// Note that you can only label completed trials
-		q := &experimentsv1alpha1.TrialListQuery{Status: []experimentsv1alpha1.TrialStatus{experimentsv1alpha1.TrialCompleted}}
-		tl, err := o.ExperimentsAPI.GetAllTrials(ctx, exp.TrialsURL, q)
+		q := experimentsv1alpha1.TrialListQuery{IndexQuery: api.IndexQuery{}}
+		q.SetStatus(experimentsv1alpha1.TrialCompleted)
+		tl, err := o.ExperimentsAPI.GetAllTrials(ctx, exp.Link(api.RelationTrials), q)
 		if err != nil {
 			return err
 		}
@@ -140,7 +142,7 @@ func (o *LabelOptions) labelTrials(ctx context.Context, numbers map[experimentsv
 			if hasTrialNumber(&tl.Trials[i], nums) {
 				t := tl.Trials[i]
 				t.Experiment = &exp
-				if err := o.ExperimentsAPI.LabelTrial(ctx, t.LabelsURL, experimentsv1alpha1.TrialLabels{Labels: o.Labels}); err != nil {
+				if err := o.ExperimentsAPI.LabelTrial(ctx, t.Link(api.RelationLabels), experimentsv1alpha1.TrialLabels{Labels: o.Labels}); err != nil {
 					return err
 				}
 				if err := o.Printer.PrintObj(&t, o.Out); err != nil {

--- a/cli/internal/commands/experiments/suggest.go
+++ b/cli/internal/commands/experiments/suggest.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/thestormforge/optimize-controller/v2/cli/internal/commander"
+	"github.com/thestormforge/optimize-go/pkg/api"
 	experimentsv1alpha1 "github.com/thestormforge/optimize-go/pkg/api/experiments/v1alpha1"
 	"github.com/thestormforge/optimize-go/pkg/api/experiments/v1alpha1/numstr"
 )
@@ -91,7 +92,7 @@ func (o *SuggestOptions) suggest(ctx context.Context) error {
 		return err
 	}
 
-	_, err = o.ExperimentsAPI.CreateTrial(ctx, exp.TrialsURL, ta)
+	_, err = o.ExperimentsAPI.CreateTrial(ctx, exp.Link(api.RelationTrials), ta)
 	if err != nil {
 		return err
 	}

--- a/cli/internal/commands/export/export.go
+++ b/cli/internal/commands/export/export.go
@@ -38,6 +38,7 @@ import (
 	"github.com/thestormforge/optimize-controller/v2/internal/server"
 	"github.com/thestormforge/optimize-controller/v2/internal/sfio"
 	"github.com/thestormforge/optimize-controller/v2/internal/template"
+	"github.com/thestormforge/optimize-go/pkg/api"
 	experimentsv1alpha1 "github.com/thestormforge/optimize-go/pkg/api/experiments/v1alpha1"
 	"github.com/thestormforge/optimize-go/pkg/config"
 	corev1 "k8s.io/api/core/v1"
@@ -439,7 +440,7 @@ func (o *Options) getTrialDetails(ctx context.Context) (*trialDetails, error) {
 	if err != nil {
 		return nil, err
 	}
-	if exp.TrialsURL == "" {
+	if exp.Link(api.RelationTrials) == "" {
 		return nil, fmt.Errorf("unable to find trials for experiment")
 	}
 
@@ -451,10 +452,9 @@ func (o *Options) getTrialDetails(ctx context.Context) (*trialDetails, error) {
 		Objective:   exp.Labels["objective"],
 	}
 
-	query := &experimentsv1alpha1.TrialListQuery{
-		Status: []experimentsv1alpha1.TrialStatus{experimentsv1alpha1.TrialCompleted},
-	}
-	trialList, err := o.ExperimentsAPI.GetAllTrials(ctx, exp.TrialsURL, query)
+	query := experimentsv1alpha1.TrialListQuery{IndexQuery: api.IndexQuery{}}
+	query.SetStatus(experimentsv1alpha1.TrialCompleted)
+	trialList, err := o.ExperimentsAPI.GetAllTrials(ctx, exp.Link(api.RelationTrials), query)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/internal/commands/export/export_api_test.go
+++ b/cli/internal/commands/export/export_api_test.go
@@ -18,7 +18,9 @@ package export_test
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/thestormforge/optimize-go/pkg/api"
 	experimentsv1alpha1 "github.com/thestormforge/optimize-go/pkg/api/experiments/v1alpha1"
 	"github.com/thestormforge/optimize-go/pkg/api/experiments/v1alpha1/numstr"
 )
@@ -44,11 +46,13 @@ var wannabeTrial = experimentsv1alpha1.TrialItem{
 // Implement the api interface
 type fakeExperimentsAPI struct{}
 
-func (f *fakeExperimentsAPI) Options(ctx context.Context) (experimentsv1alpha1.ServerMeta, error) {
-	return experimentsv1alpha1.ServerMeta{}, nil
+var _ experimentsv1alpha1.API = &fakeExperimentsAPI{}
+
+func (f *fakeExperimentsAPI) Options(ctx context.Context) (experimentsv1alpha1.Server, error) {
+	return experimentsv1alpha1.Server{}, nil
 }
 
-func (f *fakeExperimentsAPI) GetAllExperiments(ctx context.Context, query *experimentsv1alpha1.ExperimentListQuery) (experimentsv1alpha1.ExperimentList, error) {
+func (f *fakeExperimentsAPI) GetAllExperiments(ctx context.Context, query experimentsv1alpha1.ExperimentListQuery) (experimentsv1alpha1.ExperimentList, error) {
 	return experimentsv1alpha1.ExperimentList{}, nil
 }
 
@@ -58,8 +62,8 @@ func (f *fakeExperimentsAPI) GetAllExperimentsByPage(ctx context.Context, notsur
 
 func (f *fakeExperimentsAPI) GetExperimentByName(ctx context.Context, name experimentsv1alpha1.ExperimentName) (experimentsv1alpha1.Experiment, error) {
 	exp := experimentsv1alpha1.Experiment{
-		ExperimentMeta: experimentsv1alpha1.ExperimentMeta{
-			TrialsURL: "http://sometrial",
+		Metadata: api.Metadata{
+			"Link": {fmt.Sprintf("<http://sometrial>;rel=%s", api.RelationTrials)},
 		},
 		DisplayName: "postgres-example",
 		Labels: map[string]string{
@@ -118,7 +122,7 @@ func (f *fakeExperimentsAPI) DeleteExperiment(ctx context.Context, name string) 
 	return nil
 }
 
-func (f *fakeExperimentsAPI) GetAllTrials(ctx context.Context, name string, query *experimentsv1alpha1.TrialListQuery) (experimentsv1alpha1.TrialList, error) {
+func (f *fakeExperimentsAPI) GetAllTrials(ctx context.Context, name string, query experimentsv1alpha1.TrialListQuery) (experimentsv1alpha1.TrialList, error) {
 	// TODO implement some query filter magic if we really want to.
 	// Otherwise, we should clean this up to mimic just the necessary output
 	tl := experimentsv1alpha1.TrialList{

--- a/cli/internal/commands/version/version.go
+++ b/cli/internal/commands/version/version.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"strings"
 	"text/template"
 
@@ -169,7 +170,7 @@ func (o *Options) apiVersion(ctx context.Context) (*version.Info, error) {
 
 	// Try to parse out the server header
 	var info *version.Info
-	parts := strings.SplitN(sm.Server, " ", 2)
+	parts := strings.SplitN(http.Header(sm.Metadata).Get("Server"), " ", 2)
 	parts = strings.SplitN(parts[0], "/", 2)
 	if len(parts) > 1 { // TODO Also check the product name
 		info = &version.Info{}

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
 	github.com/thestormforge/konjure v0.3.0
-	github.com/thestormforge/optimize-go v0.0.10
+	github.com/thestormforge/optimize-go v0.0.11
 	github.com/yujunz/go-getter v1.5.1-lite.0.20201201013212-6d9c071adddf
 	github.com/zorkian/go-datadog-api v2.24.0+incompatible
 	go.uber.org/zap v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -572,8 +572,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/thestormforge/konjure v0.3.0 h1:VOUX6te9lbdk8dYJLQpJsvZfuhvwp8+DJMhB1VR46RM=
 github.com/thestormforge/konjure v0.3.0/go.mod h1:8gIqMRKShWB7ejEA+JCN8DUeeDe9CTIc3eXyniFdNj8=
-github.com/thestormforge/optimize-go v0.0.10 h1:i9wl0EMckIcRxp70OFdajTvHOhTNt4ltMixQkOwkVrg=
-github.com/thestormforge/optimize-go v0.0.10/go.mod h1:ZWRi49lIlw4g3JyP9Aog+zQI/rb7+81HOyHcccVqnfU=
+github.com/thestormforge/optimize-go v0.0.11 h1:+UcecKJKbIUwHKiUCOVu9tyWPNGMlR/+nZ/e6MQiGJ0=
+github.com/thestormforge/optimize-go v0.0.11/go.mod h1:LhoJFNeHXLWnMp5KVkHJdzUfx76Gwj81/m40IVM9MjA=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/internal/controller/errors.go
+++ b/internal/controller/errors.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller
 
 import (
+	"github.com/thestormforge/optimize-go/pkg/api"
 	experimentsv1alpha1 "github.com/thestormforge/optimize-go/pkg/api/experiments/v1alpha1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 )
@@ -26,7 +27,7 @@ func IgnoreNotFound(err error) error {
 	if apierrs.IsNotFound(err) {
 		return nil
 	}
-	if rserr, ok := err.(*experimentsv1alpha1.Error); ok {
+	if rserr, ok := err.(*api.Error); ok {
 		if rserr.Type == experimentsv1alpha1.ErrExperimentNotFound || rserr.Type == experimentsv1alpha1.ErrTrialNotFound {
 			return nil
 		}
@@ -47,7 +48,7 @@ func IgnoreReportError(err error) error {
 	if IgnoreNotFound(err) == nil {
 		return nil
 	}
-	if rserr, ok := err.(*experimentsv1alpha1.Error); ok {
+	if rserr, ok := err.(*api.Error); ok {
 		if rserr.Type == experimentsv1alpha1.ErrTrialAlreadyReported {
 			return nil
 		}

--- a/internal/controller/errors_test.go
+++ b/internal/controller/errors_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/thestormforge/optimize-go/pkg/api"
 	experimentsv1alpha1 "github.com/thestormforge/optimize-go/pkg/api/experiments/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -48,14 +49,14 @@ func TestIgnoreNotFound(t *testing.T) {
 		},
 		{
 			desc: "api error experiment not found",
-			in: &experimentsv1alpha1.Error{
+			in: &api.Error{
 				Type: experimentsv1alpha1.ErrExperimentNotFound,
 			},
 			expectedErr: nil,
 		},
 		{
 			desc: "api error trial not found",
-			in: &experimentsv1alpha1.Error{
+			in: &api.Error{
 				Type: experimentsv1alpha1.ErrTrialNotFound,
 			},
 			expectedErr: nil,
@@ -130,7 +131,7 @@ func TestIgnoreReportError(t *testing.T) {
 		},
 		{
 			desc: "trial already reported",
-			in: &experimentsv1alpha1.Error{
+			in: &api.Error{
 				Type: experimentsv1alpha1.ErrTrialAlreadyReported,
 			},
 			expectedErr: nil,

--- a/internal/controller/result.go
+++ b/internal/controller/result.go
@@ -21,6 +21,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/thestormforge/optimize-go/pkg/api"
 	experimentsv1alpha1 "github.com/thestormforge/optimize-go/pkg/api/experiments/v1alpha1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -33,7 +34,7 @@ import (
 // RequeueIfUnavailable will return a new result and the supplied error, adjusted for trial unavailable errors
 func RequeueIfUnavailable(err error) (*ctrl.Result, error) {
 	result := &ctrl.Result{}
-	if rse, ok := err.(*experimentsv1alpha1.Error); ok && rse.Type == experimentsv1alpha1.ErrTrialUnavailable {
+	if rse, ok := err.(*api.Error); ok && rse.Type == experimentsv1alpha1.ErrTrialUnavailable {
 		result.RequeueAfter = rse.RetryAfter
 		err = nil
 	}

--- a/internal/controller/result_test.go
+++ b/internal/controller/result_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/thestormforge/optimize-go/pkg/api"
 	experimentsv1alpha1 "github.com/thestormforge/optimize-go/pkg/api/experiments/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -145,7 +146,7 @@ func TestRequeueIfUnavailable(t *testing.T) {
 		},
 		{
 			desc: "trial unavailable",
-			err: &experimentsv1alpha1.Error{
+			err: &api.Error{
 				Type:       experimentsv1alpha1.ErrTrialUnavailable,
 				RetryAfter: 111,
 			},


### PR DESCRIPTION
This PR takes the latest version of optimize-go which introduces a slightly different approach to the API common pieces (like metadata, errors, and list queries).

Additional notes:
* There is a bug in optimize-go around setting index query values, there will be another PR on optimize-go to address that, but the workaround is in place here (e.g. `ExperimentListQuery{IndexQuery: api.IndexQuery{}}` instead of just `ExperimentListQuery{}`).
* The `server.FromCluster` function no longer adds metadata, this behavior has not been required since we stopped allowing `redskyctl get` to access the Kube API.
* If an experiment is annotated with a URL at creation, we honor it (previously optimize-go only supported "create by name").
* The "audience" parameter we send to the OAuth 2.0 issuer is now hardcoded in the root command alongside the `client_id`; we will likely be changing that value soon.