### PR TITLE
fix: Use correct key for configmap reloader

### DIFF
--- a/config/prometheus/templates/deployment.yaml
+++ b/config/prometheus/templates/deployment.yaml
@@ -111,7 +111,7 @@ spec:
           - --volume-dir=/etc/config
           - --webhook-url=http://127.0.0.1:9090/-/reload
         resources:
-          {{- toYaml .Values.promServer.resources | nindent 10 }}
+          {{- toYaml .Values.configReload.resources | nindent 10 }}
         volumeMounts:
           - name: config-volume
             mountPath: /etc/config


### PR DESCRIPTION
This fixes an issue where we were using promServer resources in configmap reloader

Signed-off-by: Brad Beam <brad.beam@stormforge.io>