### PR TITLE
Remove unnecessary references to ioutil

### DIFF
--- a/cli/internal/commander/commander.go
+++ b/cli/internal/commander/commander.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -60,7 +59,7 @@ type IOStreams struct {
 // empty (i.e. "-"), the input stream is returned.
 func (s *IOStreams) OpenFile(filename string) (io.ReadCloser, error) {
 	if filename == "-" {
-		return ioutil.NopCloser(s.In), nil
+		return io.NopCloser(s.In), nil
 	}
 	return os.Open(filename)
 }

--- a/cli/internal/commander/reader.go
+++ b/cli/internal/commander/reader.go
@@ -19,7 +19,6 @@ package commander
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -74,7 +73,7 @@ func (r *ResourceReader) ReadInto(reader io.ReadCloser, target runtime.Object) e
 
 	// Read in the raw bytes
 	defer func() { _ = reader.Close() }()
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return err
 	}

--- a/cli/internal/commands/check/controller.go
+++ b/cli/internal/commands/check/controller.go
@@ -19,7 +19,7 @@ package check
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -128,7 +128,7 @@ func (o *ControllerOptions) CheckController(ctx context.Context) error {
 		return err
 	}
 
-	kubewait.Stdout = ioutil.Discard
+	kubewait.Stdout = io.Discard
 	if err := kubewait.Run(); err != nil {
 		return fmt.Errorf("could not wait for controller pods: %w", err)
 	}

--- a/cli/internal/commands/export/export.go
+++ b/cli/internal/commands/export/export.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"path/filepath"
 	"strings"
 
@@ -137,7 +137,7 @@ func (o *Options) readInput() error {
 		}
 		defer r.Close()
 
-		data, err := ioutil.ReadAll(r)
+		data, err := io.ReadAll(r)
 		if err != nil {
 			return err
 		}
@@ -202,7 +202,7 @@ func (o *Options) extractApplication(trial *trialDetails) error {
 
 	o.application = &optimizeappsv1alpha1.Application{}
 
-	return commander.NewResourceReader().ReadInto(ioutil.NopCloser(&appBuf), o.application)
+	return commander.NewResourceReader().ReadInto(io.NopCloser(&appBuf), o.application)
 }
 
 func (o *Options) extractExperiment(trial *trialDetails) error {
@@ -225,7 +225,7 @@ func (o *Options) extractExperiment(trial *trialDetails) error {
 
 	o.experiment = &optimizev1beta2.Experiment{}
 
-	return commander.NewResourceReader().ReadInto(ioutil.NopCloser(&experimentBuf), o.experiment)
+	return commander.NewResourceReader().ReadInto(io.NopCloser(&experimentBuf), o.experiment)
 }
 
 // filter returns a filter function to exctract a specified `kind` from the input.

--- a/cli/internal/commands/revoke/revoke.go
+++ b/cli/internal/commands/revoke/revoke.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/spf13/cobra"
@@ -105,7 +105,7 @@ func revokeToken(ctx context.Context, endpoint, clientID, refreshToken string) e
 		return err
 	}
 
-	_, err = ioutil.ReadAll(resp.Body)
+	_, err = io.ReadAll(resp.Body)
 	_ = resp.Body.Close()
 	if err != nil {
 		return fmt.Errorf("cannot read revocation response: %v", err)

--- a/cli/internal/commands/run/command.go
+++ b/cli/internal/commands/run/command.go
@@ -22,7 +22,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -328,10 +328,10 @@ func (o *Options) refreshTrialsTick() tea.Cmd {
 // All the tea.Cmd functions are above, helpers are below
 // =============================================================================
 
-// discard is an IOStreams equivalent of ioutil.Discard for combined output.
+// discard is an IOStreams equivalent of io.Discard for combined output.
 var discard = commander.IOStreams{
-	Out:    ioutil.Discard,
-	ErrOut: ioutil.Discard,
+	Out:    io.Discard,
+	ErrOut: io.Discard,
 }
 
 // hideKubernetesNamespace is used to filter the list of namespaces to display

--- a/internal/experiment/generation/generation.go
+++ b/internal/experiment/generation/generation.go
@@ -19,7 +19,6 @@ package generation
 import (
 	"crypto/md5"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -92,5 +91,5 @@ func loadApplicationData(app *optimizeappsv1alpha1.Application, src string) ([]b
 		return nil, fmt.Errorf("unable to load file: %w", err)
 	}
 
-	return ioutil.ReadFile(dst)
+	return os.ReadFile(dst)
 }


### PR DESCRIPTION
Even more (less?) `ioutil`.