### PR TITLE
fix: Strip newlines from auth tokens

### DIFF
--- a/internal/experiment/generation/stormforgeperf.go
+++ b/internal/experiment/generation/stormforgeperf.go
@@ -219,7 +219,11 @@ func (s *StormForgePerformanceSource) accessToken() (string, error) {
 	org, _ := splitTestCase(s.Scenario.StormForge.TestCase)
 
 	// Hide the bodies.
-	return (&StormForgePerformanceAuthorization{ServiceAccountLabel: s.serviceAccountLabel}).AccessToken(ctx, org)
+	token, err := (&StormForgePerformanceAuthorization{ServiceAccountLabel: s.serviceAccountLabel}).AccessToken(ctx, org)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSuffix(token, "\n"), nil
 }
 
 // stormForgePerfLatency normalizes the latency enumeration to match the StormForge Performance values.


### PR DESCRIPTION
When manually adding Performance access tokens to the secret, there is
a good chance someone (cough cough me cough cough ) will forget to
run echo -n to base64 encode things and we wind up with an access
token that contains a newline.

Signed-off-by: Brad Beam <brad.beam@stormforge.io>