### PR TITLE
Change the controller user from nonroot to nobody

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY ./manager .
-USER nonroot:nonroot
+USER nobody:nobody
 
 ENTRYPOINT ["/manager"]

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -23,9 +23,7 @@ spec:
         control-plane: controller-manager
     spec:
       containers:
-        - command:
-            - /manager
-          image: controller:latest
+        - image: controller:latest
           name: manager
           resources:
             limits:
@@ -35,8 +33,8 @@ spec:
               cpu: 100m
               memory: 250Mi
           securityContext:
-            runAsUser: 65532
-            runAsGroup: 65532
+            runAsUser: 65534
+            runAsGroup: 65534
             runAsNonRoot: true
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false


### PR DESCRIPTION
Changes the runtime user for the controller from `nonroot` (which is specific to the distroless base) to `nobody` (a user which exists, even by uid, on other bases). This mostly a compatibility change to prepare us for some of the OpenShift requirements.