### PR TITLE
Controller resource configuration

### DIFF
--- a/cli/internal/commands/configure/set.go
+++ b/cli/internal/commands/configure/set.go
@@ -41,7 +41,14 @@ func NewSetCommand(o *SetOptions) *cobra.Command {
 		Use:   "set NAME [VALUE]",
 		Short: "Modify the configuration file",
 		Long:  "Modify the Optimize Configuration file",
-		Args:  cobra.RangeArgs(1, 2),
+
+		Example: `# Add an environment variable to the controller
+stormforge config set controller.default.env.FOOBAR example
+
+# Set the controller memory
+stormforge config set controller.default.resources.memory 512Mi`,
+
+		Args: cobra.RangeArgs(1, 2),
 
 		PreRun: func(cmd *cobra.Command, args []string) {
 			o.Complete(args)
@@ -67,8 +74,14 @@ func (o *SetOptions) Complete(args []string) {
 }
 
 func (o *SetOptions) set() error {
-	if err := o.Config.Update(config.SetProperty(o.Key, o.Value)); err != nil {
-		return err
+	if o.Value != "" {
+		if err := o.Config.Update(config.SetProperty(o.Key, o.Value)); err != nil {
+			return err
+		}
+	} else {
+		if err := o.Config.Update(config.UnsetProperty(o.Key)); err != nil {
+			return err
+		}
 	}
 
 	if err := o.Config.Write(); err != nil {

--- a/cli/internal/commands/initialize/generator.go
+++ b/cli/internal/commands/initialize/generator.go
@@ -157,6 +157,7 @@ func (o *GeneratorOptions) generateApplication() (io.Reader, error) {
 	yamls, err := kustomize.Yamls(
 		kustomize.WithInstall(),
 		kustomize.WithNamespace(ctrl.Namespace),
+		kustomize.WithControllerResources(ctrl.Resources),
 		kustomize.WithImage(o.Image),
 		kustomize.WithImagePullPolicy(setup.ImagePullPolicy),
 		kustomize.WithAPI(apiEnabled),

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
 	github.com/thestormforge/konjure v0.3.2
-	github.com/thestormforge/optimize-go v0.0.18
+	github.com/thestormforge/optimize-go v0.0.19
 	github.com/yujunz/go-getter v1.5.1-lite.0.20201201013212-6d9c071adddf
 	github.com/zorkian/go-datadog-api v2.24.0+incompatible
 	go.uber.org/zap v1.10.0

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
 	github.com/thestormforge/konjure v0.3.2
-	github.com/thestormforge/optimize-go v0.0.19
+	github.com/thestormforge/optimize-go v0.0.20
 	github.com/yujunz/go-getter v1.5.1-lite.0.20201201013212-6d9c071adddf
 	github.com/zorkian/go-datadog-api v2.24.0+incompatible
 	go.uber.org/zap v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -563,8 +563,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/thestormforge/konjure v0.3.2 h1:9h1HsAB9k8ENMHOOlUl2RYPE2+pZ+OqLn/Z0q0/COjM=
 github.com/thestormforge/konjure v0.3.2/go.mod h1:5cZj+F9imDQJrk4TUmXyA+dtSm6L0YdjSWFYvIX/668=
-github.com/thestormforge/optimize-go v0.0.19 h1:X80h2ycYHIQU/MyNVvy6m9Lm2Jgf81ymeEaQ6lOWoNw=
-github.com/thestormforge/optimize-go v0.0.19/go.mod h1:MpUI4Wjx5koU911F/VUezzMjhdmLJUClvm1aw9Ip7CQ=
+github.com/thestormforge/optimize-go v0.0.20 h1:MunNkbsicUY71jZ1bzh7InQQ8REFp+y7psKOwzK+z88=
+github.com/thestormforge/optimize-go v0.0.20/go.mod h1:MpUI4Wjx5koU911F/VUezzMjhdmLJUClvm1aw9Ip7CQ=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/go.sum
+++ b/go.sum
@@ -563,8 +563,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/thestormforge/konjure v0.3.2 h1:9h1HsAB9k8ENMHOOlUl2RYPE2+pZ+OqLn/Z0q0/COjM=
 github.com/thestormforge/konjure v0.3.2/go.mod h1:5cZj+F9imDQJrk4TUmXyA+dtSm6L0YdjSWFYvIX/668=
-github.com/thestormforge/optimize-go v0.0.18 h1:o5NRqLxRWer9cwFKf3OrXsJvxU2AeKAn+xcYFxQh+QQ=
-github.com/thestormforge/optimize-go v0.0.18/go.mod h1:LhoJFNeHXLWnMp5KVkHJdzUfx76Gwj81/m40IVM9MjA=
+github.com/thestormforge/optimize-go v0.0.19 h1:X80h2ycYHIQU/MyNVvy6m9Lm2Jgf81ymeEaQ6lOWoNw=
+github.com/thestormforge/optimize-go v0.0.19/go.mod h1:MpUI4Wjx5koU911F/VUezzMjhdmLJUClvm1aw9Ip7CQ=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=


### PR DESCRIPTION
This PR adds the ability to store controller resource configurations prior to init.

To use this you would run `stormforge config set controller.default.resources.cpu 200m` and/or `stormforge config set controller.default.resources.memory 512Mi` _before_ you run `stormforge init` (or `stormforge gen install`).