### PR TITLE
Add more OCI labels to the controller image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@
 TITLE := Optimize Controller
 VENDOR := StormForge
 EMAIL := techsupport@stormforge.io
+VENDOR_URL := https://www.stormforge.io/
+DOCUMENTATION_URL := https://docs.stormforge.io/
 DESCRIPTION := Kubernetes Performance Testing and resource optimization for \
                flawless app performance and cloud efficiency without manual tuning.
 
@@ -100,6 +102,8 @@ docker-build-controller:
 	docker build . -t ${IMG} \
 		--label "org.opencontainers.image.title=${TITLE}" \
 		--label "org.opencontainers.image.description=${DESCRIPTION}" \
+		--label "org.opencontainers.image.documentation=${DOCUMENTATION_URL}" \
+		--label "org.opencontainers.image.url=${VENDOR_URL}" \
 		--label "org.opencontainers.image.authors=${EMAIL}" \
 		--label "org.opencontainers.image.vendor=${VENDOR}" \
 		--label "org.opencontainers.image.version=${VERSION}" \


### PR DESCRIPTION
This PR adds two additional labels to the controller image. The primary motivation behind improving the OCI metadata for the image is so that it can be consumed downstream to construct other descriptors (for instance, an operator `ClusterServiceVersion`): by ensuring the metadata is set properly at the source we can propagate it instead of hard coding it in multiple places.