### PR TITLE
Add a name suffix to experiment specific resources

### DIFF
--- a/internal/sfio/fns.go
+++ b/internal/sfio/fns.go
@@ -145,6 +145,11 @@ func (f HasFilter) Filter(rn *yaml.RNode) (*yaml.RNode, error) {
 	return rn, nil
 }
 
+// PathMatcher returns a `yaml.PathMatcher` from the supplied path.
+func PathMatcher(p ...string) yaml.PathMatcher {
+	return yaml.PathMatcher{Path: p}
+}
+
 // TeeMatched acts as a "tee" filter for nodes matched by the supplied path matcher:
 // each matched node is processed by the supplied filters and the result of the
 // entire operation is the initial node (or an error).


### PR DESCRIPTION
This is an alternate implementation to #397; it leverages the existing `SetExperimentName` function and uses `yaml.PathMatcher` to simplify some of the lookups.