### PR TITLE
Add application/scenario lookups to `stormforge run`

### DIFF
--- a/cli/internal/commander/commander.go
+++ b/cli/internal/commander/commander.go
@@ -29,6 +29,7 @@ import (
 	optimizev1beta2 "github.com/thestormforge/optimize-controller/v2/api/v1beta2"
 	megahack "github.com/thestormforge/optimize-controller/v2/internal/experiment/generation"
 	"github.com/thestormforge/optimize-go/pkg/api"
+	applications "github.com/thestormforge/optimize-go/pkg/api/applications/v2"
 	experimentsv1alpha1 "github.com/thestormforge/optimize-go/pkg/api/experiments/v1alpha1"
 	"github.com/thestormforge/optimize-go/pkg/config"
 	"golang.org/x/oauth2"
@@ -178,6 +179,38 @@ func SetExperimentsAPI(expAPI *experimentsv1alpha1.API, cfg *config.OptimizeConf
 	}
 
 	*expAPI = experimentsv1alpha1.NewAPI(c)
+	return nil
+}
+
+// SetApplicationsAPI creates a new application API interface from the supplied configuration
+func SetApplicationsAPI(appAPI *applications.API, cfg *config.OptimizeConfig, cmd *cobra.Command) error {
+	ctx := cmd.Context()
+	srv, err := config.CurrentServer(cfg.Reader())
+	if err != nil {
+		return err
+	}
+
+	// NOTE: We should use `srv.Identifier` but technically this version of the configuration
+	// exposes this double counted "/v1/experiments/" endpoint
+	address := strings.TrimSuffix(srv.API.ApplicationsEndpoint, "/v2/applications/")
+
+	// Reuse the OAuth2 base transport for the API calls
+	t, err := cfg.Authorize(ctx, oauth2.NewClient(ctx, nil).Transport)
+	if err != nil {
+		return err
+	}
+
+	c, err := api.NewClient(address, t)
+	if err != nil {
+		return err
+	}
+
+	*appAPI = applications.NewAPI(c)
+
+	if _, err := (*appAPI).CheckEndpoint(ctx); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/cli/internal/commander/commander.go
+++ b/cli/internal/commander/commander.go
@@ -207,10 +207,6 @@ func SetApplicationsAPI(appAPI *applications.API, cfg *config.OptimizeConfig, cm
 
 	*appAPI = applications.NewAPI(c)
 
-	if _, err := (*appAPI).CheckEndpoint(ctx); err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/cli/internal/commands/run/command.go
+++ b/cli/internal/commands/run/command.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"sort"
 	"strings"
 	"time"
 
@@ -256,11 +257,13 @@ func (o *Options) listApplicationNames() tea.Msg {
 		return err
 	}
 
-	msg := internal.ApplicationMsg{}
+	msg := make(internal.ApplicationMsg, len(appList.Applications))
 
-	for _, app := range appList.Applications {
-		msg[app.Name.String()] = app.Metadata.Title()
+	for i := range appList.Applications {
+		msg[i] = fmt.Sprintf("%-32s (%s)", appList.Applications[i].Metadata.Title(), appList.Applications[i].Name.String())
 	}
+
+	sort.Strings(msg)
 
 	return msg
 }
@@ -286,11 +289,13 @@ func (o *Options) listScenarioNames() tea.Msg {
 		return err
 	}
 
-	msg := internal.ScenarioMsg{}
+	msg := make(internal.ScenarioMsg, len(scenarioList.Scenarios))
 
-	for _, scenario := range scenarioList.Scenarios {
-		msg[scenario.Name] = scenario.Metadata.Title()
+	for i := range scenarioList.Scenarios {
+		msg[i] = fmt.Sprintf("%-32s (%s)", scenarioList.Scenarios[i].Metadata.Title(), scenarioList.Scenarios[i].Name)
 	}
+
+	sort.Strings(msg)
 
 	return msg
 }

--- a/cli/internal/commands/run/internal/messages.go
+++ b/cli/internal/commands/run/internal/messages.go
@@ -59,6 +59,12 @@ type KubernetesNamespacesMsg []string
 // test case names.
 type StormForgeTestCasesMsg []string
 
+// ApplicationMsg contains the application ULID if an existing application is used.
+type ApplicationMsg map[string]string
+
+// ScenarioMsg contains the scenario ULID if an existing scenario is used.
+type ScenarioMsg map[string]string
+
 // ExperimentMsg represents the generated experiment.
 type ExperimentMsg []*yaml.RNode
 

--- a/cli/internal/commands/run/internal/messages.go
+++ b/cli/internal/commands/run/internal/messages.go
@@ -60,10 +60,10 @@ type KubernetesNamespacesMsg []string
 type StormForgeTestCasesMsg []string
 
 // ApplicationMsg contains the application ULID if an existing application is used.
-type ApplicationMsg map[string]string
+type ApplicationMsg []string
 
 // ScenarioMsg contains the scenario ULID if an existing scenario is used.
-type ScenarioMsg map[string]string
+type ScenarioMsg []string
 
 // ExperimentMsg represents the generated experiment.
 type ExperimentMsg []*yaml.RNode

--- a/cli/internal/commands/run/internal/messages.go
+++ b/cli/internal/commands/run/internal/messages.go
@@ -62,6 +62,9 @@ type StormForgeTestCasesMsg []string
 // ApplicationMsg contains the application ULID if an existing application is used.
 type ApplicationMsg []string
 
+// DoScenarioLookup triggers the retrieval of scenario names for an application.
+type DoScenarioLookup struct{}
+
 // ScenarioMsg contains the scenario ULID if an existing scenario is used.
 type ScenarioMsg []string
 

--- a/cli/internal/commands/run/model.go
+++ b/cli/internal/commands/run/model.go
@@ -17,6 +17,8 @@ limitations under the License.
 package run
 
 import (
+	"fmt"
+	"sort"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -141,6 +143,9 @@ type generatorModel struct {
 	ReplicasSelectorInput           form.TextField
 
 	ObjectiveInput form.MultiChoiceField
+
+	ApplicationInput form.ChoiceField
+	ScenarioInput    form.ChoiceField
 }
 
 func (m generatorModel) Update(msg tea.Msg) (generatorModel, tea.Cmd) {
@@ -155,6 +160,24 @@ func (m generatorModel) Update(msg tea.Msg) (generatorModel, tea.Cmd) {
 		m.NamespaceInput.Choices = msg
 		m.NamespaceInput.SelectOnly()
 
+	case internal.ApplicationMsg:
+		choices := make([]string, 0)
+		for ulid, name := range msg {
+			choices = append(choices, fmt.Sprintf("%-32s (%s)", name, ulid))
+		}
+		sort.Strings(choices)
+		m.ApplicationInput.Choices = choices
+		m.ApplicationInput.SelectOnly()
+
+	case internal.ScenarioMsg:
+		choices := make([]string, 0)
+		for ulid, name := range msg {
+			choices = append(choices, fmt.Sprintf("%-32s (%s)", name, ulid))
+		}
+		sort.Strings(choices)
+		m.ScenarioInput.Choices = choices
+		m.ScenarioInput.SelectOnly()
+
 	case tea.KeyMsg:
 		switch msg.Type {
 		case tea.KeyEnter:
@@ -163,7 +186,6 @@ func (m generatorModel) Update(msg tea.Msg) (generatorModel, tea.Cmd) {
 				m.updateLabelSelectorInputs()
 			}
 		}
-
 	}
 
 	var cmd tea.Cmd
@@ -209,6 +231,12 @@ func (m generatorModel) Update(msg tea.Msg) (generatorModel, tea.Cmd) {
 	m.ObjectiveInput, cmd = m.ObjectiveInput.Update(msg)
 	cmds = append(cmds, cmd)
 
+	m.ApplicationInput, cmd = m.ApplicationInput.Update(msg)
+	cmds = append(cmds, cmd)
+
+	m.ScenarioInput, cmd = m.ScenarioInput.Update(msg)
+	cmds = append(cmds, cmd)
+
 	return m, tea.Batch(cmds...)
 }
 
@@ -229,6 +257,8 @@ func (m *generatorModel) form() form.Fields {
 	fields = append(fields, &m.ContainerResourcesSelectorInput)
 	fields = append(fields, &m.ReplicasSelectorInput)
 	fields = append(fields, &m.ObjectiveInput)
+	fields = append(fields, &m.ApplicationInput)
+	fields = append(fields, &m.ScenarioInput)
 	return fields
 }
 

--- a/cli/internal/commands/run/model.go
+++ b/cli/internal/commands/run/model.go
@@ -17,8 +17,6 @@ limitations under the License.
 package run
 
 import (
-	"fmt"
-	"sort"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -161,21 +159,11 @@ func (m generatorModel) Update(msg tea.Msg) (generatorModel, tea.Cmd) {
 		m.NamespaceInput.SelectOnly()
 
 	case internal.ApplicationMsg:
-		choices := make([]string, 0)
-		for ulid, name := range msg {
-			choices = append(choices, fmt.Sprintf("%-32s (%s)", name, ulid))
-		}
-		sort.Strings(choices)
-		m.ApplicationInput.Choices = choices
+		m.ApplicationInput.Choices = msg
 		m.ApplicationInput.SelectOnly()
 
 	case internal.ScenarioMsg:
-		choices := make([]string, 0)
-		for ulid, name := range msg {
-			choices = append(choices, fmt.Sprintf("%-32s (%s)", name, ulid))
-		}
-		sort.Strings(choices)
-		m.ScenarioInput.Choices = choices
+		m.ScenarioInput.Choices = msg
 		m.ScenarioInput.SelectOnly()
 
 	case tea.KeyMsg:

--- a/cli/internal/commands/run/model.go
+++ b/cli/internal/commands/run/model.go
@@ -173,6 +173,9 @@ func (m generatorModel) Update(msg tea.Msg) (generatorModel, tea.Cmd) {
 			if m.NamespaceInput.Focused() {
 				m.updateLabelSelectorInputs()
 			}
+			if m.ApplicationInput.Focused() {
+				cmds = append(cmds, func() tea.Msg { return internal.DoScenarioLookup{} })
+			}
 		}
 	}
 

--- a/cli/internal/commands/run/run.go
+++ b/cli/internal/commands/run/run.go
@@ -142,7 +142,6 @@ func (o *Options) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		case tea.KeyEnter:
 			if o.generatorModel.ApplicationInput.Focused() {
-				fmt.Println("app input focused, enter hit, listing scenario names")
 				cmds = append(cmds, o.listScenarioNames)
 			}
 
@@ -294,7 +293,7 @@ func (m generatorModel) applyToApp(app *optimizeappsv1alpha1.Application) {
 
 	var scenarioName string
 	if m.ScenarioInput.Enabled() {
-		parts := strings.Fields(m.ApplicationInput.Value())
+		parts := strings.Fields(m.ScenarioInput.Value())
 		scenarioName = strings.Trim(parts[len(parts)-1], "()")
 	}
 

--- a/cli/internal/commands/run/run.go
+++ b/cli/internal/commands/run/run.go
@@ -140,11 +140,6 @@ func (o *Options) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case tea.KeyCtrlC:
 			return o, tea.Quit
 
-		case tea.KeyEnter:
-			if o.generatorModel.ApplicationInput.Focused() {
-				cmds = append(cmds, o.listScenarioNames)
-			}
-
 		default:
 			if o.maybeQuit {
 				switch msg.String() {
@@ -223,6 +218,9 @@ func (o *Options) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case internal.TrialsRefreshMsg:
 		// Refresh the trials list
 		cmds = append(cmds, o.refreshTrials)
+
+	case internal.DoScenarioLookup:
+		cmds = append(cmds, o.listScenarioNames)
 
 	case error:
 		// Handle errors so any command returning tea.Msg can just return an error

--- a/cli/internal/commands/run/view.go
+++ b/cli/internal/commands/run/view.go
@@ -205,7 +205,8 @@ https://docs.stormforger.com/guides/getting-started/`,
 	o.generatorModel.ObjectiveInput.Select(2)
 
 	o.generatorModel.ApplicationInput = out.FormField{
-		Prompt: "Please select an application name:",
+		Prompt:         "Please select an application name:",
+		LoadingMessage: "Fetching applications",
 		Instructions: []interface{}{
 			"up/down: select",
 			out.KeyBinding{Key: tea.Key{Type: tea.KeyRunes, Runes: []rune{'x'}}, Desc: "choose"},
@@ -213,7 +214,8 @@ https://docs.stormforger.com/guides/getting-started/`,
 	}.NewChoiceField(opts...)
 
 	o.generatorModel.ScenarioInput = out.FormField{
-		Prompt: "Please select a scenario name:",
+		Prompt:         "Please select a scenario name:",
+		LoadingMessage: "Fetching scenarios",
 		Instructions: []interface{}{
 			"up/down: select",
 			out.KeyBinding{Key: tea.Key{Type: tea.KeyRunes, Runes: []rune{'x'}}, Desc: "choose"},

--- a/cli/internal/commands/run/view.go
+++ b/cli/internal/commands/run/view.go
@@ -204,6 +204,22 @@ https://docs.stormforger.com/guides/getting-started/`,
 	o.generatorModel.ObjectiveInput.Select(0)
 	o.generatorModel.ObjectiveInput.Select(2)
 
+	o.generatorModel.ApplicationInput = out.FormField{
+		Prompt: "Please select an application name:",
+		Instructions: []interface{}{
+			"up/down: select",
+			out.KeyBinding{Key: tea.Key{Type: tea.KeyRunes, Runes: []rune{'x'}}, Desc: "choose"},
+		},
+	}.NewChoiceField(opts...)
+
+	o.generatorModel.ScenarioInput = out.FormField{
+		Prompt: "Please select a scenario name:",
+		Instructions: []interface{}{
+			"up/down: select",
+			out.KeyBinding{Key: tea.Key{Type: tea.KeyRunes, Runes: []rune{'x'}}, Desc: "choose"},
+		},
+	}.NewChoiceField(opts...)
+
 	o.previewModel.Destination = out.FormField{
 		Prompt: "What would you like to do?",
 		Choices: []string{
@@ -349,7 +365,13 @@ func (o *Options) updateGeneratorForm() {
 		return
 	}
 
+	if o.Generator.Application.Name == "" {
+		o.generatorModel.ApplicationInput.Enable()
+	}
+
 	if len(o.Generator.Application.Scenarios) == 0 {
+		o.generatorModel.ScenarioInput.Enable()
+
 		o.generatorModel.ScenarioType.Enable()
 		useStormForge := o.generatorModel.ScenarioType.Value() == ScenarioTypeStormForge
 		useLocust := o.generatorModel.ScenarioType.Value() == ScenarioTypeLocust


### PR DESCRIPTION
This adds in integration with the application services so we can generate the experiment with the proper application and scenario labels. 

`stormforge run` output:
```
Please select an application name:

[ ] Unsorted Experiments             (default)
[x] default-nginx                    (01fjch9t8zdvsdc5mfyctzage4)
[ ] voting-app-tester                (01fg298ycx5f40fn87c334esqf)


Please select a scenario name:

[x] simple nginx                     (01fjchd15axdkb7t3cnyg0yn9j)

🎉  Your experiment is ready to run!

Application Name: 01fjch9t8zdvsdc5mfyctzage4
Experiment Name: 01fjch9t8zdvsdc5mfyctzage4-14a0041e
```

Generated experiment:
```
apiVersion: optimize.stormforge.io/v1beta2
kind: Experiment
metadata:
  name: 01fjch9t8zdvsdc5mfyctzage4-14a0041e
  namespace: default
  labels:
    stormforge.io/application: '01fjch9t8zdvsdc5mfyctzage4'
    stormforge.io/objective: 'cost-vs-p95-latency'
    stormforge.io/scenario: '01fjchd15axdkb7t3cnyg0yn9j'
 ```

Note, this does require and updated optimize-go release ( fix in https://github.com/thestormforge/optimize-go/pull/61 ) 