### PR TITLE
Allow forcing configuration writes from the CLI

### DIFF
--- a/cli/internal/commands/configure/set.go
+++ b/cli/internal/commands/configure/set.go
@@ -74,6 +74,13 @@ func (o *SetOptions) Complete(args []string) {
 }
 
 func (o *SetOptions) set() error {
+	// Allow an explicitly empty key value to just save the configuration. This
+	// is very much an edge case, e.g. a developer wants to explicitly save a
+	// migrated configuration before making further changes.
+	if o.Key == "" {
+		return o.Config.Write()
+	}
+
 	if o.Value != "" {
 		if err := o.Config.Update(config.SetProperty(o.Key, o.Value)); err != nil {
 			return err


### PR DESCRIPTION
In the current implementation of configuration, writes are deferred until the user initiates a change. Often times changes can staged in the configuration but not written to disk (e.g. during migrations of old configurations). Normally this is not an issue because the next time the configuration is loaded, the same changes will be made again. Sometimes it is useful to force those changes to disk and up until now, there was no way to do it. Now you can do a `stormforge config set ""` to force writing out just the unstaged changes.