### PR TITLE
feat: Refactor Poller.Start to use updated subscriber logic 

### DIFF
--- a/controllers/application_poller_api_test.go
+++ b/controllers/application_poller_api_test.go
@@ -187,7 +187,7 @@ var _ applications.Subscriber = fakeScanSubscriber{}
 
 type fakeScanSubscriber struct{}
 
-func (f fakeScanSubscriber) Subscribe(ctx context.Context, ch chan<- applications.ActivityItem) {
+func (f fakeScanSubscriber) Subscribe(ctx context.Context, ch chan<- applications.ActivityItem) error {
 	sampleActivity := applications.ActivityItem{
 		ID:    "01FB5DMRW14JNNC7R9EWJEB5FM",
 		URL:   "http://localhost:8113/v2/applications/01FB5227WVRE4RFFDJ4TCZY8Z9/scenarios/01FB5229WXA976GSYX1BSJNM8G",
@@ -197,13 +197,14 @@ func (f fakeScanSubscriber) Subscribe(ctx context.Context, ch chan<- application
 
 	ch <- sampleActivity
 	close(ch)
+	return nil
 }
 
 var _ applications.Subscriber = fakeRunSubscriber{}
 
 type fakeRunSubscriber struct{}
 
-func (f fakeRunSubscriber) Subscribe(ctx context.Context, ch chan<- applications.ActivityItem) {
+func (f fakeRunSubscriber) Subscribe(ctx context.Context, ch chan<- applications.ActivityItem) error {
 	sampleActivity := applications.ActivityItem{
 		ID:    "01FB5DMRW14JNNC7R9EWJEB5FM",
 		URL:   "http://localhost:8113/v2/applications/01FB5227WVRE4RFFDJ4TCZY8Z9/scenarios/01FB5229WXA976GSYX1BSJNM8G",
@@ -213,4 +214,5 @@ func (f fakeRunSubscriber) Subscribe(ctx context.Context, ch chan<- applications
 
 	ch <- sampleActivity
 	close(ch)
+	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
 	github.com/thestormforge/konjure v0.3.2
-	github.com/thestormforge/optimize-go v0.0.17
+	github.com/thestormforge/optimize-go v0.0.18
 	github.com/yujunz/go-getter v1.5.1-lite.0.20201201013212-6d9c071adddf
 	github.com/zorkian/go-datadog-api v2.24.0+incompatible
 	go.uber.org/zap v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -562,8 +562,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/thestormforge/konjure v0.3.2 h1:9h1HsAB9k8ENMHOOlUl2RYPE2+pZ+OqLn/Z0q0/COjM=
 github.com/thestormforge/konjure v0.3.2/go.mod h1:5cZj+F9imDQJrk4TUmXyA+dtSm6L0YdjSWFYvIX/668=
-github.com/thestormforge/optimize-go v0.0.17 h1:Aib+X9I+aIj4NOPr8yUKU+rIr+CMvPujWfkk+rTsO3w=
-github.com/thestormforge/optimize-go v0.0.17/go.mod h1:LhoJFNeHXLWnMp5KVkHJdzUfx76Gwj81/m40IVM9MjA=
+github.com/thestormforge/optimize-go v0.0.18 h1:o5NRqLxRWer9cwFKf3OrXsJvxU2AeKAn+xcYFxQh+QQ=
+github.com/thestormforge/optimize-go v0.0.18/go.mod h1:LhoJFNeHXLWnMp5KVkHJdzUfx76Gwj81/m40IVM9MjA=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=


### PR DESCRIPTION
This refactor makes use of the updated subscriber.Subscribe logic to be blocking.
This should address the issues we saw while using for/select over a closed channel.

Signed-off-by: Brad Beam <brad.beam@stormforge.io>