### PR TITLE
feat: Add support for generating unique-ish resources

### DIFF
--- a/internal/experiment/generator.go
+++ b/internal/experiment/generator.go
@@ -99,6 +99,8 @@ func (g *Generator) Execute(output kio.Writer) error {
 			kio.FilterAll(generation.SetExperimentLabel(optimizeappsv1alpha1.LabelScenario, scenarioName)),
 			kio.FilterAll(generation.SetExperimentLabel(optimizeappsv1alpha1.LabelObjective, objectiveName)),
 
+			kio.FilterAll(generation.SetHashedName(experimentName)),
+
 			// Apply Kubernetes formatting conventions and clean up the objects
 			&filters.FormatFilter{UseSchema: true},
 			kio.FilterAll(yaml.ClearAnnotation(filters.FmtAnnotation)),


### PR DESCRIPTION
This adds in a fun yaml filter (Ive got the bug) that manipulates all the
resource name references to use a suffixed hash of the experiment name. This
should enable us to have multiple generated experiments exist in a cluster.

```
stormforge generate experiment -f $examples/webserver/sf-perftest-metrics/fixed_sf_app.yaml | grep 82abf8
  name: voting-sf-example-a9c48911-82abf8
                  name: standard-test-case-file-82abf8
      setupServiceAccountName: optimize-setup-82abf8
  name: standard-test-case-file-82abf8
  name: stormforge-perf-service-accounts-82abf8
  name: optimize-setup-82abf8
  name: optimize-prometheus-82abf8
  name: optimize-setup-prometheus-82abf8
  name: optimize-prometheus-82abf8
- name: optimize-setup-82abf8
```

Signed-off-by: Brad Beam <brad.beam@stormforge.io>