### PR TITLE
Do not tag pre-release versions as "latest"

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -99,9 +99,11 @@ jobs:
             docker tag "$1" "$2"
             docker push "$2"
           }
-          docker-push "${IMG}" "${IMG%%:*}:${IMAGE_TAG}"
-          docker-push "${CLI_IMG}" "${CLI_IMG%%:*}:${IMAGE_TAG}"
-          docker-push "${SETUPTOOLS_IMG}" "${SETUPTOOLS_IMG%%:*}:${IMAGE_TAG}"
+          if [[ "${IMAGE_TAG}" != "latest" || ! "${VERSION}" =~ "-" ]]; then
+            docker-push "${IMG}" "${IMG%%:*}:${IMAGE_TAG}"
+            docker-push "${CLI_IMG}" "${CLI_IMG%%:*}:${IMAGE_TAG}"
+            docker-push "${SETUPTOOLS_IMG}" "${SETUPTOOLS_IMG%%:*}:${IMAGE_TAG}"
+          fi
           if [ "${IMG#ghcr.io/}" = "${IMG}" ]; then
             docker-push "${IMG}" "ghcr.io/${IMG}"
             docker-push "${CLI_IMG}" "ghcr.io/${CLI_IMG}"

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -76,6 +76,7 @@ jobs:
             DOCKER_TAG="sha-$(git rev-parse --short HEAD)"
             echo "IMAGE_TAG=edge" >> $GITHUB_ENV
           fi
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login "ghcr.io" -u "${{ github.actor }}" --password-stdin
           echo "IMG=${DOCKER_REGISTRY}/optimize-controller:${DOCKER_TAG}" >> $GITHUB_ENV
           echo "CLI_IMG=${DOCKER_REGISTRY}/optimize-cli:${DOCKER_TAG}" >> $GITHUB_ENV
           echo "SETUPTOOLS_IMG=${DOCKER_REGISTRY}/setuptools:${DOCKER_TAG}" >> $GITHUB_ENV
@@ -93,7 +94,6 @@ jobs:
           AC_IDENTITY_P12: ${{ secrets.AC_IDENTITY_P12 }}
       - name: Push Docker images
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login "ghcr.io" -u "${{ github.actor }}" --password-stdin
           make docker-push
           docker-push() {
             docker tag "$1" "$2"

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -70,6 +70,7 @@ jobs:
         run: |
           DOCKER_REGISTRY="ghcr.io/thestormforge"
           DOCKER_TAG="sha-$(git rev-parse --short HEAD)"
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login "ghcr.io" -u "${{ github.actor }}" --password-stdin
           echo "IMAGE_TAG=pr-${{ github.event.number }}" >> $GITHUB_ENV
           echo "IMG=${DOCKER_REGISTRY}/optimize-controller:${DOCKER_TAG}" >> $GITHUB_ENV
           echo "CLI_IMG=${DOCKER_REGISTRY}/optimize-cli:${DOCKER_TAG}" >> $GITHUB_ENV
@@ -85,7 +86,6 @@ jobs:
       - name: Push Docker images
         if: github.event.pull_request.head.repo.fork == false
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login "ghcr.io" -u "${{ github.actor }}" --password-stdin
           make docker-push
           docker-push() {
             docker tag "$1" "$2"


### PR DESCRIPTION
I noticed this with the v2.0.0-beta.1 release: the `latest` tag should have been left at `v1.12.2` instead of going to the pre-release version. It's not a big deal since no one should be using "latest", but nice to have in the future.

I also moved the Docker login for GHCR to the "Bootstrap" step so all the logins happen in the same spot.