### PR TITLE
Expose custom scenario in run

### DIFF
--- a/cli/internal/commands/run/model.go
+++ b/cli/internal/commands/run/model.go
@@ -128,6 +128,8 @@ type generatorModel struct {
 	StormForgerTestCaseInput  form.ChoiceField
 	StormForgerGettingStarted form.ExitField
 	LocustfileInput           form.TextField
+	CustomImage               form.TextField
+	CustomPushGateway         form.ChoiceField
 
 	NamespaceInput        form.MultiChoiceField
 	LabelSelectorInputs   []form.TextField
@@ -181,6 +183,12 @@ func (m generatorModel) Update(msg tea.Msg) (generatorModel, tea.Cmd) {
 	m.LocustfileInput, cmd = m.LocustfileInput.Update(msg)
 	cmds = append(cmds, cmd)
 
+	m.CustomImage, cmd = m.CustomImage.Update(msg)
+	cmds = append(cmds, cmd)
+
+	m.CustomPushGateway, cmd = m.CustomPushGateway.Update(msg)
+	cmds = append(cmds, cmd)
+
 	m.NamespaceInput, cmd = m.NamespaceInput.Update(msg)
 	cmds = append(cmds, cmd)
 
@@ -211,6 +219,8 @@ func (m *generatorModel) form() form.Fields {
 	fields = append(fields, &m.StormForgerTestCaseInput)
 	fields = append(fields, &m.StormForgerGettingStarted)
 	fields = append(fields, &m.LocustfileInput)
+	fields = append(fields, &m.CustomImage)
+	fields = append(fields, &m.CustomPushGateway)
 	fields = append(fields, &m.NamespaceInput)
 	for i := range m.LabelSelectorInputs {
 		fields = append(fields, &m.LabelSelectorInputs[i])

--- a/cli/internal/commands/run/run.go
+++ b/cli/internal/commands/run/run.go
@@ -310,6 +310,18 @@ func (m generatorModel) applyToApp(app *optimizeappsv1alpha1.Application) {
 		}
 	}
 
+	if m.CustomImage.Enabled() {
+		if image := m.CustomImage.Value(); image != "" {
+			usePushGateway := m.CustomPushGateway.Enabled() && m.CustomPushGateway.Value() == CustomPushGatewayYes
+			app.Scenarios = append(app.Scenarios, optimizeappsv1alpha1.Scenario{
+				Custom: &optimizeappsv1alpha1.CustomScenario{
+					Image:          image,
+					UsePushGateway: usePushGateway,
+				},
+			})
+		}
+	}
+
 	if m.IngressURLInput.Enabled() {
 		if u := m.IngressURLInput.Value(); u != "" {
 			app.Ingress = &optimizeappsv1alpha1.Ingress{


### PR DESCRIPTION
This PR adds support for custom scenarios to `stormforge run`. This implementation has a few gaps, for example the leaving the default p95-latency objective selected will cause experiment generation to fail, however it should be a good enough starting point to interactively scaffold out an experiment.yaml.