### PR TITLE
Upgrade optimize-trials to v0.0.2 and optimize-go to v0.0.16

### DIFF
--- a/api/apps/v1alpha1/application_types.go
+++ b/api/apps/v1alpha1/application_types.go
@@ -50,7 +50,7 @@ type Application struct {
 	Objectives []Objective `json:"objectives,omitempty"`
 
 	// StormForgePerformance allows you to configure StormForge Performance to apply load on your application.
-	StormForgePerformance *StormForgePerformance `json:"stormforge-perf-config,omitempty"`
+	StormForgePerformance *StormForgePerformance `json:"stormforgePerfConfig,omitempty"`
 }
 
 // Parameter describes the strategy for tuning the application.
@@ -103,7 +103,7 @@ type Scenario struct {
 	// The name of scenario.
 	Name string `json:"name,omitempty"`
 	// StormForge Performance configuration for the scenario.
-	StormForge *StormForgeScenario `json:"stormforge-perf,omitempty"`
+	StormForge *StormForgeScenario `json:"stormforgePerf,omitempty"`
 	// Locust configuration for the scenario.
 	Locust *LocustScenario `json:"locust,omitempty"`
 	// Custom configuration for the scenario.

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
 	github.com/thestormforge/konjure v0.3.0
-	github.com/thestormforge/optimize-go v0.0.14
+	github.com/thestormforge/optimize-go v0.0.16
 	github.com/yujunz/go-getter v1.5.1-lite.0.20201201013212-6d9c071adddf
 	github.com/zorkian/go-datadog-api v2.24.0+incompatible
 	go.uber.org/zap v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -572,8 +572,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/thestormforge/konjure v0.3.0 h1:VOUX6te9lbdk8dYJLQpJsvZfuhvwp8+DJMhB1VR46RM=
 github.com/thestormforge/konjure v0.3.0/go.mod h1:8gIqMRKShWB7ejEA+JCN8DUeeDe9CTIc3eXyniFdNj8=
-github.com/thestormforge/optimize-go v0.0.14 h1:9YQ7t58IP4R+pekwRvJvMKYRLipzgAZE29XoTRU/5kw=
-github.com/thestormforge/optimize-go v0.0.14/go.mod h1:LhoJFNeHXLWnMp5KVkHJdzUfx76Gwj81/m40IVM9MjA=
+github.com/thestormforge/optimize-go v0.0.16 h1:A2tpI+yUuBLLSqK1Z3udzxXOOWDJFGwMWNxRDqTpNvc=
+github.com/thestormforge/optimize-go v0.0.16/go.mod h1:LhoJFNeHXLWnMp5KVkHJdzUfx76Gwj81/m40IVM9MjA=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/internal/application/documentation.go
+++ b/internal/application/documentation.go
@@ -58,10 +58,10 @@ for example: "p95-latency".
 Reference: https://docs.stormforge.io/reference/application/v1alpha1/#objective
 `,
 
-		"stormforge-perf-config": `
+		"stormforgePerfConfig": `
 StormForge Performance specific configuration information to set up StormForge
 Performance tests. This is only needed when using StormForge scenarios.
-Reference: https://docs.stormforge.io/reference/application/v1alpha1/#stormforge-perf-config
+Reference: https://docs.stormforge.io/reference/application/v1alpha1/#stormforgePerfConfig
 `,
 
 		"ingress": `
@@ -93,7 +93,7 @@ Reference: https://docs.stormforge.io/reference/application/v1alpha1/#ingress
 		"ingress": "url: https://localhost # Specifies the entrypoint for your application.",
 
 		"scenarios": `- name: cybermonday # StormForge Performance Test example
-  stormforge-perf:
+  stormforgePerf:
     testCaseFile: foobar.js # You can alternatively specify just the test case name if you provide the access token
 - name: just-another-tuesday # Locust example
   locust:
@@ -113,7 +113,7 @@ Reference: https://docs.stormforge.io/reference/application/v1alpha1/#ingress
   - latency: p99
     optimize: false # Reports on the metric while not explicitly optimizing for them`,
 
-		"stormforge-perf-config": `org: myorg # The StormForge Performance organization to use for performance testing
+		"stormforgePerfConfig": `org: myorg # The StormForge Performance organization to use for performance testing
   accessToken:
     file: mytoken.jwt # Read in the StormForge Performance JWT from a file
     literal: mysupersecretjwt # The raw StormForge Performance JWT. Be mindful of the security implications of including the JWT here.
@@ -126,13 +126,13 @@ Reference: https://docs.stormforge.io/reference/application/v1alpha1/#ingress
 	// This is used to ensure even empty (and otherwise omitted) fields can be
 	// included for documentation purposes.
 	required = map[string]string{
-		"resources":              "",
-		"configuration":          "resources",
-		"ingress":                "configuration",
-		"scenarios":              "ingress",
-		"objectives":             "scenarios",
-		"stormforge-perf-config": "objectives",
-		"":                       "stormforge-perf-config",
+		"resources":            "",
+		"configuration":        "resources",
+		"ingress":              "configuration",
+		"scenarios":            "ingress",
+		"objectives":           "scenarios",
+		"stormforgePerfConfig": "objectives",
+		"":                     "stormforgePerfConfig",
 	}
 )
 

--- a/internal/experiment/generation/generation.go
+++ b/internal/experiment/generation/generation.go
@@ -63,7 +63,7 @@ func trialJobImage(job string) string {
 	if imageTag == "" {
 		imageTagBase := os.Getenv("OPTIMIZE_TRIALS_IMAGE_TAG_BASE")
 		if imageTagBase == "" {
-			imageTagBase = "v0.0.1"
+			imageTagBase = "v0.0.2"
 		}
 		imageTag = imageTagBase + "-" + job
 	}

--- a/internal/experiment/generation/stormforgeperf.go
+++ b/internal/experiment/generation/stormforgeperf.go
@@ -61,7 +61,7 @@ func (s *StormForgePerformanceSource) Update(exp *optimizev1beta2.Experiment) er
 	pod.Containers = []corev1.Container{
 		{
 			Name:  s.Scenario.Name,
-			Image: trialJobImage("stormforger"),
+			Image: trialJobImage("stormforge-perf"),
 			Env: []corev1.EnvVar{
 				{
 					Name: "TITLE",

--- a/internal/sfio/migrate.go
+++ b/internal/sfio/migrate.go
@@ -126,12 +126,12 @@ func (f *ExperimentMigrationFilter) MigrateRSOApplicationV1alpha1(node *yaml.RNo
 
 		// Rename fields
 		yaml.Tee(RenameField("parameters", "configuration")),
-		yaml.Tee(RenameField("stormForger", "stormforge-perf-config")),
+		yaml.Tee(RenameField("stormForger", "stormforgePerfConfig")),
 		yaml.Tee(
 			yaml.Lookup("scenarios"),
 			yaml.FilterFunc(func(node *yaml.RNode) (*yaml.RNode, error) {
 				return node, node.VisitElements(func(node *yaml.RNode) error {
-					return node.PipeE(RenameField("stormforger", "stormforge-perf"))
+					return node.PipeE(RenameField("stormforger", "stormforgePerf"))
 				})
 			}),
 		),


### PR DESCRIPTION
I borked the names in #387 and used `stormforge-perf` where I should have used `stormforgePerf`. This PR corrects that and updates the one place where `stormforge-perf` _was_ actually correct: the Docker tag of `optimize-trials` v0.0.2.