### PR TITLE
Make fix update application labels

### DIFF
--- a/cli/internal/commands/commands.go
+++ b/cli/internal/commands/commands.go
@@ -73,7 +73,7 @@ func NewRootCommand() *cobra.Command {
 	rootCmd.AddCommand(grant_permissions.NewCommand(&grant_permissions.Options{GeneratorOptions: grant_permissions.GeneratorOptions{Config: cfg}}))
 	rootCmd.AddCommand(authorize_cluster.NewCommand(&authorize_cluster.Options{GeneratorOptions: authorize_cluster.GeneratorOptions{Config: cfg}}))
 	rootCmd.AddCommand(generate.NewCommand(&generate.Options{Config: cfg}))
-	rootCmd.AddCommand(fix.NewCommand(&fix.Options{}))
+	rootCmd.AddCommand(fix.NewCommand(&fix.Options{Config: cfg}))
 	rootCmd.AddCommand(export.NewCommand(&export.Options{Config: cfg}))
 	rootCmd.AddCommand(run.NewCommand(&run.Options{Config: cfg}))
 


### PR DESCRIPTION
This PR adds a migration step to experiments that attempts to match the "application" label to the display name of a known application, if a match is found the label is updated to have the actual application name.