### PR TITLE
Helm changes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,15 @@
+name: Release
+on: release
+jobs:
+
+  helmChart:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Update Helm Chart
+      run: |-
+        curl \
+          -X POST \
+          -H "Authorization: token ${{ secrets.BMASTERS_TOKEN }}}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          ${GITHUB_API_URL}/repos/thestormforge/helm-charts/actions/workflows/build.yaml/dispatches \
+          -d '{"ref":"main"}'

--- a/cli/internal/commands/authorize_cluster/generator.go
+++ b/cli/internal/commands/authorize_cluster/generator.go
@@ -257,10 +257,7 @@ func printHelmValues(obj interface{}, w io.Writer) error {
 	}
 
 	vals := map[string]interface{}{
-		"remoteServer": map[string]interface{}{
-			"enabled":      true,
-			"identifier":   string(secret.Data["STORMFORGE_SERVER_IDENTIFIER"]),
-			"issuer":       string(secret.Data["STORMFORGE_SERVER_ISSUER"]),
+		"authorization": map[string]interface{}{
 			"clientID":     string(secret.Data["STORMFORGE_AUTHORIZATION_CLIENT_ID"]),
 			"clientSecret": string(secret.Data["STORMFORGE_AUTHORIZATION_CLIENT_SECRET"]),
 		},


### PR DESCRIPTION
This PR updates the output of `stormforge generate secret --output helm` to match the latest incarnation of the Helm chart. Additionally, it includes a workflow dispatch to automatically keep the Helm chart up-to-date:
1. This repo is tagged, the build pushes images to Docker Hub and creates a draft release in GitHub
2. When the release notes are published, the new release action in this PR will just use cURL and a `b-masters` token to trigger the `build.yaml` workflow in the [`helm-charts`](https://github.com/thestormforge/helm-charts) repository.
3. When the `build.yaml` workflow runs, it pulls `thestormforge/optimize-controller:latest` from Docker Hub and updates the chart. If there any changes (which there should be, it's a new release), it will commit those and push them.
4. The `release.yaml` workflow will see the new commit on `helm-charts` `main` and will check to do [it's thing](https://github.com/marketplace/actions/helm-chart-releaser).