### PR TITLE
StormForger Authorization

### DIFF
--- a/cli/internal/commands/authorize_cluster/generator.go
+++ b/cli/internal/commands/authorize_cluster/generator.go
@@ -292,13 +292,13 @@ func printHelmValues(obj interface{}, w io.Writer) error {
 // map will also be updated with any new tokens.
 func performanceTokens(label, controllerName string, data map[string][]byte) config.Change {
 	var envVars []config.ControllerEnvVar
-	hasEnvVar := func(name string) bool { return len(data[name]) > 0 }
+	hasControllerEnvVar := func(name string) bool { return len(data[name]) > 0 }
 
 	// List all the organizations the user belongs to
 	orgs, err := exec.Command("forge", "organization", "list", "--output", "plain").Output()
 	if err != nil {
 		// Check if we already have a generic token
-		if hasEnvVar("STORMFORGER_JWT") {
+		if hasControllerEnvVar("STORMFORGER_JWT") {
 			return nil
 		}
 
@@ -328,7 +328,7 @@ func performanceTokens(label, controllerName string, data map[string][]byte) con
 
 		// Check to see if we already created a service account
 		name := fmt.Sprintf("STORMFORGER_%s_JWT", strings.Map(toEnv, org))
-		if hasEnvVar(name) {
+		if hasControllerEnvVar(name) {
 			continue
 		}
 

--- a/cli/internal/commands/authorize_cluster/generator.go
+++ b/cli/internal/commands/authorize_cluster/generator.go
@@ -21,8 +21,11 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
+	"os/user"
+	"path/filepath"
 	"strings"
 
+	"github.com/pelletier/go-toml"
 	"github.com/spf13/cobra"
 	"github.com/thestormforge/optimize-controller/v2/cli/internal/commander"
 	"github.com/thestormforge/optimize-go/pkg/api"
@@ -181,6 +184,16 @@ func (o *GeneratorOptions) readConfig() (string, *config.Controller, map[string]
 	if err != nil {
 		return "", nil, nil, err
 	}
+
+	// Check for additional configuration
+	if usr, err := user.Current(); err == nil {
+		if cfg, err := toml.LoadFile(filepath.Join(usr.HomeDir, ".stormforger.toml")); err == nil {
+			if v, ok := cfg.Get("jwt").(string); ok {
+				data["STORMFORGER_JWT"] = []byte(v)
+			}
+		}
+	}
+
 	return controllerName, &ctrl, data, nil
 }
 

--- a/cli/internal/commands/authorize_cluster/generator.go
+++ b/cli/internal/commands/authorize_cluster/generator.go
@@ -17,13 +17,15 @@ limitations under the License.
 package authorize_cluster
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
-	"os/user"
-	"path/filepath"
 	"strings"
+	"unicode"
 
 	"github.com/pelletier/go-toml"
 	"github.com/spf13/cobra"
@@ -129,6 +131,14 @@ func (o *GeneratorOptions) generate(ctx context.Context) error {
 		return err
 	}
 
+	// Ensure Performance Test tokens have been added
+	label := fmt.Sprintf("optimize-%s", strings.Map(toLabel, o.ClientName))
+	if chg := performanceTokens(label, controllerName, data); chg != nil {
+		if err := o.Config.Update(chg); err != nil {
+			return err
+		}
+	}
+
 	// Get the client information (either read or register)
 	info, err := o.clientInfo(ctx, ctrl)
 	if o.AllowUnauthorized && api.IsUnauthorized(err) {
@@ -184,16 +194,6 @@ func (o *GeneratorOptions) readConfig() (string, *config.Controller, map[string]
 	if err != nil {
 		return "", nil, nil, err
 	}
-
-	// Check for additional configuration
-	if usr, err := user.Current(); err == nil {
-		if cfg, err := toml.LoadFile(filepath.Join(usr.HomeDir, ".stormforger.toml")); err == nil {
-			if v, ok := cfg.Get("jwt").(string); ok {
-				data["STORMFORGER_JWT"] = []byte(v)
-			}
-		}
-	}
-
 	return controllerName, &ctrl, data, nil
 }
 
@@ -285,4 +285,105 @@ func printHelmValues(obj interface{}, w io.Writer) error {
 	}
 	_, err = w.Write(b)
 	return err
+}
+
+// performanceTokens returns a configuration change with any new Performance Test
+// tokens or nil if there are no changes necessary. Note that the supplied data
+// map will also be updated with any new tokens.
+func performanceTokens(label, controllerName string, data map[string][]byte) config.Change {
+	var envVars []config.ControllerEnvVar
+	hasEnvVar := func(name string) bool { return len(data[name]) > 0 }
+
+	// List all the organizations the user belongs to
+	orgs, err := exec.Command("forge", "organization", "list", "--output", "plain").Output()
+	if err != nil {
+		// Check if we already have a generic token
+		if hasEnvVar("STORMFORGER_JWT") {
+			return nil
+		}
+
+		// Since we couldn't list the orgs (e.g. no `forge` installed), maybe there is a config file
+		cfg, err := toml.LoadFile(os.ExpandEnv("${HOME}/.stormforger.toml"))
+		if err != nil {
+			return nil
+		}
+
+		// We need the JWT as a string, otherwise there is nothing to add
+		tok, ok := cfg.Get("jwt").(string)
+		if !ok {
+			return nil
+		}
+
+		orgs = nil
+		envVars = append(envVars, config.ControllerEnvVar{Name: "STORMFORGER_JWT", Value: tok})
+	}
+
+	// Scan the organization list to
+	orgScanner := bufio.NewScanner(bytes.NewBuffer(orgs))
+	for orgScanner.Scan() {
+		org := strings.TrimSpace(orgScanner.Text())
+		if org == "" {
+			continue
+		}
+
+		// Check to see if we already created a service account
+		name := fmt.Sprintf("STORMFORGER_%s_JWT", strings.Map(toEnv, org))
+		if hasEnvVar(name) {
+			continue
+		}
+
+		// Register a new service account, ignore errors
+		sa, err := exec.Command("forge", "serviceaccount", "create", org, label).Output()
+		if err != nil {
+			continue
+		}
+
+		// The last line with two dots is the JWT
+		tokenScanner := bufio.NewScanner(bytes.NewBuffer(sa))
+		for tokenScanner.Scan() {
+			// TODO It might be nice to capture the UID values into an annotation on the secret
+			if strings.Count(tokenScanner.Text(), ".") == 2 {
+				envVars = append(envVars, config.ControllerEnvVar{Name: name, Value: tokenScanner.Text()})
+			}
+		}
+	}
+
+	// If we found any new environment variables for the configuration, return a configuration change set
+	if len(envVars) == 0 {
+		return nil
+	}
+	for i := range envVars {
+		data[envVars[i].Name] = []byte(envVars[i].Value)
+	}
+	return func(cfg *config.Config) error {
+		for i := range cfg.Controllers {
+			if cfg.Controllers[i].Name != controllerName {
+				continue
+			}
+
+			cfg.Controllers[i].Controller.Env = append(cfg.Controllers[i].Controller.Env, envVars...)
+			return nil
+		}
+		return nil
+	}
+}
+
+func toLabel(r rune) rune {
+	switch {
+	case unicode.IsSpace(r):
+		return '_'
+	case unicode.IsLetter(r):
+		return unicode.ToLower(r)
+	default:
+		return -1
+	}
+}
+
+func toEnv(r rune) rune {
+	switch {
+	case r == '-':
+		return '_'
+	default:
+		return unicode.ToUpper(r)
+	}
 }

--- a/internal/experiment/generation/stormforger.go
+++ b/internal/experiment/generation/stormforger.go
@@ -244,10 +244,13 @@ func (s *StormForgerSource) stormForgerAccessToken(org string) *optimizeappsv1al
 	}
 
 	// If the environment variable is set, take that over the file
-	if tok, ok := os.LookupEnv("STORMFORGER_JWT"); ok {
-		return fixRef(&optimizeappsv1alpha1.StormForgerAccessToken{
-			Literal: tok,
-		})
+	envOrg := strings.ToUpper(strings.ReplaceAll(org, "-", "_"))
+	for _, key := range []string{"STORMFORGER_" + envOrg + "_JWT", "STORMFORGER_JWT"} {
+		if tok, ok := os.LookupEnv(key); ok {
+			return fixRef(&optimizeappsv1alpha1.StormForgerAccessToken{
+				Literal: tok,
+			})
+		}
 	}
 
 	// Check the config file to see if there is something we can use

--- a/internal/experiment/generation/stormforger.go
+++ b/internal/experiment/generation/stormforger.go
@@ -18,6 +18,7 @@ package generation
 
 import (
 	"fmt"
+	"os"
 	"os/user"
 	"path/filepath"
 	"strings"
@@ -240,6 +241,13 @@ func (s *StormForgerSource) stormForgerAccessToken(org string) *optimizeappsv1al
 	// Use the access token specified in the application
 	if s.Application.StormForger != nil && s.Application.StormForger.AccessToken != nil {
 		return fixRef(s.Application.StormForger.AccessToken.DeepCopy())
+	}
+
+	// If the environment variable is set, take that over the file
+	if tok, ok := os.LookupEnv("STORMFORGER_JWT"); ok {
+		return fixRef(&optimizeappsv1alpha1.StormForgerAccessToken{
+			Literal: tok,
+		})
 	}
 
 	// Check the config file to see if there is something we can use


### PR DESCRIPTION
This PR adds two features around Performance Test authorization:
1. The experiment generation code will now honor `STORMFORGER_JWT` and `STORMFORGER_<ORG>_JWT` environment variables. This is applies to both CLI invocations of `gen exp` and in-cluster generations (in which case the environment variables are expected to come in via the same authorization secret we use to store the client ID/secret).
2. The authorization secret generation code will now attempt to use the `forge` tool to determine which organizations the current user belongs to: if this is successful a new organization specific service account is created for each org and stored in the configuration file (in the environment variables, the same place you would find something like a Datadog API secret). If the `forge org list` command fails for any reason (e.g. `forge` is not installed or is not logged in), an attempt will be made to copy the user's token from `~/.stormforger.toml` into the cluster as the `STORMFORGE_JWT` environment variable.

Note: if you do not have permission to create service accounts, those orgs will be silently omitted from this automatic registration and your user token will not be included (in fact once the org list is successfully obtained, all errors are silently ignored).

If your cluster has already been initialized, you can run `stormforge authorize-cluster` to update the secret.
