### PR TITLE
feat: Add support for tolerations for prometheus deployment

### DIFF
--- a/config/prometheus/templates/deployment.yaml
+++ b/config/prometheus/templates/deployment.yaml
@@ -129,3 +129,15 @@ spec:
         - name: storage-volume
           emptyDir:
             sizeLimit: "{{ .Values.storageVolumeSize }}"
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/config/prometheus/values.yaml
+++ b/config/prometheus/values.yaml
@@ -3,6 +3,12 @@ storageVolumeSize: 100Mi
 scrapeInterval: 10s
 scrapeTimeout: 8s
 
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
 kubeStateMetrics:
   image:
     repository: quay.io/coreos/kube-state-metrics


### PR DESCRIPTION
```
# --- Node Selector
- name: nodeSelector.diskType
  value: ssdNodeSelector
# --- Tolerations
- name: tolerations[0].key
  value: example-key
- name: tolerations[0].operator
  value: Exists
- name: tolerations[0].effect
  value: NoSchedule
# --- Affinity requredDuringSchedulingIgnoredDuringExecution
- name: affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key
  value: kubernetes.io/e2e-az-name
- name: affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator
  value: In
- name: affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]
  value: e2e-az1
- name: affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[1]
  value: e2e-az2
# --- Affinity preferredDuringSchedulingIgnoredDuringExecution
- name: affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].weight
  value: 1
- name: affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].key
  value: another-node-label-key
- name: affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].operator
  value: In
- name: affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].values[0]
  value: another-node-label-value
  ```
  Signed-off-by: Brad Beam <brad.beam@stormforge.io>