### PR TITLE
Use "index" on parameter names in generated patches

### DIFF
--- a/internal/experiment/generation/containerresources.go
+++ b/internal/experiment/generation/containerresources.go
@@ -181,10 +181,11 @@ func (p *containerResourcesParameter) Patch(name ParameterNamer) (yaml.Filter, e
 	requestsPatch := yaml.FieldSetter{Name: "requests", Value: yaml.NewMapRNode(nil)}
 
 	for _, rn := range p.resources {
-		// Create patch filter for each ResourceName (e.g. "cpu: {{ .Values ...")
+		// Create patch filter for each ResourceName (e.g. "cpu: {{ index .Values ...")
 		parameterName := name(p.meta, p.fieldPath, string(rn))
 		patch := fmt.Sprintf("{{ index .Values %q }}%s", parameterName, ind[rn].Suffix())
 		patchFilter := yaml.SetField(string(rn), yaml.NewStringRNode(patch))
+		patchFilter.Value.YNode().Style = yaml.SingleQuotedStyle
 
 		// Apply the same patch filter to both limits and requests
 		if err := limitsPatch.Value.PipeE(patchFilter); err != nil {

--- a/internal/experiment/generation/containerresources.go
+++ b/internal/experiment/generation/containerresources.go
@@ -183,7 +183,7 @@ func (p *containerResourcesParameter) Patch(name ParameterNamer) (yaml.Filter, e
 	for _, rn := range p.resources {
 		// Create patch filter for each ResourceName (e.g. "cpu: {{ .Values ...")
 		parameterName := name(p.meta, p.fieldPath, string(rn))
-		patch := fmt.Sprintf("{{ .Values.%s }}%s", parameterName, ind[rn].Suffix())
+		patch := fmt.Sprintf("{{ index .Values %q }}%s", parameterName, ind[rn].Suffix())
 		patchFilter := yaml.SetField(string(rn), yaml.NewStringRNode(patch))
 
 		// Apply the same patch filter to both limits and requests

--- a/internal/experiment/generation/containerresources_test.go
+++ b/internal/experiment/generation/containerresources_test.go
@@ -65,9 +65,9 @@ func TestContainerResourcesParameter(t *testing.T) {
               spec:
                 resources:
                   limits:
-                    memory: "{{ .Values.memory }}Mi"
+                    memory: '{{ index .Values "memory" }}Mi'
                   requests:
-                    memory: "{{ .Values.memory }}Mi"`),
+                    memory: '{{ index .Values "memory" }}Mi'`),
 		},
 
 		{
@@ -97,9 +97,9 @@ func TestContainerResourcesParameter(t *testing.T) {
               spec:
                 resources:
                   limits:
-                    memory: "{{ .Values.memory }}M"
+                    memory: '{{ index .Values "memory" }}M'
                   requests:
-                    memory: "{{ .Values.memory }}M"`),
+                    memory: '{{ index .Values "memory" }}M'`),
 		},
 
 		{
@@ -129,9 +129,9 @@ func TestContainerResourcesParameter(t *testing.T) {
               spec:
                 resources:
                   limits:
-                    cpu: "{{ .Values.cpu }}m"
+                    cpu: '{{ index .Values "cpu" }}m'
                   requests:
-                    cpu: "{{ .Values.cpu }}m"`),
+                    cpu: '{{ index .Values "cpu" }}m'`),
 		},
 
 		{
@@ -161,9 +161,9 @@ func TestContainerResourcesParameter(t *testing.T) {
               spec:
                 resources:
                   limits:
-                    memory: "{{ .Values.memory }}Ki"
+                    memory: '{{ index .Values "memory" }}Ki'
                   requests:
-                    memory: "{{ .Values.memory }}Ki"`),
+                    memory: '{{ index .Values "memory" }}Ki'`),
 		},
 
 		{
@@ -193,9 +193,9 @@ func TestContainerResourcesParameter(t *testing.T) {
               spec:
                 resources:
                   limits:
-                    cpu: "{{ .Values.cpu }}m"
+                    cpu: '{{ index .Values "cpu" }}m'
                   requests:
-                    cpu: "{{ .Values.cpu }}m"`),
+                    cpu: '{{ index .Values "cpu" }}m'`),
 		},
 
 		{
@@ -225,9 +225,9 @@ func TestContainerResourcesParameter(t *testing.T) {
               spec:
                 resources:
                   limits:
-                    memory: "{{ .Values.memory }}M"
+                    memory: '{{ index .Values "memory" }}M'
                   requests:
-                    memory: "{{ .Values.memory }}M"`),
+                    memory: '{{ index .Values "memory" }}M'`),
 		},
 	}
 	for _, c := range cases {

--- a/internal/experiment/generation/environmentvariables.go
+++ b/internal/experiment/generation/environmentvariables.go
@@ -100,7 +100,7 @@ var _ ParameterSource = &environmentVariablesParameter{}
 func (p *environmentVariablesParameter) Patch(name ParameterNamer) (yaml.Filter, error) {
 	// Since the field path will contain a "[name=ENV_VAR]" we can just leave the name blank
 	parameterName := name(p.meta, p.fieldPath, "")
-	patch := fmt.Sprintf("%s{{ .Values.%s }}%s", p.prefix, parameterName, p.suffix)
+	patch := fmt.Sprintf("%s{{ index .Values %q }}%s", p.prefix, parameterName, p.suffix)
 	value := yaml.NewScalarRNode(patch)
 
 	return yaml.Tee(

--- a/internal/experiment/generation/environmentvariables.go
+++ b/internal/experiment/generation/environmentvariables.go
@@ -102,6 +102,7 @@ func (p *environmentVariablesParameter) Patch(name ParameterNamer) (yaml.Filter,
 	parameterName := name(p.meta, p.fieldPath, "")
 	patch := fmt.Sprintf("%s{{ index .Values %q }}%s", p.prefix, parameterName, p.suffix)
 	value := yaml.NewScalarRNode(patch)
+	value.YNode().Style = yaml.SingleQuotedStyle
 
 	return yaml.Tee(
 		&yaml.PathGetter{Path: p.fieldPath, Create: yaml.ScalarNode},

--- a/internal/experiment/generation/replicas.go
+++ b/internal/experiment/generation/replicas.go
@@ -17,6 +17,8 @@ limitations under the License.
 package generation
 
 import (
+	"fmt"
+
 	optimizev1beta2 "github.com/thestormforge/optimize-controller/v2/api/v1beta2"
 	"github.com/thestormforge/optimize-controller/v2/internal/scan"
 	"github.com/thestormforge/optimize-controller/v2/internal/sfio"
@@ -82,7 +84,7 @@ var _ PatchSource = &replicaParameter{}
 var _ ParameterSource = &replicaParameter{}
 
 func (p *replicaParameter) Patch(name ParameterNamer) (yaml.Filter, error) {
-	value := yaml.NewScalarRNode("{{ .Values." + name(p.meta, p.fieldPath, "replicas") + " }}")
+	value := yaml.NewScalarRNode(fmt.Sprintf("{{ index .Values %q }}", name(p.meta, p.fieldPath, "replicas")))
 	value.YNode().Tag = yaml.NodeTagInt
 	return yaml.Tee(
 		&yaml.PathGetter{Path: p.fieldPath, Create: yaml.ScalarNode},


### PR DESCRIPTION
This does not fix any existing problems (parameter name generation currently only produces valid Go field names), however it could become an issue in the future.