### PR TITLE
Upgrade Optimize Go to v0.0.12

### DIFF
--- a/cli/internal/commander/commander.go
+++ b/cli/internal/commander/commander.go
@@ -148,8 +148,8 @@ func SetExperimentsAPI(expAPI *experimentsv1alpha1.API, cfg *config.OptimizeConf
 	}
 
 	// NOTE: We should use `srv.Identifier` but technically this version of the configuration
-	// exposes this double counted "/experiments/" endpoint
-	address := strings.TrimSuffix(srv.API.ExperimentsEndpoint, "/experiments/")
+	// exposes this double counted "/v1/experiments/" endpoint
+	address := strings.TrimSuffix(srv.API.ExperimentsEndpoint, "/v1/experiments/")
 
 	// Reuse the OAuth2 base transport for the API calls
 	t, err := cfg.Authorize(ctx, oauth2.NewClient(ctx, nil).Transport)

--- a/cli/internal/commands/experiments/get.go
+++ b/cli/internal/commands/experiments/get.go
@@ -76,7 +76,7 @@ func (o *GetOptions) get(ctx context.Context) error {
 
 		case typeExperiment:
 			if n.Name == "" {
-				q := experimentsv1alpha1.ExperimentListQuery{IndexQuery: api.IndexQuery{}}
+				q := experimentsv1alpha1.ExperimentListQuery{}
 				q.SetLimit(o.ChunkSize)
 				return o.getExperimentList(ctx, q)
 			}
@@ -106,7 +106,7 @@ func (o *GetOptions) get(ctx context.Context) error {
 }
 
 func (o *GetOptions) trialListQuery() experimentsv1alpha1.TrialListQuery {
-	q := experimentsv1alpha1.TrialListQuery{IndexQuery: api.IndexQuery{}}
+	q := experimentsv1alpha1.TrialListQuery{}
 	q.SetStatus(experimentsv1alpha1.TrialActive, experimentsv1alpha1.TrialCompleted, experimentsv1alpha1.TrialFailed)
 	if o.All {
 		q.AddStatus(experimentsv1alpha1.TrialStaged)

--- a/cli/internal/commands/experiments/label.go
+++ b/cli/internal/commands/experiments/label.go
@@ -130,7 +130,7 @@ func (o *LabelOptions) labelTrials(ctx context.Context, numbers map[experimentsv
 		}
 
 		// Note that you can only label completed trials
-		q := experimentsv1alpha1.TrialListQuery{IndexQuery: api.IndexQuery{}}
+		q := experimentsv1alpha1.TrialListQuery{}
 		q.SetStatus(experimentsv1alpha1.TrialCompleted)
 		tl, err := o.ExperimentsAPI.GetAllTrials(ctx, exp.Link(api.RelationTrials), q)
 		if err != nil {

--- a/cli/internal/commands/export/export.go
+++ b/cli/internal/commands/export/export.go
@@ -452,7 +452,7 @@ func (o *Options) getTrialDetails(ctx context.Context) (*trialDetails, error) {
 		Objective:   exp.Labels["objective"],
 	}
 
-	query := experimentsv1alpha1.TrialListQuery{IndexQuery: api.IndexQuery{}}
+	query := experimentsv1alpha1.TrialListQuery{}
 	query.SetStatus(experimentsv1alpha1.TrialCompleted)
 	trialList, err := o.ExperimentsAPI.GetAllTrials(ctx, exp.Link(api.RelationTrials), query)
 	if err != nil {

--- a/cli/internal/commands/login/login.go
+++ b/cli/internal/commands/login/login.go
@@ -135,8 +135,8 @@ func (o *Options) complete() error {
 			return fmt.Errorf("server must be a valid URL: %v", err)
 		} else if u.Scheme != "https" && u.Scheme != "http" {
 			return fmt.Errorf("server must be an 'https' URL")
-		} else if u.Path != "/v1/" {
-			_, _ = fmt.Fprintf(o.ErrOut, "Warning: Server URL does not have a path of '/v1/', StormForge API endpoints may not resolve correctly")
+		} else if u.Path == "/v1/" {
+			_, _ = fmt.Fprintf(o.ErrOut, "Warning: Server URL has a path of '/v1/', StormForge API endpoints may not resolve correctly")
 		}
 	}
 

--- a/controllers/server_controller.go
+++ b/controllers/server_controller.go
@@ -175,7 +175,7 @@ func (r *ServerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			return err
 		}
 
-		address := strings.TrimSuffix(srv.API.ExperimentsEndpoint, "/experiments/")
+		address := strings.TrimSuffix(srv.API.ExperimentsEndpoint, "/v1/experiments/")
 
 		// Compute the UA string comment using the Kube API server information
 		var comment string

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
 	github.com/thestormforge/konjure v0.3.0
-	github.com/thestormforge/optimize-go v0.0.11
+	github.com/thestormforge/optimize-go v0.0.12
 	github.com/yujunz/go-getter v1.5.1-lite.0.20201201013212-6d9c071adddf
 	github.com/zorkian/go-datadog-api v2.24.0+incompatible
 	go.uber.org/zap v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -572,8 +572,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/thestormforge/konjure v0.3.0 h1:VOUX6te9lbdk8dYJLQpJsvZfuhvwp8+DJMhB1VR46RM=
 github.com/thestormforge/konjure v0.3.0/go.mod h1:8gIqMRKShWB7ejEA+JCN8DUeeDe9CTIc3eXyniFdNj8=
-github.com/thestormforge/optimize-go v0.0.11 h1:+UcecKJKbIUwHKiUCOVu9tyWPNGMlR/+nZ/e6MQiGJ0=
-github.com/thestormforge/optimize-go v0.0.11/go.mod h1:LhoJFNeHXLWnMp5KVkHJdzUfx76Gwj81/m40IVM9MjA=
+github.com/thestormforge/optimize-go v0.0.12 h1:pWo/QnVs+1QFNJ+s1xtnZA9UBnsbubGt1Z3GUEjMR2I=
+github.com/thestormforge/optimize-go v0.0.12/go.mod h1:LhoJFNeHXLWnMp5KVkHJdzUfx76Gwj81/m40IVM9MjA=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=


### PR DESCRIPTION
Take the latest optimize-go (again). This change moves the `/v1/` on the experiments endpoint from the configuration file to the API implementation (i.e. it is hard coded). This is primarily to make room for having a shared base for the upcoming application API.