### PR TITLE
Add parameter constraint checks to the baseline

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -27,6 +27,7 @@ import (
 	optimizev1beta2 "github.com/thestormforge/optimize-controller/v2/api/v1beta2"
 	"github.com/thestormforge/optimize-controller/v2/internal/experiment"
 	"github.com/thestormforge/optimize-controller/v2/internal/trial"
+	"github.com/thestormforge/optimize-controller/v2/internal/validation"
 	"github.com/thestormforge/optimize-go/pkg/api"
 	experimentsv1alpha1 "github.com/thestormforge/optimize-go/pkg/api/experiments/v1alpha1"
 	"github.com/thestormforge/optimize-go/pkg/api/experiments/v1alpha1/numstr"
@@ -161,6 +162,8 @@ func FromCluster(in *optimizev1beta2.Experiment) (experimentsv1alpha1.Experiment
 		baseline = nil
 	} else if len(baseline.Assignments) != len(out.Parameters) {
 		return nil, nil, nil, fmt.Errorf("baseline must be specified on all or none of the parameters")
+	} else if err := validation.CheckConstraints(out.Constraints, baseline.Assignments); err != nil {
+		return nil, nil, nil, err
 	}
 
 	n := experimentsv1alpha1.NewExperimentName(in.Name)

--- a/internal/validation/definition.go
+++ b/internal/validation/definition.go
@@ -18,6 +18,7 @@ package validation
 
 import (
 	"fmt"
+	"math"
 
 	optimizev1beta2 "github.com/thestormforge/optimize-controller/v2/api/v1beta2"
 	experimentsv1alpha1 "github.com/thestormforge/optimize-go/pkg/api/experiments/v1alpha1"
@@ -53,6 +54,76 @@ func CheckDefinition(exp *optimizev1beta2.Experiment, ee *experimentsv1alpha1.Ex
 		}
 	} else {
 		return fmt.Errorf("server and cluster have incompatible metric definitions")
+	}
+
+	return nil
+}
+
+// CheckConstraints ensures the supplied baseline assignments are valid for a set
+// of constraints.
+func CheckConstraints(constraints []redskyapi.Constraint, baselines []redskyapi.Assignment) error {
+	// Nothing to check
+	if len(constraints) == 0 || len(baselines) == 0 {
+		return nil
+	}
+
+	// Index numeric assignments and expose a helper for validating them
+	values := make(map[string]float64, len(baselines))
+	for _, b := range baselines {
+		if b.Value.IsString {
+			values[b.ParameterName] = math.NaN()
+		} else {
+			values[b.ParameterName] = b.Value.Float64Value()
+		}
+	}
+	getValue := func(constraintName, parameterName string) (float64, error) {
+		value, ok := values[parameterName]
+		switch {
+		case !ok:
+			return 0, fmt.Errorf("constraint %q references missing parameter %q", constraintName, parameterName)
+		case math.IsNaN(value):
+			return 0, fmt.Errorf("non-numeric baseline for parameter %q cannot be used to satisfy constraint %q", parameterName, constraintName)
+		default:
+			return value, nil
+		}
+	}
+
+	// Make sure all constraints pass
+	for _, c := range constraints {
+		switch c.ConstraintType {
+		case redskyapi.ConstraintOrder:
+			lower, err := getValue(c.Name, c.OrderConstraint.LowerParameter)
+			if err != nil {
+				return err
+			}
+
+			upper, err := getValue(c.Name, c.OrderConstraint.UpperParameter)
+			if err != nil {
+				return err
+			}
+
+			if lower > upper {
+				return fmt.Errorf("baseline does not satisfy constraint %q", c.Name)
+			}
+
+		case redskyapi.ConstraintSum:
+			bound := c.SumConstraint.Bound
+			for _, p := range c.SumConstraint.Parameters {
+				value, err := getValue(c.Name, p.Name)
+				if err != nil {
+					return err
+				}
+
+				bound -= value * p.Weight
+			}
+			if !c.IsUpperBound {
+				bound *= -1
+			}
+
+			if bound < 0 {
+				return fmt.Errorf("baseline does not satisfy constraint %q", c.Name)
+			}
+		}
 	}
 
 	return nil

--- a/internal/validation/definition_test.go
+++ b/internal/validation/definition_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	redskyapi "github.com/thestormforge/optimize-go/pkg/api/experiments/v1alpha1"
+	experimentsv1alpha1 "github.com/thestormforge/optimize-go/pkg/api/experiments/v1alpha1"
 	"github.com/thestormforge/optimize-go/pkg/api/experiments/v1alpha1/numstr"
 )
 
@@ -28,23 +28,23 @@ func TestCheckConstraints(t *testing.T) {
 	cases := []struct {
 		desc        string
 		expectErr   bool
-		constraints []redskyapi.Constraint
-		baselines   []redskyapi.Assignment
+		constraints []experimentsv1alpha1.Constraint
+		baselines   []experimentsv1alpha1.Assignment
 	}{
 		{
 			desc:      "order-a-less-than-b",
 			expectErr: false,
-			constraints: []redskyapi.Constraint{
+			constraints: []experimentsv1alpha1.Constraint{
 				{
 					Name:           "a-less-than-b",
-					ConstraintType: redskyapi.ConstraintOrder,
-					OrderConstraint: redskyapi.OrderConstraint{
+					ConstraintType: experimentsv1alpha1.ConstraintOrder,
+					OrderConstraint: &experimentsv1alpha1.OrderConstraint{
 						LowerParameter: "a",
 						UpperParameter: "b",
 					},
 				},
 			},
-			baselines: []redskyapi.Assignment{
+			baselines: []experimentsv1alpha1.Assignment{
 				{ParameterName: "a", Value: numstr.FromInt64(1)},
 				{ParameterName: "b", Value: numstr.FromInt64(2)},
 			},
@@ -52,17 +52,17 @@ func TestCheckConstraints(t *testing.T) {
 		{
 			desc:      "order-a-equal-b",
 			expectErr: false,
-			constraints: []redskyapi.Constraint{
+			constraints: []experimentsv1alpha1.Constraint{
 				{
 					Name:           "a-less-than-b",
-					ConstraintType: redskyapi.ConstraintOrder,
-					OrderConstraint: redskyapi.OrderConstraint{
+					ConstraintType: experimentsv1alpha1.ConstraintOrder,
+					OrderConstraint: &experimentsv1alpha1.OrderConstraint{
 						LowerParameter: "a",
 						UpperParameter: "b",
 					},
 				},
 			},
-			baselines: []redskyapi.Assignment{
+			baselines: []experimentsv1alpha1.Assignment{
 				{ParameterName: "a", Value: numstr.FromInt64(2)},
 				{ParameterName: "b", Value: numstr.FromInt64(2)},
 			},
@@ -70,17 +70,17 @@ func TestCheckConstraints(t *testing.T) {
 		{
 			desc:      "order-a-greater-than-b",
 			expectErr: true,
-			constraints: []redskyapi.Constraint{
+			constraints: []experimentsv1alpha1.Constraint{
 				{
 					Name:           "a-less-than-b",
-					ConstraintType: redskyapi.ConstraintOrder,
-					OrderConstraint: redskyapi.OrderConstraint{
+					ConstraintType: experimentsv1alpha1.ConstraintOrder,
+					OrderConstraint: &experimentsv1alpha1.OrderConstraint{
 						LowerParameter: "a",
 						UpperParameter: "b",
 					},
 				},
 			},
-			baselines: []redskyapi.Assignment{
+			baselines: []experimentsv1alpha1.Assignment{
 				{ParameterName: "a", Value: numstr.FromInt64(3)},
 				{ParameterName: "b", Value: numstr.FromInt64(2)},
 			},
@@ -89,21 +89,21 @@ func TestCheckConstraints(t *testing.T) {
 		{
 			desc:      "sum-less-than-upper",
 			expectErr: false,
-			constraints: []redskyapi.Constraint{
+			constraints: []experimentsv1alpha1.Constraint{
 				{
 					Name:           "a-plus-b-less-than-5",
-					ConstraintType: redskyapi.ConstraintSum,
-					SumConstraint: redskyapi.SumConstraint{
+					ConstraintType: experimentsv1alpha1.ConstraintSum,
+					SumConstraint: &experimentsv1alpha1.SumConstraint{
 						Bound:        5.0,
 						IsUpperBound: true,
-						Parameters: []redskyapi.SumConstraintParameter{
+						Parameters: []experimentsv1alpha1.SumConstraintParameter{
 							{Name: "a", Weight: 1.0},
 							{Name: "b", Weight: 1.0},
 						},
 					},
 				},
 			},
-			baselines: []redskyapi.Assignment{
+			baselines: []experimentsv1alpha1.Assignment{
 				{ParameterName: "a", Value: numstr.FromInt64(2)},
 				{ParameterName: "b", Value: numstr.FromInt64(2)},
 			},
@@ -111,21 +111,21 @@ func TestCheckConstraints(t *testing.T) {
 		{
 			desc:      "sum-equal-upper",
 			expectErr: false,
-			constraints: []redskyapi.Constraint{
+			constraints: []experimentsv1alpha1.Constraint{
 				{
 					Name:           "a-plus-b-less-than-5",
-					ConstraintType: redskyapi.ConstraintSum,
-					SumConstraint: redskyapi.SumConstraint{
+					ConstraintType: experimentsv1alpha1.ConstraintSum,
+					SumConstraint: &experimentsv1alpha1.SumConstraint{
 						Bound:        5.0,
 						IsUpperBound: true,
-						Parameters: []redskyapi.SumConstraintParameter{
+						Parameters: []experimentsv1alpha1.SumConstraintParameter{
 							{Name: "a", Weight: 1.0},
 							{Name: "b", Weight: 1.0},
 						},
 					},
 				},
 			},
-			baselines: []redskyapi.Assignment{
+			baselines: []experimentsv1alpha1.Assignment{
 				{ParameterName: "a", Value: numstr.FromInt64(2)},
 				{ParameterName: "b", Value: numstr.FromInt64(3)},
 			},
@@ -133,21 +133,21 @@ func TestCheckConstraints(t *testing.T) {
 		{
 			desc:      "sum-greater-than-upper",
 			expectErr: true,
-			constraints: []redskyapi.Constraint{
+			constraints: []experimentsv1alpha1.Constraint{
 				{
 					Name:           "a-plus-b-less-than-5",
-					ConstraintType: redskyapi.ConstraintSum,
-					SumConstraint: redskyapi.SumConstraint{
+					ConstraintType: experimentsv1alpha1.ConstraintSum,
+					SumConstraint: &experimentsv1alpha1.SumConstraint{
 						Bound:        5.0,
 						IsUpperBound: true,
-						Parameters: []redskyapi.SumConstraintParameter{
+						Parameters: []experimentsv1alpha1.SumConstraintParameter{
 							{Name: "a", Weight: 1.0},
 							{Name: "b", Weight: 1.0},
 						},
 					},
 				},
 			},
-			baselines: []redskyapi.Assignment{
+			baselines: []experimentsv1alpha1.Assignment{
 				{ParameterName: "a", Value: numstr.FromInt64(3)},
 				{ParameterName: "b", Value: numstr.FromInt64(3)},
 			},
@@ -156,20 +156,20 @@ func TestCheckConstraints(t *testing.T) {
 		{
 			desc:      "sum-less-than-lower",
 			expectErr: true,
-			constraints: []redskyapi.Constraint{
+			constraints: []experimentsv1alpha1.Constraint{
 				{
 					Name:           "a-plus-b-greater-than-3",
-					ConstraintType: redskyapi.ConstraintSum,
-					SumConstraint: redskyapi.SumConstraint{
+					ConstraintType: experimentsv1alpha1.ConstraintSum,
+					SumConstraint: &experimentsv1alpha1.SumConstraint{
 						Bound: 3.0,
-						Parameters: []redskyapi.SumConstraintParameter{
+						Parameters: []experimentsv1alpha1.SumConstraintParameter{
 							{Name: "a", Weight: 1.0},
 							{Name: "b", Weight: 1.0},
 						},
 					},
 				},
 			},
-			baselines: []redskyapi.Assignment{
+			baselines: []experimentsv1alpha1.Assignment{
 				{ParameterName: "a", Value: numstr.FromInt64(1)},
 				{ParameterName: "b", Value: numstr.FromInt64(1)},
 			},
@@ -177,20 +177,20 @@ func TestCheckConstraints(t *testing.T) {
 		{
 			desc:      "sum-equal-lower",
 			expectErr: false,
-			constraints: []redskyapi.Constraint{
+			constraints: []experimentsv1alpha1.Constraint{
 				{
 					Name:           "a-plus-b-greater-than-3",
-					ConstraintType: redskyapi.ConstraintSum,
-					SumConstraint: redskyapi.SumConstraint{
+					ConstraintType: experimentsv1alpha1.ConstraintSum,
+					SumConstraint: &experimentsv1alpha1.SumConstraint{
 						Bound: 3.0,
-						Parameters: []redskyapi.SumConstraintParameter{
+						Parameters: []experimentsv1alpha1.SumConstraintParameter{
 							{Name: "a", Weight: 1.0},
 							{Name: "b", Weight: 1.0},
 						},
 					},
 				},
 			},
-			baselines: []redskyapi.Assignment{
+			baselines: []experimentsv1alpha1.Assignment{
 				{ParameterName: "a", Value: numstr.FromInt64(1)},
 				{ParameterName: "b", Value: numstr.FromInt64(2)},
 			},
@@ -198,20 +198,20 @@ func TestCheckConstraints(t *testing.T) {
 		{
 			desc:      "sum-greater-than-lower",
 			expectErr: false,
-			constraints: []redskyapi.Constraint{
+			constraints: []experimentsv1alpha1.Constraint{
 				{
 					Name:           "a-plus-b-greater-than-3",
-					ConstraintType: redskyapi.ConstraintSum,
-					SumConstraint: redskyapi.SumConstraint{
+					ConstraintType: experimentsv1alpha1.ConstraintSum,
+					SumConstraint: &experimentsv1alpha1.SumConstraint{
 						Bound: 3.0,
-						Parameters: []redskyapi.SumConstraintParameter{
+						Parameters: []experimentsv1alpha1.SumConstraintParameter{
 							{Name: "a", Weight: 1.0},
 							{Name: "b", Weight: 1.0},
 						},
 					},
 				},
 			},
-			baselines: []redskyapi.Assignment{
+			baselines: []experimentsv1alpha1.Assignment{
 				{ParameterName: "a", Value: numstr.FromInt64(2)},
 				{ParameterName: "b", Value: numstr.FromInt64(2)},
 			},

--- a/internal/validation/definition_test.go
+++ b/internal/validation/definition_test.go
@@ -1,0 +1,230 @@
+/*
+Copyright 2021 GramLabs, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	redskyapi "github.com/thestormforge/optimize-go/pkg/api/experiments/v1alpha1"
+	"github.com/thestormforge/optimize-go/pkg/api/experiments/v1alpha1/numstr"
+)
+
+func TestCheckConstraints(t *testing.T) {
+	cases := []struct {
+		desc        string
+		expectErr   bool
+		constraints []redskyapi.Constraint
+		baselines   []redskyapi.Assignment
+	}{
+		{
+			desc:      "order-a-less-than-b",
+			expectErr: false,
+			constraints: []redskyapi.Constraint{
+				{
+					Name:           "a-less-than-b",
+					ConstraintType: redskyapi.ConstraintOrder,
+					OrderConstraint: redskyapi.OrderConstraint{
+						LowerParameter: "a",
+						UpperParameter: "b",
+					},
+				},
+			},
+			baselines: []redskyapi.Assignment{
+				{ParameterName: "a", Value: numstr.FromInt64(1)},
+				{ParameterName: "b", Value: numstr.FromInt64(2)},
+			},
+		},
+		{
+			desc:      "order-a-equal-b",
+			expectErr: false,
+			constraints: []redskyapi.Constraint{
+				{
+					Name:           "a-less-than-b",
+					ConstraintType: redskyapi.ConstraintOrder,
+					OrderConstraint: redskyapi.OrderConstraint{
+						LowerParameter: "a",
+						UpperParameter: "b",
+					},
+				},
+			},
+			baselines: []redskyapi.Assignment{
+				{ParameterName: "a", Value: numstr.FromInt64(2)},
+				{ParameterName: "b", Value: numstr.FromInt64(2)},
+			},
+		},
+		{
+			desc:      "order-a-greater-than-b",
+			expectErr: true,
+			constraints: []redskyapi.Constraint{
+				{
+					Name:           "a-less-than-b",
+					ConstraintType: redskyapi.ConstraintOrder,
+					OrderConstraint: redskyapi.OrderConstraint{
+						LowerParameter: "a",
+						UpperParameter: "b",
+					},
+				},
+			},
+			baselines: []redskyapi.Assignment{
+				{ParameterName: "a", Value: numstr.FromInt64(3)},
+				{ParameterName: "b", Value: numstr.FromInt64(2)},
+			},
+		},
+
+		{
+			desc:      "sum-less-than-upper",
+			expectErr: false,
+			constraints: []redskyapi.Constraint{
+				{
+					Name:           "a-plus-b-less-than-5",
+					ConstraintType: redskyapi.ConstraintSum,
+					SumConstraint: redskyapi.SumConstraint{
+						Bound:        5.0,
+						IsUpperBound: true,
+						Parameters: []redskyapi.SumConstraintParameter{
+							{Name: "a", Weight: 1.0},
+							{Name: "b", Weight: 1.0},
+						},
+					},
+				},
+			},
+			baselines: []redskyapi.Assignment{
+				{ParameterName: "a", Value: numstr.FromInt64(2)},
+				{ParameterName: "b", Value: numstr.FromInt64(2)},
+			},
+		},
+		{
+			desc:      "sum-equal-upper",
+			expectErr: false,
+			constraints: []redskyapi.Constraint{
+				{
+					Name:           "a-plus-b-less-than-5",
+					ConstraintType: redskyapi.ConstraintSum,
+					SumConstraint: redskyapi.SumConstraint{
+						Bound:        5.0,
+						IsUpperBound: true,
+						Parameters: []redskyapi.SumConstraintParameter{
+							{Name: "a", Weight: 1.0},
+							{Name: "b", Weight: 1.0},
+						},
+					},
+				},
+			},
+			baselines: []redskyapi.Assignment{
+				{ParameterName: "a", Value: numstr.FromInt64(2)},
+				{ParameterName: "b", Value: numstr.FromInt64(3)},
+			},
+		},
+		{
+			desc:      "sum-greater-than-upper",
+			expectErr: true,
+			constraints: []redskyapi.Constraint{
+				{
+					Name:           "a-plus-b-less-than-5",
+					ConstraintType: redskyapi.ConstraintSum,
+					SumConstraint: redskyapi.SumConstraint{
+						Bound:        5.0,
+						IsUpperBound: true,
+						Parameters: []redskyapi.SumConstraintParameter{
+							{Name: "a", Weight: 1.0},
+							{Name: "b", Weight: 1.0},
+						},
+					},
+				},
+			},
+			baselines: []redskyapi.Assignment{
+				{ParameterName: "a", Value: numstr.FromInt64(3)},
+				{ParameterName: "b", Value: numstr.FromInt64(3)},
+			},
+		},
+
+		{
+			desc:      "sum-less-than-lower",
+			expectErr: true,
+			constraints: []redskyapi.Constraint{
+				{
+					Name:           "a-plus-b-greater-than-3",
+					ConstraintType: redskyapi.ConstraintSum,
+					SumConstraint: redskyapi.SumConstraint{
+						Bound: 3.0,
+						Parameters: []redskyapi.SumConstraintParameter{
+							{Name: "a", Weight: 1.0},
+							{Name: "b", Weight: 1.0},
+						},
+					},
+				},
+			},
+			baselines: []redskyapi.Assignment{
+				{ParameterName: "a", Value: numstr.FromInt64(1)},
+				{ParameterName: "b", Value: numstr.FromInt64(1)},
+			},
+		},
+		{
+			desc:      "sum-equal-lower",
+			expectErr: false,
+			constraints: []redskyapi.Constraint{
+				{
+					Name:           "a-plus-b-greater-than-3",
+					ConstraintType: redskyapi.ConstraintSum,
+					SumConstraint: redskyapi.SumConstraint{
+						Bound: 3.0,
+						Parameters: []redskyapi.SumConstraintParameter{
+							{Name: "a", Weight: 1.0},
+							{Name: "b", Weight: 1.0},
+						},
+					},
+				},
+			},
+			baselines: []redskyapi.Assignment{
+				{ParameterName: "a", Value: numstr.FromInt64(1)},
+				{ParameterName: "b", Value: numstr.FromInt64(2)},
+			},
+		},
+		{
+			desc:      "sum-greater-than-lower",
+			expectErr: false,
+			constraints: []redskyapi.Constraint{
+				{
+					Name:           "a-plus-b-greater-than-3",
+					ConstraintType: redskyapi.ConstraintSum,
+					SumConstraint: redskyapi.SumConstraint{
+						Bound: 3.0,
+						Parameters: []redskyapi.SumConstraintParameter{
+							{Name: "a", Weight: 1.0},
+							{Name: "b", Weight: 1.0},
+						},
+					},
+				},
+			},
+			baselines: []redskyapi.Assignment{
+				{ParameterName: "a", Value: numstr.FromInt64(2)},
+				{ParameterName: "b", Value: numstr.FromInt64(2)},
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			err := CheckConstraints(c.constraints, c.baselines)
+			if c.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
If any constraints are present on an experiment that defines a viable baseline, that baseline is validated against the constraints. This is meant to cut down on the chance of an experiment being submitted with a constraint that cannot be satisfied.

I'm not sure if I should re-base on this part-deux since that is where the serialization fixes will appear.