### PR TITLE
Specify numeric UID in the containers rather then in the manifests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY ./manager .
-USER nobody:nobody
+
+# Numeric identifers for nobody:nobody (allows Kube to infer "run as")
+USER 65534:65534
 
 ENTRYPOINT ["/manager"]

--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -17,21 +17,21 @@ ENV HELM_URL="https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" \
     KUSTOMIZE_URL="https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz" \
     KONJURE_URL="https://github.com/carbonrelay/konjure/releases/download/${KONJURE_VERSION}/konjure-linux-amd64.tar.gz"
 
+ENV KUSTOMIZE_PLUGIN_HOME="/home/setup/.kustomize"
+
 RUN apk --no-cache add curl && \
-    curl -L "$HELM_URL" | tar xz -C /usr/local/bin --exclude '*/*[^helm]' --strip-components=1 && \
+    curl -L "$HELM_URL" | tar xoz -C /usr/local/bin --exclude '*/*[^helm]' --strip-components=1 && \
     curl -L "$KUBECTL_URL" -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl && \
-    curl -L "$KUSTOMIZE_URL" | tar xz -C /usr/local/bin && \
-    curl -L "$KONJURE_URL" | tar xz -C /usr/local/bin && \
-    mkdir -p /workspace/base && \
+    curl -L "$KUSTOMIZE_URL" | tar xoz -C /usr/local/bin && \
+    curl -L "$KONJURE_URL" | tar xoz -C /usr/local/bin && \
     addgroup -g 1000 -S setup && \
-    adduser -u 1000 -S setup -G setup
+    adduser -u 1000 -S setup -G setup -h /home/setup
 
-COPY . /workspace/
-RUN chown -R setup /workspace
+COPY --chown=setup:setup . /home/setup
+WORKDIR "/home/setup/base"
+RUN chown setup:setup . && chmod o+w .
+USER 1000:1000
+RUN konjure kustomize init && chmod -R go+rX "${KUSTOMIZE_PLUGIN_HOME}"
 
-USER setup:setup
-RUN konjure kustomize init
-
-WORKDIR "/workspace/base"
-ENTRYPOINT ["/workspace/docker-entrypoint.sh"]
+ENTRYPOINT ["/home/setup/docker-entrypoint.sh"]
 CMD ["build"]

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -33,8 +33,6 @@ spec:
               cpu: 100m
               memory: 250Mi
           securityContext:
-            runAsUser: 65534
-            runAsGroup: 65534
             runAsNonRoot: true
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false

--- a/internal/setup/job.go
+++ b/internal/setup/job.go
@@ -72,8 +72,7 @@ func NewJob(t *optimizev1beta2.Trial, mode string) (*batchv1.Job, error) {
 		volumes[v.Name] = &v
 	}
 
-	// We need to run as a non-root user that has the same UID and GID
-	id := int64(1000)
+	// We need to run as a non-root user
 	allowPrivilegeEscalation := false
 	runAsNonRoot := true
 	job.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
@@ -96,8 +95,6 @@ func NewJob(t *optimizev1beta2.Trial, mode string) (*batchv1.Job, error) {
 				{Name: "MODE", Value: mode},
 			},
 			SecurityContext: &corev1.SecurityContext{
-				RunAsUser:                &id,
-				RunAsGroup:               &id,
 				AllowPrivilegeEscalation: &allowPrivilegeEscalation,
 			},
 		}


### PR DESCRIPTION
This change removes the explicit UID/GID from the manifests in favor of numeric `USER` commands in the Dockerfile.

We have always specified `runAsNonRoot: true`, but we also specified explicit UID/GID values to match what we had in the container. This conflicts with container runtimes that choose the UID/GID for you. By removing the explicit UID/GID and leaving `runAsNonRoot: true` some runtimes will simply choose default `runAsUser`/`runAsGroup` values by inspecting the container; however this requires using numeric `USER` commands in the container (since the container runtime can't resolve names to numbers without actually starting the container).

Other runtimes will ignore the `USER` information in the container and will choose their own values. This is fine for the controller container, however the setup images write to disk: without adjusting permissions a random user wouldn't be able to perform these required writes. Additionally, Kustomize has expectations about the user with regards to where plugins can be loaded from. Both of these issues were addressed by creating a home directory for the setup user and granting additional permissions to other users (an environment variable also pins the plugin directory regardless of the user or their possible home directory).