### PR TITLE
Lint required experiment labels

### DIFF
--- a/cli/internal/commander/reader.go
+++ b/cli/internal/commander/reader.go
@@ -79,8 +79,11 @@ func (r *ResourceReader) ReadInto(reader io.ReadCloser, target runtime.Object) e
 	}
 
 	// Decode the raw data
-	obj, _, err := decoder.Decode(data, &gvk, target)
+	obj, errGvk, err := decoder.Decode(data, &gvk, target)
 	if err != nil {
+		if runtime.IsNotRegisteredError(err) && errGvk.Kind == gvk.Kind {
+			return fmt.Errorf("unsupported %s version, try running '%s fix'", gvk.Kind, os.Args[0])
+		}
 		return err
 	}
 

--- a/cli/internal/commands/check/experiment.go
+++ b/cli/internal/commands/check/experiment.go
@@ -26,6 +26,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/go-logr/zapr"
 	"github.com/spf13/cobra"
+	optimizeappsv1alpha1 "github.com/thestormforge/optimize-controller/v2/api/apps/v1alpha1"
 	optimizev1beta2 "github.com/thestormforge/optimize-controller/v2/api/v1beta2"
 	"github.com/thestormforge/optimize-controller/v2/cli/internal/commander"
 	"github.com/thestormforge/optimize-controller/v2/internal/experiment"
@@ -57,9 +58,10 @@ type ExperimentOptions struct {
 // NewExperimentCommand creates a new command for checking an experiment manifest
 func NewExperimentCommand(o *ExperimentOptions) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "experiment",
-		Short: "Check an experiment",
-		Long:  "Check an experiment manifest",
+		Use:     "experiment",
+		Short:   "Check an experiment",
+		Long:    "Check an experiment manifest",
+		Aliases: []string{"exp"},
 
 		PreRun: commander.StreamsPreRun(&o.IOStreams),
 		RunE:   commander.WithContextE(o.checkExperiment),
@@ -136,6 +138,13 @@ func (l *linter) Visit(ctx context.Context, obj interface{}) experiment.Visitor 
 	lint := l.logger.WithValues("path", strings.Join(experiment.WalkPath(ctx), "/"))
 
 	switch o := obj.(type) {
+
+	case experiment.MetadataLabels:
+		for _, k := range []string{optimizeappsv1alpha1.LabelApplication, optimizeappsv1alpha1.LabelScenario} {
+			if o[k] == "" {
+				lint.V(vError).Info("Experiment label is required", "key", k)
+			}
+		}
 
 	case *optimizev1beta2.Optimization:
 		switch o.Name {

--- a/cli/internal/commands/check/experiment.go
+++ b/cli/internal/commands/check/experiment.go
@@ -185,6 +185,7 @@ func (l *linter) Visit(ctx context.Context, obj interface{}) experiment.Visitor 
 			optimizev1beta2.MetricPrometheus,
 			optimizev1beta2.MetricJSONPath,
 			optimizev1beta2.MetricDatadog,
+			optimizev1beta2.MetricNewRelic,
 			"": // Type is valid
 		default:
 			lint.V(vError).Info("Metric type is invalid", "type", o.Type)


### PR DESCRIPTION
This PR adds required label validation to the linter.

Additionally, old experiments (incorrect GV) will fail to load into the `runtime.Scheme` because we no longer have converters; the rather unhelpful error message is replaced with one that suggests running `fix`.