### PR TITLE
Use the Performance token exchange from `run`

### DIFF
--- a/cli/internal/commands/run/command.go
+++ b/cli/internal/commands/run/command.go
@@ -234,7 +234,12 @@ func (o *Options) listStormForgeTestCaseNames() tea.Msg {
 		}
 		for j := range testCases.Data {
 			testCase := testCases.Data[j].Attributes.Name
-			msg = append(msg, fmt.Sprintf("%s/%s", org, testCase))
+			if len(orgs.Data) == 1 {
+				// If there is only one organization we can just use the test case name
+				msg = append(msg, testCase)
+			} else {
+				msg = append(msg, fmt.Sprintf("%s/%s", org, testCase))
+			}
 		}
 	}
 


### PR DESCRIPTION
This change sets the local `STORMFORGER_JWT` environment variable so that forked `forge` calls use the token from the exchange. Before doing the exchange, an attempt is made to just use `forge`: this allows you to set `STORMFORGER_JWT` before calling `run` (or to have `.stormforger.toml`) to bypass the token exchange.

Additionally, if the current Performance authorization is only valid for a single organization, we do not include it in the test case names, as of v0.0.3 the `optimize-trials` job can handle that case and it avoids showing unnecessary information.