### PR TITLE
RBAC: list services is no longer required

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -19,12 +19,6 @@ rules:
   verbs:
   - list
 - apiGroups:
-  - ""
-  resources:
-  - services
-  verbs:
-  - list
-- apiGroups:
   - batch
   - extensions
   resources:

--- a/controllers/metric_controller.go
+++ b/controllers/metric_controller.go
@@ -49,7 +49,6 @@ type MetricReconciler struct {
 // +kubebuilder:rbac:groups=optimize.stormforge.io,resources=experiments,verbs=get;list;watch
 // +kubebuilder:rbac:groups=optimize.stormforge.io,resources=trials,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups="",resources=pods,verbs=list
-// +kubebuilder:rbac:groups="",resources=services,verbs=list
 
 func (r *MetricReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	ctx := context.Background()


### PR DESCRIPTION
This was required for evaluating legacy metrics in 1.x, however given that 2.0 only supports the newer URL based metrics it is no longer necessary.