### PR TITLE
Fix generate RBAC for readiness gates

### DIFF
--- a/cli/internal/commands/generate/rbac.go
+++ b/cli/internal/commands/generate/rbac.go
@@ -295,15 +295,6 @@ func (o *RBACOptions) appendRules(rules []*rbacv1.PolicyRule, exp *optimizev1bet
 		}
 	}
 
-	// Readiness gates will be converted to readiness checks; therefore we need the same check on non-empty names
-	for i := range exp.Spec.TrialTemplate.Spec.ReadinessGates {
-		r := &exp.Spec.TrialTemplate.Spec.ReadinessGates[i]
-		if r.Name == "" {
-			ref := &corev1.ObjectReference{Kind: r.Kind, APIVersion: r.APIVersion}
-			rules = append(rules, o.newPolicyRule(ref, "list"))
-		}
-	}
-
 	return rules
 }
 

--- a/cli/internal/commands/generate/rbac.go
+++ b/cli/internal/commands/generate/rbac.go
@@ -283,14 +283,17 @@ func (o *RBACOptions) appendRules(rules []*rbacv1.PolicyRule, exp *optimizev1bet
 		}
 	}
 
-	// Readiness gates with no name require "list" permissions
+	// Readiness gates with a name require "get" permissions, no name requires "list" permissions
 	for i := range exp.Spec.TrialTemplate.Spec.ReadinessGates {
-		rg := &exp.Spec.TrialTemplate.Spec.ReadinessGates[i]
-		if rg.Name == "" {
-			ref := &corev1.ObjectReference{
-				Kind:       rg.Kind,
-				APIVersion: rg.APIVersion,
-			}
+		ref := &corev1.ObjectReference{
+			Kind:       exp.Spec.TrialTemplate.Spec.ReadinessGates[i].Kind,
+			APIVersion: exp.Spec.TrialTemplate.Spec.ReadinessGates[i].APIVersion,
+			Name:       exp.Spec.TrialTemplate.Spec.ReadinessGates[i].Name,
+		}
+
+		if ref.Name != "" {
+			rules = append(rules, o.newPolicyRule(ref, "get"))
+		} else {
 			rules = append(rules, o.newPolicyRule(ref, "list"))
 		}
 	}


### PR DESCRIPTION
The current implementation only adds policies for readiness gates with empty names. This has been corrected so that the presence of the name toggles between `get` and `list` verbs.