### PR TITLE
Add missing application/scenario labels on fix

### DIFF
--- a/internal/experiment/generation/custom.go
+++ b/internal/experiment/generation/custom.go
@@ -66,14 +66,15 @@ func (s *CustomSource) Update(exp *optimizev1beta2.Experiment) error {
 	// It is possible we ended up in an invalid state, try to clean things up
 	if exp.Spec.TrialTemplate.Spec.JobTemplate != nil {
 		pod := ensureTrialJobPod(exp)
+		var usedScenarioName bool
 		for i := range pod.Spec.Containers {
 			if pod.Spec.Containers[i].Name == "" {
-				name := pod.Spec.Containers[i].Image
-				name = name[strings.LastIndex(name, "/")+1:]
-				if pos := strings.Index(name, ":"); pos > 0 {
-					name = name[0:pos]
+				if usedScenarioName {
+					return fmt.Errorf("multiple containers are missing names")
 				}
-				pod.Spec.Containers[i].Name = name
+
+				pod.Spec.Containers[i].Name = s.Scenario.Name
+				usedScenarioName = true
 			}
 		}
 	}

--- a/internal/experiment/generation/locust.go
+++ b/internal/experiment/generation/locust.go
@@ -45,7 +45,7 @@ func (s *LocustSource) Update(exp *optimizev1beta2.Experiment) error {
 	pod := &ensureTrialJobPod(exp).Spec
 	pod.Containers = []corev1.Container{
 		{
-			Name:  "locust",
+			Name:  s.Scenario.Name,
 			Image: trialJobImage("locust"),
 			Env:   s.locustEnv(),
 			VolumeMounts: []corev1.VolumeMount{

--- a/internal/experiment/generation/stormforger.go
+++ b/internal/experiment/generation/stormforger.go
@@ -60,7 +60,7 @@ func (s *StormForgerSource) Update(exp *optimizev1beta2.Experiment) error {
 	pod := &ensureTrialJobPod(exp).Spec
 	pod.Containers = []corev1.Container{
 		{
-			Name:  "stormforger",
+			Name:  s.Scenario.Name,
 			Image: trialJobImage("stormforger"),
 			Env: []corev1.EnvVar{
 				{

--- a/internal/sfio/migrate.go
+++ b/internal/sfio/migrate.go
@@ -297,7 +297,7 @@ func (f *ExperimentMigrationFilter) appLabels(node *yaml.RNode) (labelApplicatio
 
 		// Filter out buzzwords, and pure integers
 		var appName []string
-		drop := regexp.MustCompile("^example|experiment|final|yolo|[0-9]+$")
+		drop := regexp.MustCompile("^(example|experiment|final|yolo|[0-9]+)$")
 		for _, p := range strings.Split(strings.ToLower(md.Name), "-") {
 			if p != "" && !drop.MatchString(p) {
 				appName = append(appName, p)
@@ -317,7 +317,7 @@ func (f *ExperimentMigrationFilter) appLabels(node *yaml.RNode) (labelApplicatio
 
 		// Try to get the first container name off the trial job
 		nameNode, err := node.Pipe(yaml.Lookup("spec", "trialTemplate", "spec", "jobTemplate", "spec", "template", "spec", "containers", "0", "name"))
-		if err == nil && nameNode.YNode().Value != "" {
+		if err == nil && !nameNode.IsNilOrEmpty() && nameNode.YNode().Value != "" {
 			labelScenario = nameNode.YNode().Value
 		}
 	}

--- a/internal/sfio/migrate_test.go
+++ b/internal/sfio/migrate_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2021 GramLabs, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sfio
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+func TestExperimentMigrationFilter_AppLabels(t *testing.T) {
+	cases := []struct {
+		desc            string
+		applicationName string
+		scenarioName    string
+		experiment      *yaml.RNode
+	}{
+		{
+			desc:            "simple name",
+			applicationName: "postgres",
+			scenarioName:    "default",
+			experiment: yaml.MustParse(`
+metadata:
+  name: postgres-example
+`),
+		},
+		{
+			desc:            "common name",
+			applicationName: "postgres",
+			scenarioName:    "default",
+			experiment: yaml.MustParse(`
+metadata:
+  name: postgres-example-final-final-3
+`),
+		},
+		{
+			desc:            "trailing int",
+			applicationName: "myapp30",
+			scenarioName:    "default",
+			experiment: yaml.MustParse(`
+metadata:
+  name: myapp30
+`),
+		},
+		{
+			desc:            "isolated int",
+			applicationName: "myapp",
+			scenarioName:    "default",
+			experiment: yaml.MustParse(`
+metadata:
+  name: myapp-40
+`),
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			appName, scnName, err := (&ExperimentMigrationFilter{}).appLabels(c.experiment)
+			if assert.NoError(t, err) {
+				assert.Equal(t, c.applicationName, appName)
+				assert.Equal(t, c.scenarioName, scnName)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds a step in the `v1beta1/Experiment` to `v1beta2/Experiment` migration that ensures both the application and scenario labels are set (as they will be soon be required on all `v1beta2/Experiment` instances).

Additionally, I changed the name of the container used during experiment generation to match the scenario itself (rather then the type of scenario): for example, when generating an experiment using a StormForger test case named "jeremy/black-friday" the old behavior would have been to use "stormforger" as the container name while the new behavior will be to call that container "black-friday". This also aligns with the behavior implemented in the migration (where a missing scenario name will be inferred from the first container name when the explicit label is missing).