### PR TITLE
refactor: Move api client creation to server package

### DIFF
--- a/controllers/server_controller.go
+++ b/controllers/server_controller.go
@@ -165,12 +165,12 @@ func (r *ServerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			}
 		}
 
-		client, err := server.NewExperimentClient(context.Background(), comment)
+		api, err := server.NewExperimentAPI(context.Background(), comment)
 		if err != nil {
 			return err
 		}
 
-		r.ExperimentsAPI = client
+		r.ExperimentsAPI = api
 	}
 
 	// Enforce trial creation rate limit (no burst! that is the whole point)

--- a/controllers/server_controller.go
+++ b/controllers/server_controller.go
@@ -31,10 +31,8 @@ import (
 	"github.com/thestormforge/optimize-controller/v2/internal/server"
 	"github.com/thestormforge/optimize-controller/v2/internal/trial"
 	"github.com/thestormforge/optimize-controller/v2/internal/validation"
-	"github.com/thestormforge/optimize-controller/v2/internal/version"
 	"github.com/thestormforge/optimize-go/pkg/api"
 	experimentsv1alpha1 "github.com/thestormforge/optimize-go/pkg/api/experiments/v1alpha1"
-	"github.com/thestormforge/optimize-go/pkg/config"
 	"golang.org/x/time/rate"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -159,27 +157,6 @@ func (r *ServerReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 
 func (r *ServerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if r.ExperimentsAPI == nil {
-		ctx := context.Background()
-
-		// Load the configuration
-		cfg := &config.OptimizeConfig{}
-		cfg.AuthorizationParameters = map[string][]string{
-			"audience": {"https://api.carbonrelay.io/v1/"},
-		}
-		if err := cfg.Load(); err != nil {
-			return err
-		}
-
-		// Get the Experiments API endpoint from the configuration
-		// NOTE: The current version of the configuration has an explicit configuration for the
-		// experiments endpoint which would duplicate the "/experiments/" path segment
-		srv, err := config.CurrentServer(cfg.Reader())
-		if err != nil {
-			return err
-		}
-
-		address := strings.TrimSuffix(srv.API.ExperimentsEndpoint, "/v1/experiments/")
-
 		// Compute the UA string comment using the Kube API server information
 		var comment string
 		if dc, err := discovery.NewDiscoveryClientForConfig(mgr.GetConfig()); err == nil {
@@ -188,24 +165,12 @@ func (r *ServerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			}
 		}
 
-		rt, err := cfg.Authorize(ctx, version.UserAgent("optimize-controller", comment, nil))
+		client, err := server.NewExperimentClient(context.Background(), comment)
 		if err != nil {
 			return err
 		}
 
-		// Create a new Experiment API client
-		c, err := api.NewClient(address, rt)
-		if err != nil {
-			return err
-		}
-		expAPI := experimentsv1alpha1.NewAPI(c)
-
-		// An unauthorized error means we will never be able to connect without changing the credentials and restarting
-		if _, err := expAPI.Options(ctx); api.IsUnauthorized(err) {
-			r.Log.Info("Experiments API is unavailable, skipping setup", "message", err.Error())
-			return nil
-		}
-		r.ExperimentsAPI = expAPI
+		r.ExperimentsAPI = client
 	}
 
 	// Enforce trial creation rate limit (no burst! that is the whole point)

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -30,7 +30,7 @@ import (
 
 const audience = "https://api.carbonrelay.io/v1/"
 
-func NewExperimentClient(ctx context.Context, uaComment string) (experimentsv1alpha1.API, error) {
+func NewExperimentAPI(ctx context.Context, uaComment string) (experimentsv1alpha1.API, error) {
 	address, rt, err := loadConfig(ctx, uaComment)
 	if err != nil {
 		return nil, err

--- a/internal/server/client.go
+++ b/internal/server/client.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2020 GramLabs, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/thestormforge/optimize-controller/v2/internal/version"
+	"github.com/thestormforge/optimize-go/pkg/api"
+	experimentsv1alpha1 "github.com/thestormforge/optimize-go/pkg/api/experiments/v1alpha1"
+	"github.com/thestormforge/optimize-go/pkg/config"
+)
+
+const audience = "https://api.carbonrelay.io/v1/"
+
+func NewExperimentClient(ctx context.Context, uaComment string) (experimentsv1alpha1.API, error) {
+	address, rt, err := loadConfig(ctx, uaComment)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a new Experiment API client
+	c, err := api.NewClient(address, rt)
+	if err != nil {
+		return nil, err
+	}
+
+	expAPI := experimentsv1alpha1.NewAPI(c)
+
+	// An unauthorized error means we will never be able to connect without changing the credentials and restarting
+	if _, err := expAPI.Options(ctx); api.IsUnauthorized(err) {
+		return nil, fmt.Errorf("experiments API is unavailable, skipping setup: %s", err.Error())
+	}
+
+	return expAPI, nil
+}
+
+func loadConfig(ctx context.Context, uaComment string) (string, http.RoundTripper, error) {
+	// Load the configuration
+	cfg := &config.OptimizeConfig{}
+	cfg.AuthorizationParameters = map[string][]string{
+		"audience": {audience},
+	}
+
+	if err := cfg.Load(); err != nil {
+		return "", nil, err
+	}
+
+	// Get the Experiments API endpoint from the configuration
+	// NOTE: The current version of the configuration has an explicit configuration for the
+	// experiments endpoint which would duplicate the "/experiments/" path segment
+	srv, err := config.CurrentServer(cfg.Reader())
+	if err != nil {
+		return "", nil, err
+	}
+
+	address := strings.TrimSuffix(srv.API.ExperimentsEndpoint, "/v1/experiments/")
+
+	rt, err := cfg.Authorize(ctx, version.UserAgent("optimize-controller", uaComment, nil))
+	if err != nil {
+		return "", nil, err
+	}
+
+	return address, rt, nil
+}


### PR DESCRIPTION
This moves our api client functions to the server package. This should set the
stage for adding in the application api client code since they both should
share a very similiar initialization.

Note, this requires the latest optimize-go code, so we can't merge until a new optimize-go release is cut.

Signed-off-by: Brad Beam <brad.beam@stormforge.io>