### PR TITLE
Compute min on scaled baseline value

### DIFF
--- a/internal/experiment/generation/containerresources.go
+++ b/internal/experiment/generation/containerresources.go
@@ -307,13 +307,12 @@ func (cr containerResources) Max() int32 {
 
 // Min returns the the configured minimum or half the baseline.
 func (cr containerResources) Min() int32 {
-	min := cr.min
-	min.Format = cr.baseline.Format
-
 	if !cr.baseline.IsZero() {
-		min.Set(cr.baseline.Value() / 2)
+		return AsScaledInt(cr.baseline, cr.scale()) / 2
 	}
 
+	min := cr.min
+	min.Format = cr.baseline.Format
 	return AsScaledInt(min, cr.scale())
 }
 

--- a/internal/experiment/generation/containerresources_test.go
+++ b/internal/experiment/generation/containerresources_test.go
@@ -165,6 +165,38 @@ func TestContainerResourcesParameter(t *testing.T) {
                   requests:
                     memory: "{{ .Values.memory }}Ki"`),
 		},
+
+		{
+			desc: "tiny cpu",
+
+			containerResourcesParameter: containerResourcesParameter{
+				pnode: pnode{
+					fieldPath: []string{"spec", "resources"},
+					value: encodeResourceRequirements(corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("1.0"),
+						},
+					}),
+				},
+				resources: []corev1.ResourceName{corev1.ResourceCPU},
+			},
+
+			expectedParameters: []optimizev1beta2.Parameter{
+				{
+					Name:     "cpu",
+					Baseline: newInt(1000),
+					Min:      500,
+					Max:      2000,
+				},
+			},
+			expectedPatch: unindent(`
+              spec:
+                resources:
+                  limits:
+                    cpu: "{{ .Values.cpu }}m"
+                  requests:
+                    cpu: "{{ .Values.cpu }}m"`),
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.desc, func(t *testing.T) {


### PR DESCRIPTION
This prevents an issue where a CPU value of `1000m` (aka `1.0`) is really the integer value `1` (which ends up as 0 when divided by 2).

Originally I was trying to keep the min/max implementations as similar as possible, turns out that wasn't a good approach.