### PR TITLE
Remove HTTP method from ping output

### DIFF
--- a/cli/internal/commands/ping/ping.go
+++ b/cli/internal/commands/ping/ping.go
@@ -66,7 +66,7 @@ func (o *Options) ping(ctx context.Context) error {
 
 	updateUserAgent(ctx)
 
-	_, _ = fmt.Fprintf(o.Out, "PING %s (%s): HTTP/1.1 OPTIONS\n", host, strings.Join(addrs, ", "))
+	_, _ = fmt.Fprintf(o.Out, "PING %s (%s): HTTP/1.1\n", host, strings.Join(addrs, ", "))
 
 	start := time.Now()
 	_, err = o.ExperimentsAPI.CheckEndpoint(ctx)


### PR DESCRIPTION
This is misleading and (now) outright incorrect.