### PR TITLE
Replace Red Sky samples

### DIFF
--- a/api/apps/v1alpha1/application_defaults.go
+++ b/api/apps/v1alpha1/application_defaults.go
@@ -196,6 +196,10 @@ func defaultDurationGoal(goal *Goal, duration DurationType) {
 
 func defaultScenarioName(values ...string) string {
 	for _, in := range values {
+		if strings.ContainsRune(in, '\n') {
+			continue
+		}
+
 		name := filepath.Base(in)
 		if name == "." || name == "locustfile.py" {
 			continue

--- a/cli/internal/commands/generate/generate.go
+++ b/cli/internal/commands/generate/generate.go
@@ -45,6 +45,7 @@ func NewCommand(o *Options) *cobra.Command {
 	cmd.AddCommand(NewRBACCommand(&RBACOptions{Config: o.Config, ClusterRole: true, ClusterRoleBinding: true}))
 	cmd.AddCommand(NewApplicationCommand(&ApplicationOptions{Config: o.Config}))
 	cmd.AddCommand(NewExperimentCommand(&ExperimentOptions{Config: o.Config}))
+	cmd.AddCommand(NewSampleCommand(&SampleOptions{}))
 	cmd.AddCommand(NewTrialCommand(&TrialOptions{}))
 
 	return cmd

--- a/cli/internal/commands/generate/sample.go
+++ b/cli/internal/commands/generate/sample.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2021 GramLabs, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generate
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"github.com/thestormforge/konjure/pkg/konjure"
+	"github.com/thestormforge/optimize-controller/v2/cli/internal/commander"
+	manifests "github.com/thestormforge/optimize-controller/v2/config"
+	"sigs.k8s.io/kustomize/kyaml/kio"
+)
+
+type SampleOptions struct {
+	Filter konjure.Filter
+	Out    konjure.Writer
+}
+
+func NewSampleCommand(o *SampleOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "sample",
+		Short:  "Generate samples",
+		Long:   "Generate sample manifests for the custom resources",
+		Hidden: true,
+
+		PreRunE: func(cmd *cobra.Command, args []string) (err error) {
+			o.Out.Writer = cmd.OutOrStdout()
+			o.Filter.DefaultReader = cmd.InOrStdin()
+			o.Filter.WorkingDirectory, err = os.Getwd()
+			return
+		},
+		RunE: commander.WithoutArgsE(o.generate),
+	}
+
+	cmd.Flags().StringVar(&o.Filter.Kind, "kind", "", "resource `kind` of samples to emit")
+	cmd.Flags().StringVar(&o.Filter.Name, "name", "", "restrict to `name`d samples")
+	cmd.Flags().StringVarP(&o.Out.Format, "output", "o", "yaml", "output `format`; one of: yaml|json")
+
+	return cmd
+}
+
+func (o *SampleOptions) generate() error {
+	inputs, err := samples()
+	if err != nil {
+		return err
+	}
+
+	return kio.Pipeline{
+		Inputs:  inputs,
+		Filters: []kio.Filter{&o.Filter},
+		Outputs: []kio.Writer{&o.Out},
+	}.Execute()
+}
+
+// samples returns a KIO resource reader over the embedded sample resources.
+func samples() ([]kio.Reader, error) {
+	var samples []kio.Reader
+	return samples, fs.WalkDir(manifests.Content, "samples", func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || filepath.Ext(path) != ".yaml" {
+			return err
+		}
+
+		f, err := manifests.Content.Open(path)
+		if err != nil {
+			return err
+		}
+
+		samples = append(samples, &kio.ByteReader{Reader: f})
+		return nil
+	})
+}

--- a/config/config_files.go
+++ b/config/config_files.go
@@ -22,4 +22,5 @@ import "embed"
 //go:embed default
 //go:embed manager
 //go:embed rbac
+//go:embed samples
 var Content embed.FS

--- a/config/samples/optimize.stormforge.io_v1beta2_experiment.yaml
+++ b/config/samples/optimize.stormforge.io_v1beta2_experiment.yaml
@@ -1,0 +1,60 @@
+apiVersion: optimize.stormforge.io/v1beta2
+kind: Experiment
+metadata:
+  name: experiment-sample
+  labels:
+    stormforge.io/application: my-app
+    stormforge.io/scenario: black-friday
+spec:
+  parameters:
+  - name: cpu
+    baseline: 1000
+    min: 500
+    max: 2000
+  - name: memory
+    baseline: 2048
+    min: 1024
+    max: 4096
+  metrics:
+  - name: duration
+    minimize: true
+    query: "{{ duration .StartTime .CompletionTime }}"
+  - name: resource_requests
+    minimize: true
+    query: '{{ resourceRequests .Target "cpu=0.017,memory=0.000000000003" }}'
+    target:
+      apiVersion: v1
+      kind: PodList
+  patches:
+  - targetRef:
+      name: my-app
+      apiVersion: apps/v1
+      kind: Deployment
+    patch: |
+      spec:
+        template:
+          spec:
+            containers:
+            - name: postgres
+              resources:
+                limits:
+                  cpu: '{{ .Values.cpu }}m'
+                  memory: '{{ .Values.memory }}Mi'
+                requests:
+                  cpu: '{{ .Values.cpu }}m'
+                  memory: '{{ .Values.memory }}Mi'
+  trialTemplate:
+    spec:
+      initialDelaySeconds: 5
+      jobTemplate:
+        spec:
+          template:
+            spec:
+              containers:
+              - name: black-friday
+                image: my-load-test:latest
+                args:
+                - --testCase=black-friday
+                env:
+                - name: LOAD_TEST_URL
+                  value: http://my-app/

--- a/config/samples/optimize.stormforge.io_v1beta2_trial.yaml
+++ b/config/samples/optimize.stormforge.io_v1beta2_trial.yaml
@@ -1,0 +1,39 @@
+apiVersion: optimize.stormforge.io/v1beta2
+kind: Trial
+metadata:
+  name: experiment-sample-001
+  labels:
+    stormforge.io/experiment: experiment-sample
+    stormforge.io/application: my-app
+    stormforge.io/scenario: black-friday
+  annotations:
+    documentation: |-
+      A trial object will be created automatically for every set of
+      parameter assignments based on the `trialTemplate` configured
+      on the Experiment. The trial objects can be used to track the
+      progress of your experiments as it runs in the cluster.
+
+      As a user, you only need to configure your trial specification
+      on the Experiment.
+spec:
+  initialDelaySeconds: 5
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: black-friday
+            image: my-load-test:latest
+            args:
+            - --testCase=black-friday
+            env:
+            - name: LOAD_TEST_URL
+              value: http://my-app/
+  assignments:
+  - name: cpu
+    value: 1000
+  - name: memory
+    value: 2048
+status:
+  phase: Created
+  assignments: 'cpu=1000, memory=2048'

--- a/config/samples/redsky_v1alpha1_experiment.yaml
+++ b/config/samples/redsky_v1alpha1_experiment.yaml
@@ -1,8 +1,0 @@
-apiVersion: redskyops.dev/v1alpha1
-kind: Experiment
-metadata:
-  name: elk-experiment-sample
-spec:
-  parameters:
-  metrics:
-  configuration:

--- a/config/samples/redsky_v1alpha1_trial.yaml
+++ b/config/samples/redsky_v1alpha1_trial.yaml
@@ -1,9 +1,0 @@
-apiVersion: redskyops.dev/v1alpha1
-kind: Trial
-metadata:
-  labels:
-    controller-tools.k8s.io: "1.0"
-  name: trial-sample
-spec:
-  # Add fields here
-  foo: bar

--- a/internal/experiment/generation/generation.go
+++ b/internal/experiment/generation/generation.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	optimizeappsv1alpha1 "github.com/thestormforge/optimize-controller/v2/api/apps/v1alpha1"
 	optimizev1beta2 "github.com/thestormforge/optimize-controller/v2/api/v1beta2"
@@ -72,6 +73,12 @@ func trialJobImage(job string) string {
 
 // loadApplicationData loads data (e.g. a supporting test file).
 func loadApplicationData(app *optimizeappsv1alpha1.Application, src string) ([]byte, error) {
+	// As a special case, any multi-line "file name" is recognized as content
+	// instead, allowing small files to be inlined directly in the definition
+	if strings.ContainsRune(src, '\n') {
+		return []byte(src), nil
+	}
+
 	dst := filepath.Join(os.TempDir(), fmt.Sprintf("load-application-data-%x", md5.Sum([]byte(src))))
 	defer os.Remove(dst)
 


### PR DESCRIPTION
There were two "Red Sky" samples that were basically left over from the initial Kubebuilder scaffolding. This PR replaces them with `optimize.stormforge.io` versions that contain at least a few populated fields.

The main reason for doing this now is to fulfil an [OperatorHub requirement](https://k8s-operatorhub.github.io/community-operators/packaging-required-fields/): the `alm-examples` annotation contains a JSON list of sample resources for each of the CRDs owned by the operator. For an Operator SDK bootstrapped project, this annotation is populated when generating the operator bundle using the contents of the `/config/samples` directory (via inclusion in the Kustomization piped into `operator-sdk generate bundle`).

These samples are shown on the OperatorHub generated preview (for example, you can see the presentation [here](https://operatorhub.io/operator/elastic-cloud-eck) at the bottom of the page). Because they are converted to JSON to be stored in the annotation, I have omitted what might have been otherwise useful documentation comments in the samples.