### PR TITLE
Update parameter namer

### DIFF
--- a/cli/internal/commands/export/export_api_test.go
+++ b/cli/internal/commands/export/export_api_test.go
@@ -29,11 +29,11 @@ var wannabeTrial = experimentsv1alpha1.TrialItem{
 	TrialAssignments: experimentsv1alpha1.TrialAssignments{
 		Assignments: []experimentsv1alpha1.Assignment{
 			{
-				ParameterName: "cpu",
+				ParameterName: "deployment/postgres/postgres/cpu",
 				Value:         api.FromInt64(100),
 			},
 			{
-				ParameterName: "memory",
+				ParameterName: "deployment/postgres/postgres/memory",
 				Value:         api.FromInt64(200),
 			},
 		},
@@ -84,7 +84,7 @@ func (f *fakeExperimentsAPI) GetExperimentByName(ctx context.Context, name exper
 		Optimization: []experimentsv1alpha1.Optimization{},
 		Parameters: []experimentsv1alpha1.Parameter{
 			{
-				Name: "cpu",
+				Name: "deployment/postgres/postgres/cpu",
 				Type: experimentsv1alpha1.ParameterTypeInteger,
 				Bounds: &experimentsv1alpha1.Bounds{
 					Max: "4000",
@@ -92,7 +92,7 @@ func (f *fakeExperimentsAPI) GetExperimentByName(ctx context.Context, name exper
 				},
 			},
 			{
-				Name: "memory",
+				Name: "deployment/postgres/postgres/memory",
 				Type: experimentsv1alpha1.ParameterTypeInteger,
 				Bounds: &experimentsv1alpha1.Bounds{
 					Max: "4000",
@@ -132,11 +132,11 @@ func (f *fakeExperimentsAPI) GetAllTrials(ctx context.Context, name string, quer
 				TrialAssignments: experimentsv1alpha1.TrialAssignments{
 					Assignments: []experimentsv1alpha1.Assignment{
 						{
-							ParameterName: "cpu",
+							ParameterName: "deployment/postgres/postgres/cpu",
 							Value:         api.FromInt64(999),
 						},
 						{
-							ParameterName: "memory",
+							ParameterName: "deployment/postgres/postgres/memory",
 							Value:         api.FromInt64(999),
 						},
 					},
@@ -149,11 +149,11 @@ func (f *fakeExperimentsAPI) GetAllTrials(ctx context.Context, name string, quer
 				TrialAssignments: experimentsv1alpha1.TrialAssignments{
 					Assignments: []experimentsv1alpha1.Assignment{
 						{
-							ParameterName: "cpu",
+							ParameterName: "deployment/postgres/postgres/cpu",
 							Value:         api.FromInt64(999),
 						},
 						{
-							ParameterName: "memory",
+							ParameterName: "deployment/postgres/postgres/memory",
 							Value:         api.FromInt64(999),
 						},
 					},

--- a/cli/internal/commands/export/export_api_test.go
+++ b/cli/internal/commands/export/export_api_test.go
@@ -29,11 +29,11 @@ var wannabeTrial = experimentsv1alpha1.TrialItem{
 	TrialAssignments: experimentsv1alpha1.TrialAssignments{
 		Assignments: []experimentsv1alpha1.Assignment{
 			{
-				ParameterName: "deployment/postgres/postgres/cpu",
+				ParameterName: "deployment/postgres/postgres/resources/cpu",
 				Value:         api.FromInt64(100),
 			},
 			{
-				ParameterName: "deployment/postgres/postgres/memory",
+				ParameterName: "deployment/postgres/postgres/resources/memory",
 				Value:         api.FromInt64(200),
 			},
 		},
@@ -84,7 +84,7 @@ func (f *fakeExperimentsAPI) GetExperimentByName(ctx context.Context, name exper
 		Optimization: []experimentsv1alpha1.Optimization{},
 		Parameters: []experimentsv1alpha1.Parameter{
 			{
-				Name: "deployment/postgres/postgres/cpu",
+				Name: "deployment/postgres/postgres/resources/cpu",
 				Type: experimentsv1alpha1.ParameterTypeInteger,
 				Bounds: &experimentsv1alpha1.Bounds{
 					Max: "4000",
@@ -92,7 +92,7 @@ func (f *fakeExperimentsAPI) GetExperimentByName(ctx context.Context, name exper
 				},
 			},
 			{
-				Name: "deployment/postgres/postgres/memory",
+				Name: "deployment/postgres/postgres/resources/memory",
 				Type: experimentsv1alpha1.ParameterTypeInteger,
 				Bounds: &experimentsv1alpha1.Bounds{
 					Max: "4000",
@@ -132,11 +132,11 @@ func (f *fakeExperimentsAPI) GetAllTrials(ctx context.Context, name string, quer
 				TrialAssignments: experimentsv1alpha1.TrialAssignments{
 					Assignments: []experimentsv1alpha1.Assignment{
 						{
-							ParameterName: "deployment/postgres/postgres/cpu",
+							ParameterName: "deployment/postgres/postgres/resources/cpu",
 							Value:         api.FromInt64(999),
 						},
 						{
-							ParameterName: "deployment/postgres/postgres/memory",
+							ParameterName: "deployment/postgres/postgres/resources/memory",
 							Value:         api.FromInt64(999),
 						},
 					},
@@ -149,11 +149,11 @@ func (f *fakeExperimentsAPI) GetAllTrials(ctx context.Context, name string, quer
 				TrialAssignments: experimentsv1alpha1.TrialAssignments{
 					Assignments: []experimentsv1alpha1.Assignment{
 						{
-							ParameterName: "deployment/postgres/postgres/cpu",
+							ParameterName: "deployment/postgres/postgres/resources/cpu",
 							Value:         api.FromInt64(999),
 						},
 						{
-							ParameterName: "deployment/postgres/postgres/memory",
+							ParameterName: "deployment/postgres/postgres/resources/memory",
 							Value:         api.FromInt64(999),
 						},
 					},

--- a/cli/internal/commands/export/export_test.go
+++ b/cli/internal/commands/export/export_test.go
@@ -26,10 +26,14 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/thestormforge/konjure/pkg/filters"
 	"github.com/thestormforge/optimize-controller/v2/cli/internal/commander"
 	"github.com/thestormforge/optimize-controller/v2/cli/internal/commands/export"
 	"github.com/thestormforge/optimize-go/pkg/config"
+	appsv1 "k8s.io/api/apps/v1"
 	"sigs.k8s.io/kustomize/api/filesys"
+	"sigs.k8s.io/kustomize/kyaml/kio"
+	"sigs.k8s.io/yaml"
 )
 
 func TestPatchExperiment(t *testing.T) {
@@ -106,10 +110,16 @@ func TestPatchExperiment(t *testing.T) {
 			err := cmd.Execute()
 			require.NoError(t, err)
 
+			exp, err := extractDeployment(b.Bytes(), "postgres")
+			require.NoError(t, err)
+
 			cpu := wannabeTrial.TrialAssignments.Assignments[0]
 			mem := wannabeTrial.TrialAssignments.Assignments[1]
-			assert.Contains(t, b.String(), fmt.Sprintf("%s: %sm", cpu.ParameterName, cpu.Value.String()))
-			assert.Contains(t, b.String(), fmt.Sprintf("%s: %sMi", mem.ParameterName, mem.Value.String()))
+			cpuLimits := exp.Spec.Template.Spec.Containers[0].Resources.Limits["cpu"]
+			memLimits := exp.Spec.Template.Spec.Containers[0].Resources.Limits["memory"]
+
+			assert.Equal(t, fmt.Sprintf("%sm", cpu.Value.String()), (&cpuLimits).String())
+			assert.Equal(t, fmt.Sprintf("%sMi", mem.Value.String()), (&memLimits).String())
 		})
 	}
 }
@@ -182,10 +192,36 @@ func TestPatchApplication(t *testing.T) {
 			err = cmd.Execute()
 			require.NoError(t, err)
 
+			exp, err := extractDeployment(b.Bytes(), "postgres")
+			require.NoError(t, err)
+
 			cpu := wannabeTrial.TrialAssignments.Assignments[0]
 			mem := wannabeTrial.TrialAssignments.Assignments[1]
-			assert.Contains(t, b.String(), fmt.Sprintf("%s: %sm", cpu.ParameterName, cpu.Value.String()))
-			assert.Contains(t, b.String(), fmt.Sprintf("%s: %sM", mem.ParameterName, mem.Value.String()))
+			cpuLimits := exp.Spec.Template.Spec.Containers[0].Resources.Limits["cpu"]
+			memLimits := exp.Spec.Template.Spec.Containers[0].Resources.Limits["memory"]
+
+			assert.Equal(t, fmt.Sprintf("%sm", cpu.Value.String()), (&cpuLimits).String())
+			assert.Equal(t, fmt.Sprintf("%sMi", mem.Value.String()), (&memLimits).String())
 		})
 	}
+}
+
+func extractDeployment(input []byte, name string) (*appsv1.Deployment, error) {
+	var deploymentBuf bytes.Buffer
+
+	deploymentInput := kio.Pipeline{
+		Inputs:  []kio.Reader{&kio.ByteReader{Reader: bytes.NewReader(input)}},
+		Filters: []kio.Filter{&filters.ResourceMetaFilter{Group: appsv1.GroupName, Kind: "Deployment", Name: name}},
+		Outputs: []kio.Writer{kio.ByteWriter{Writer: &deploymentBuf}},
+	}
+	if err := deploymentInput.Execute(); err != nil {
+		return nil, err
+	}
+
+	exp := &appsv1.Deployment{}
+	if err := yaml.Unmarshal(deploymentBuf.Bytes(), exp); err != nil {
+		return nil, err
+	}
+
+	return exp, nil
 }

--- a/cli/internal/commands/export/export_util_test.go
+++ b/cli/internal/commands/export/export_util_test.go
@@ -39,11 +39,11 @@ func createTempExperimentFile(t *testing.T) (*optimizev1beta2.Experiment, []byte
          - name: postgres
            resources:
              limits:
-               cpu: "{{ .Values.cpu }}m"
-               memory: "{{ .Values.memory }}Mi"
+               cpu: {{ index .Values "deployment/postgres/postgres/cpu" }}m
+               memory: {{ index .Values "deployment/postgres/postgres/memory" }}Mi
              requests:
-               cpu: "{{ .Values.cpu }}m"
-               memory: "{{ .Values.memory }}Mi"`
+               cpu: {{ index .Values "deployment/postgres/postgres/cpu" }}m
+               memory: {{ index .Values "deployment/postgres/postgres/memory" }}Mi`
 
 	tm := &metav1.TypeMeta{}
 	tm.SetGroupVersionKind(optimizev1beta2.GroupVersion.WithKind("Experiment"))

--- a/cli/internal/commands/export/export_util_test.go
+++ b/cli/internal/commands/export/export_util_test.go
@@ -39,11 +39,11 @@ func createTempExperimentFile(t *testing.T) (*optimizev1beta2.Experiment, []byte
          - name: postgres
            resources:
              limits:
-               cpu: {{ index .Values "deployment/postgres/postgres/cpu" }}m
-               memory: {{ index .Values "deployment/postgres/postgres/memory" }}Mi
+               cpu: {{ index .Values "deployment/postgres/postgres/resources/cpu" }}m
+               memory: {{ index .Values "deployment/postgres/postgres/resources/memory" }}Mi
              requests:
-               cpu: {{ index .Values "deployment/postgres/postgres/cpu" }}m
-               memory: {{ index .Values "deployment/postgres/postgres/memory" }}Mi`
+               cpu: {{ index .Values "deployment/postgres/postgres/resources/cpu" }}m
+               memory: {{ index .Values "deployment/postgres/postgres/resources/memory" }}Mi`
 
 	tm := &metav1.TypeMeta{}
 	tm.SetGroupVersionKind(optimizev1beta2.GroupVersion.WithKind("Experiment"))

--- a/controllers/application_poller_test.go
+++ b/controllers/application_poller_test.go
@@ -57,7 +57,7 @@ func TestPoller(t *testing.T) {
 			expected: applications.Template{
 				Parameters: []applications.TemplateParameter{
 					{
-						Name: "deployment/nginx/nginx/cpu",
+						Name: "deployment/nginx/nginx/resources/cpu",
 						Type: "int",
 						Bounds: &applications.TemplateParameterBounds{
 							Max: json.Number("2000"),
@@ -66,7 +66,7 @@ func TestPoller(t *testing.T) {
 						Baseline: &fifty,
 					},
 					{
-						Name: "deployment/nginx/nginx/memory",
+						Name: "deployment/nginx/nginx/resources/memory",
 						Type: "int",
 						Bounds: &applications.TemplateParameterBounds{
 							Max: json.Number("50"),

--- a/controllers/application_poller_test.go
+++ b/controllers/application_poller_test.go
@@ -57,7 +57,7 @@ func TestPoller(t *testing.T) {
 			expected: applications.Template{
 				Parameters: []applications.TemplateParameter{
 					{
-						Name: "nginx_cpu",
+						Name: "deployment/nginx/nginx/cpu",
 						Type: "int",
 						Bounds: &applications.TemplateParameterBounds{
 							Max: json.Number("2000"),
@@ -66,7 +66,7 @@ func TestPoller(t *testing.T) {
 						Baseline: &fifty,
 					},
 					{
-						Name: "nginx_memory",
+						Name: "deployment/nginx/nginx/memory",
 						Type: "int",
 						Bounds: &applications.TemplateParameterBounds{
 							Max: json.Number("50"),
@@ -74,7 +74,7 @@ func TestPoller(t *testing.T) {
 						},
 						Baseline: &twentyfive,
 					}, {
-						Name: "replicas",
+						Name: "deployment/nginx/replicas",
 						Type: "int",
 						Bounds: &applications.TemplateParameterBounds{
 							Max: json.Number("5"),

--- a/internal/experiment/generation/transformer_test.go
+++ b/internal/experiment/generation/transformer_test.go
@@ -169,11 +169,26 @@ func TestParameterNames(t *testing.T) {
 					meta:      meta("Deployment", "test2"),
 					fieldPath: []string{"spec", "template", "spec", "containers", "[name=test2]", "env", "[name=MY_ENV_VAR]"},
 				},
+				{
+					meta:      meta("Deployment", "test2"),
+					fieldPath: []string{"spec", "template", "spec", "containers", "[name=env]", "env", "[name=MY_ENV_VAR]"},
+				},
+				{
+					meta:      meta("Deployment", "test2"),
+					fieldPath: []string{"spec", "template", "spec", "containers", "[name=env]", "env", "[name=cpu]"},
+				},
+				{
+					meta:      meta("Deployment", "test2"),
+					fieldPath: []string{"spec", "template", "spec", "containers", "[name=env]", "env", "[name=env]"},
+				},
 			},
 			expected: []string{
-				"deployment/test1/test2/env/my_env_var",
-				"deployment/test1/test2/env/my_second_env_var",
-				"deployment/test2/test2/env/my_env_var",
+				"deployment/test1/test2/env/MY_ENV_VAR",
+				"deployment/test1/test2/env/MY_SECOND_ENV_VAR",
+				"deployment/test2/test2/env/MY_ENV_VAR",
+				"deployment/test2/env/env/MY_ENV_VAR", // :troll:
+				"deployment/test2/env/env/cpu",        // :troll:
+				"deployment/test2/env/env/env",        // :troll:
 			},
 		},
 	}

--- a/internal/experiment/generation/transformer_test.go
+++ b/internal/experiment/generation/transformer_test.go
@@ -78,12 +78,17 @@ func TestParameterNames(t *testing.T) {
 					meta:      meta("Deployment", "test2"),
 					fieldPath: []string{"spec", "template", "spec", "containers", "[name=test]", "resources"},
 				},
+				{
+					meta:      meta("Deployment", "test1"),
+					fieldPath: []string{"spec", "replicas"},
+				},
 			},
 			expected: []string{
 				"test1_cpu",
 				"test1_memory",
 				"test2_cpu",
 				"test2_memory",
+				"test1_replicas",
 			},
 		},
 
@@ -112,6 +117,29 @@ func TestParameterNames(t *testing.T) {
 				"test2_memory",
 			},
 		},
+
+		{
+			desc: "brad",
+			selected: []pnode{
+				{
+					meta:      meta("Deployment", "a-b"),
+					fieldPath: []string{"spec", "template", "spec", "containers", "[name=c]", "resources"},
+				},
+				{
+					meta:      meta("Deployment", "a"),
+					fieldPath: []string{"spec", "template", "spec", "containers", "[name=b]", "resources"},
+				},
+				{
+					meta:      meta("Deployment", "a"),
+					fieldPath: []string{"spec", "template", "spec", "containers", "[name=c]", "resources"},
+				},
+				{
+					meta:      meta("Deployment", "a-b"),
+					fieldPath: []string{"spec", "replicas"},
+				},
+			},
+			expected: []string{},
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.desc, func(t *testing.T) {
@@ -123,8 +151,12 @@ func TestParameterNames(t *testing.T) {
 
 			var actual []string
 			for _, sel := range c.selected {
-				actual = append(actual, namer(sel.meta, sel.fieldPath, "cpu"))
-				actual = append(actual, namer(sel.meta, sel.fieldPath, "memory"))
+				if sel.fieldPath[len(sel.fieldPath)-1] == "resources" {
+					actual = append(actual, namer(sel.meta, sel.fieldPath, "cpu"))
+					actual = append(actual, namer(sel.meta, sel.fieldPath, "memory"))
+				} else {
+					actual = append(actual, namer(sel.meta, sel.fieldPath, "replicas"))
+				}
 			}
 			assert.Equal(t, c.expected, actual)
 		})

--- a/internal/experiment/generation/transformer_test.go
+++ b/internal/experiment/generation/transformer_test.go
@@ -42,8 +42,8 @@ func TestParameterNames(t *testing.T) {
 				},
 			},
 			expected: []string{
-				"deployment/test/test/cpu",
-				"deployment/test/test/memory",
+				"deployment/test/test/resources/cpu",
+				"deployment/test/test/resources/memory",
 			},
 		},
 
@@ -60,10 +60,10 @@ func TestParameterNames(t *testing.T) {
 				},
 			},
 			expected: []string{
-				"deployment/test/test1/cpu",
-				"deployment/test/test1/memory",
-				"deployment/test/test2/cpu",
-				"deployment/test/test2/memory",
+				"deployment/test/test1/resources/cpu",
+				"deployment/test/test1/resources/memory",
+				"deployment/test/test2/resources/cpu",
+				"deployment/test/test2/resources/memory",
 			},
 		},
 
@@ -84,10 +84,10 @@ func TestParameterNames(t *testing.T) {
 				},
 			},
 			expected: []string{
-				"deployment/test1/test/cpu",
-				"deployment/test1/test/memory",
-				"deployment/test2/test/cpu",
-				"deployment/test2/test/memory",
+				"deployment/test1/test/resources/cpu",
+				"deployment/test1/test/resources/memory",
+				"deployment/test2/test/resources/cpu",
+				"deployment/test2/test/resources/memory",
 				"deployment/test1/replicas",
 			},
 		},
@@ -109,12 +109,12 @@ func TestParameterNames(t *testing.T) {
 				},
 			},
 			expected: []string{
-				"deployment/test1/test1/cpu",
-				"deployment/test1/test1/memory",
-				"deployment/test1/test2/cpu",
-				"deployment/test1/test2/memory",
-				"deployment/test2/test/cpu",
-				"deployment/test2/test/memory",
+				"deployment/test1/test1/resources/cpu",
+				"deployment/test1/test1/resources/memory",
+				"deployment/test1/test2/resources/cpu",
+				"deployment/test1/test2/resources/memory",
+				"deployment/test2/test/resources/cpu",
+				"deployment/test2/test/resources/memory",
 			},
 		},
 
@@ -143,12 +143,12 @@ func TestParameterNames(t *testing.T) {
 				},
 			},
 			expected: []string{
-				"deployment/a-b/c/cpu",
-				"deployment/a-b/c/memory",
-				"deployment/a/b/cpu",
-				"deployment/a/b/memory",
-				"deployment/a/c/cpu",
-				"deployment/a/c/memory",
+				"deployment/a-b/c/resources/cpu",
+				"deployment/a-b/c/resources/memory",
+				"deployment/a/b/resources/cpu",
+				"deployment/a/b/resources/memory",
+				"deployment/a/c/resources/cpu",
+				"deployment/a/c/resources/memory",
 				"deployment/a-b/replicas",
 				"statefulset/a-b/replicas",
 			},
@@ -194,16 +194,13 @@ func TestParameterNames(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.desc, func(t *testing.T) {
-			var selected []interface{}
-			for i := range c.selected {
-				selected = append(selected, &c.selected[i])
-			}
-			namer := parameterNamer(selected)
+			namer := parameterNamer()
 
 			var actual []string
 
 			for _, sel := range c.selected {
 				switch sel.fieldPath[len(sel.fieldPath)-1] {
+
 				case "resources":
 					actual = append(actual, namer(sel.meta, sel.fieldPath, "cpu"))
 					actual = append(actual, namer(sel.meta, sel.fieldPath, "memory"))

--- a/internal/experiment/generation/transformer_test.go
+++ b/internal/experiment/generation/transformer_test.go
@@ -137,6 +137,10 @@ func TestParameterNames(t *testing.T) {
 					meta:      meta("Deployment", "a-b"),
 					fieldPath: []string{"spec", "replicas"},
 				},
+				{
+					meta:      meta("Statefulset", "a-b"),
+					fieldPath: []string{"spec", "replicas"},
+				},
 			},
 			expected: []string{},
 		},

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -147,7 +147,7 @@ func GetConditionStatus(j *batchv1.Job) (corev1.ConditionStatus, string) {
 // AppendAssignmentEnv appends an environment variable for each trial assignment
 func AppendAssignmentEnv(t *optimizev1beta2.Trial, env []corev1.EnvVar) []corev1.EnvVar {
 	for _, a := range t.Spec.Assignments {
-		name := strings.ReplaceAll(strings.ToUpper(a.Name), ".", "_")
+		name := strings.ReplaceAll(strings.ReplaceAll(strings.ToUpper(a.Name), ".", "_"), "/", "_")
 		env = append(env, corev1.EnvVar{Name: name, Value: a.Value.String()})
 	}
 


### PR DESCRIPTION
This introduces generating parameter names as fully qualified paths, ex `deployment/test/test1/cpu`. 
This (hopefully) should clear up some of the confusion around the discovered parameter names.