### PR TITLE
fix: Correct handling of unauthorized errors

### DIFF
--- a/controllers/server_controller.go
+++ b/controllers/server_controller.go
@@ -18,7 +18,6 @@ package controllers
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -168,11 +167,8 @@ func (r *ServerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 		expAPI, err := server.NewExperimentAPI(context.Background(), comment)
 		if err != nil {
-			if authErr := errors.Unwrap(err); api.IsUnauthorized(authErr) {
-				r.Log.Info(err.Error())
-				return nil
-			}
-			return err
+			r.Log.Info("Experiments API is unavailable, skipping setup", "message", err.Error())
+			return nil
 		}
 
 		r.ExperimentsAPI = expAPI

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -18,7 +18,6 @@ package server
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"strings"
 
@@ -46,7 +45,7 @@ func NewExperimentAPI(ctx context.Context, uaComment string) (experimentsv1alpha
 
 	// An unauthorized error means we will never be able to connect without changing the credentials and restarting
 	if _, err := expAPI.Options(ctx); api.IsUnauthorized(err) {
-		return nil, fmt.Errorf("experiments API is unavailable, skipping setup: %w", err)
+		return nil, err
 	}
 
 	return expAPI, nil

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -46,7 +46,7 @@ func NewExperimentAPI(ctx context.Context, uaComment string) (experimentsv1alpha
 
 	// An unauthorized error means we will never be able to connect without changing the credentials and restarting
 	if _, err := expAPI.Options(ctx); api.IsUnauthorized(err) {
-		return nil, fmt.Errorf("experiments API is unavailable, skipping setup: %s", err.Error())
+		return nil, fmt.Errorf("experiments API is unavailable, skipping setup: %w", err)
 	}
 
 	return expAPI, nil


### PR DESCRIPTION
#379 introduced a regression where we wouldnt properly handle unauthorized errors
causing the controller to fail to start if we were unauthorized. :oops:


Pulling out of https://github.com/thestormforge/optimize-controller/pull/381/commits/ac28368e40025f6b2c402c54fad2c0f6f0c14b3d to address failures in #382 

Signed-off-by: Brad Beam <brad.beam@stormforge.io>