### PR TITLE
refactor: Use MODE environment variable instead of args

### DIFF
--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -34,4 +34,3 @@ RUN konjure kustomize init
 
 WORKDIR "/workspace/base"
 ENTRYPOINT ["/workspace/docker-entrypoint.sh"]
-CMD ["build"]


### PR DESCRIPTION
This is mostly whitespace changes; the handling of script args moves to the beginning of the script.
The initial loop to handle args is provided for backwards compatibility with older setup tasks that make use of `prometheus $(MODE)`.

