### PR TITLE
Add YAML document delimiters to head of YAML output

### DIFF
--- a/cli/internal/commander/commander.go
+++ b/cli/internal/commander/commander.go
@@ -132,7 +132,7 @@ type prefixWriter struct {
 
 func (w *prefixWriter) Write(p []byte) (n int, err error) {
 	w.Once.Do(func() {
-		_, err = w.w.Write([]byte("---\n"))
+		n, err = w.w.Write([]byte("---\n"))
 	})
 	if err != nil {
 		return

--- a/cli/internal/commander/commander.go
+++ b/cli/internal/commander/commander.go
@@ -117,12 +117,27 @@ func (r *fileReader) Read(p []byte) (n int, err error) {
 // is configured to strip common annotations used during pipeline processing.
 func (s *IOStreams) YAMLWriter() kio.Writer {
 	return &kio.ByteWriter{
-		Writer: s.Out,
+		Writer: &prefixWriter{w: s.Out},
 		ClearAnnotations: []string{
 			kioutil.PathAnnotation,
 			filters.FmtAnnotation,
 		},
 	}
+}
+
+type prefixWriter struct {
+	sync.Once
+	w io.Writer
+}
+
+func (w *prefixWriter) Write(p []byte) (n int, err error) {
+	w.Once.Do(func() {
+		_, err = w.w.Write([]byte("---\n"))
+	})
+	if err != nil {
+		return
+	}
+	return w.w.Write(p)
 }
 
 // SetStreams updates the streams using the supplied command

--- a/cli/internal/commander/printer.go
+++ b/cli/internal/commander/printer.go
@@ -18,6 +18,7 @@ package commander
 
 import (
 	"encoding/csv"
+	"encoding/json"
 	"fmt"
 	"io"
 	"sort"
@@ -25,8 +26,6 @@ import (
 	"strings"
 	"text/tabwriter"
 	"time"
-
-	"encoding/json"
 
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
@@ -283,7 +282,7 @@ func (p *marshalPrinter) PrintObj(obj interface{}, w io.Writer) error {
 		if err != nil {
 			return err
 		}
-		_, err = fmt.Fprint(w, string(output))
+		_, err = fmt.Fprint(w, "---\n"+string(output))
 		return err
 	}
 
@@ -553,7 +552,6 @@ func (k *kubePrinter) PrintObj(obj interface{}, w io.Writer) error {
 			if err := k.printer.PrintObj(ul.Items[i].Object, w); err != nil {
 				return err
 			}
-			_, _ = fmt.Fprintln(w, "---")
 		}
 	}
 

--- a/cli/internal/commands/generate/application.go
+++ b/cli/internal/commands/generate/application.go
@@ -25,7 +25,6 @@ import (
 	"github.com/thestormforge/optimize-controller/v2/cli/internal/commander"
 	"github.com/thestormforge/optimize-controller/v2/internal/application"
 	"github.com/thestormforge/optimize-go/pkg/config"
-	"sigs.k8s.io/kustomize/kyaml/kio"
 )
 
 type ApplicationOptions struct {
@@ -86,7 +85,7 @@ func (o *ApplicationOptions) generate() error {
 	}
 
 	// Generate the application
-	return o.Generator.Execute(&kio.ByteWriter{Writer: o.Out})
+	return o.Generator.Execute(o.YAMLWriter())
 }
 
 func (o *ApplicationOptions) isDefaultResourceEmpty() bool {

--- a/cli/internal/commands/initialize/generator.go
+++ b/cli/internal/commands/initialize/generator.go
@@ -105,7 +105,7 @@ func (o *GeneratorOptions) generate() error {
 			o.labelFilter(),
 		},
 		Outputs: []kio.Writer{
-			kio.ByteWriter{Writer: o.Out},
+			o.YAMLWriter(),
 		},
 	}
 


### PR DESCRIPTION
Makes sure `---` appears first for all resources to facilitate cat herding.