### PR TITLE
Allow setting labels and environment variables in setup tasks

### DIFF
--- a/api/v1beta2/trial_types.go
+++ b/api/v1beta2/trial_types.go
@@ -115,6 +115,10 @@ type SetupTask struct {
 	SkipDelete bool `json:"skipDelete,omitempty"`
 	// Volume mounts for the setup task
 	VolumeMounts []corev1.VolumeMount `json:"volumeMounts,omitempty"`
+	// Environment variables to expose to the container
+	Env []corev1.EnvVar `json:"env,omitempty"`
+	// Labels to associate with the setup task
+	Labels map[string]string `json:"labels,omitempty"`
 	// The Helm chart reference to release as part of this task
 	HelmChart string `json:"helmChart,omitempty"`
 	// The Helm chart version, empty means use the latest

--- a/api/v1beta2/zz_generated.deepcopy.go
+++ b/api/v1beta2/zz_generated.deepcopy.go
@@ -567,6 +567,20 @@ func (in *SetupTask) DeepCopyInto(out *SetupTask) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Env != nil {
+		in, out := &in.Env, &out.Env
+		*out = make([]corev1.EnvVar, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.Labels != nil {
+		in, out := &in.Labels, &out.Labels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.HelmValues != nil {
 		in, out := &in.HelmValues, &out.HelmValues
 		*out = make([]HelmValue, len(*in))

--- a/config/crd/bases/optimize.stormforge.io_experiments.yaml
+++ b/config/crd/bases/optimize.stormforge.io_experiments.yaml
@@ -3065,6 +3065,62 @@ spec:
                             type: array
                             items:
                               type: string
+                          env:
+                            type: array
+                            items:
+                              type: object
+                              required:
+                              - name
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                                valueFrom:
+                                  type: object
+                                  properties:
+                                    configMapKeyRef:
+                                      type: object
+                                      required:
+                                      - key
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                    fieldRef:
+                                      type: object
+                                      required:
+                                      - fieldPath
+                                      properties:
+                                        apiVersion:
+                                          type: string
+                                        fieldPath:
+                                          type: string
+                                    resourceFieldRef:
+                                      type: object
+                                      required:
+                                      - resource
+                                      properties:
+                                        containerName:
+                                          type: string
+                                        divisor:
+                                          type: string
+                                        resource:
+                                          type: string
+                                    secretKeyRef:
+                                      type: object
+                                      required:
+                                      - key
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
                           helmChart:
                             type: string
                           helmChartVersion:
@@ -3108,6 +3164,10 @@ spec:
                                       type: string
                           image:
                             type: string
+                          labels:
+                            type: object
+                            additionalProperties:
+                              type: string
                           name:
                             type: string
                           skipCreate:

--- a/config/crd/bases/optimize.stormforge.io_trials.yaml
+++ b/config/crd/bases/optimize.stormforge.io_trials.yaml
@@ -2831,6 +2831,62 @@ spec:
                     type: array
                     items:
                       type: string
+                  env:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                      - name
+                      properties:
+                        name:
+                          type: string
+                        value:
+                          type: string
+                        valueFrom:
+                          type: object
+                          properties:
+                            configMapKeyRef:
+                              type: object
+                              required:
+                              - key
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+                            fieldRef:
+                              type: object
+                              required:
+                              - fieldPath
+                              properties:
+                                apiVersion:
+                                  type: string
+                                fieldPath:
+                                  type: string
+                            resourceFieldRef:
+                              type: object
+                              required:
+                              - resource
+                              properties:
+                                containerName:
+                                  type: string
+                                divisor:
+                                  type: string
+                                resource:
+                                  type: string
+                            secretKeyRef:
+                              type: object
+                              required:
+                              - key
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
                   helmChart:
                     type: string
                   helmChartVersion:
@@ -2874,6 +2930,10 @@ spec:
                               type: string
                   image:
                     type: string
+                  labels:
+                    type: object
+                    additionalProperties:
+                      type: string
                   name:
                     type: string
                   skipCreate:

--- a/config/prometheus/templates/configmap.yaml
+++ b/config/prometheus/templates/configmap.yaml
@@ -15,6 +15,7 @@ data:
       scrape_interval: "{{ .Values.scrapeInterval }}"
       scrape_timeout: "{{ .Values.scrapeTimeout }}"
     scrape_configs:
+    {{- if .Values.promServer.scrapes.cadvisor }}
     - job_name: kubernetes-cadvisor
       scheme: https
       metrics_path: /metrics/cadvisor
@@ -32,6 +33,8 @@ data:
       - regex: ^container_cpu_usage_seconds_total|container_memory_max_usage_bytes$
         source_labels: [ __name__ ]
         action: keep
+    {{- end }}
+    {{- if .Values.promServer.scrapes.kubeStateMetrics }}
     - job_name: kube-state-metrics
       scheme: http
       static_configs:
@@ -57,10 +60,13 @@ data:
         action: labeldrop
       - regex: ^node$
         action: labeldrop
+    {{- end }}
+    {{- if .Values.promServer.scrapes.pushGateway }}
     - job_name: prometheus-pushgateway
       honor_labels: true
       scheme: http
       static_configs:
       - targets:
         - localhost:9091
+    {{- end }}
 

--- a/config/prometheus/templates/deployment.yaml
+++ b/config/prometheus/templates/deployment.yaml
@@ -8,6 +8,9 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: Helm
     app: prometheus
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: {{ .Release.Name }}-server
 spec:
   selector:
@@ -17,6 +20,9 @@ spec:
       app.kubernetes.io/name: optimize-prometheus
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/managed-by: Helm
+      {{- with .Values.commonLabels }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
   replicas: 1
   template:
     metadata:
@@ -26,6 +32,9 @@ spec:
         app.kubernetes.io/name: optimize-prometheus
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/managed-by: Helm
+        {{- with .Values.commonLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ .Release.Name }}-server
       containers:

--- a/config/prometheus/values.yaml
+++ b/config/prometheus/values.yaml
@@ -38,6 +38,10 @@ pushGateway:
       memory: 50M
 
 promServer:
+  scrapes:
+    cadvisor: true
+    kubeStateMetrics: true
+    pushGateway: true
   image:
     repository: prom/prometheus
     pullPolicy: IfNotPresent

--- a/config/prometheus/values.yaml
+++ b/config/prometheus/values.yaml
@@ -3,6 +3,8 @@ storageVolumeSize: 100Mi
 scrapeInterval: 10s
 scrapeTimeout: 8s
 
+commonLabels: {}
+
 nodeSelector: {}
 
 tolerations: []

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -27,18 +27,18 @@ import (
 )
 
 const (
-	// ModeCreate is the primary argument to the setup tools container when the task is creating objects
+	// ModeCreate is the primary argument to the setup tools container when the task is creating objects.
 	ModeCreate = "create"
-	// ModeDelete is the primary argument to the setup tools container when the task is deleting objects
+	// ModeDelete is the primary argument to the setup tools container when the task is deleting objects.
 	ModeDelete = "delete"
 
-	// Initializer is used to paused the trial initialization for setup tasks
+	// Initializer is used to paused the trial initialization for setup tasks.
 	Initializer = "setupInitializer.stormforge.io"
-	// Finalizer is used to prevent the trial deletion for setup tasks
+	// Finalizer is used to prevent the trial deletion for setup tasks.
 	Finalizer = "setupFinalizer.stormforge.io"
 )
 
-// UpdateStatus returns true if there are setup tasks
+// UpdateStatus returns true if there are setup tasks.
 func UpdateStatus(t *optimizev1beta2.Trial, probeTime *metav1.Time) bool {
 	var needsCreate, needsDelete bool
 	for _, task := range t.Spec.SetupTasks {
@@ -85,7 +85,7 @@ func UpdateStatus(t *optimizev1beta2.Trial, probeTime *metav1.Time) bool {
 	return true
 }
 
-// GetTrialConditionType returns the trial condition type used to report status for the specified job
+// GetTrialConditionType returns the trial condition type used to report status for the specified job.
 func GetTrialConditionType(j *batchv1.Job) (optimizev1beta2.TrialConditionType, error) {
 	for _, c := range j.Spec.Template.Spec.Containers {
 		for _, env := range c.Env {
@@ -106,7 +106,7 @@ func GetTrialConditionType(j *batchv1.Job) (optimizev1beta2.TrialConditionType, 
 	return "", fmt.Errorf("unable to determine setup job type")
 }
 
-// GetConditionStatus returns condition True for a finished job or condition False for an job in progress
+// GetConditionStatus returns condition True for a finished job or condition False for an job in progress.
 func GetConditionStatus(j *batchv1.Job) (corev1.ConditionStatus, string) {
 	// Never return "ConditionUnknown", that is reserved to mean "a setup task exists"
 
@@ -144,7 +144,7 @@ func GetConditionStatus(j *batchv1.Job) (corev1.ConditionStatus, string) {
 	return corev1.ConditionFalse, ""
 }
 
-// AppendAssignmentEnv appends an environment variable for each trial assignment
+// AppendAssignmentEnv appends an environment variable for each trial assignment.
 func AppendAssignmentEnv(t *optimizev1beta2.Trial, env []corev1.EnvVar) []corev1.EnvVar {
 	for _, a := range t.Spec.Assignments {
 		name := strings.ReplaceAll(strings.ReplaceAll(strings.ToUpper(a.Name), ".", "_"), "/", "_")
@@ -154,7 +154,7 @@ func AppendAssignmentEnv(t *optimizev1beta2.Trial, env []corev1.EnvVar) []corev1
 	return env
 }
 
-// AppendPrometheusEnv appends environment variables to help reference the built in Prometheus
+// AppendPrometheusEnv appends environment variables to help reference the built in Prometheus.
 func AppendPrometheusEnv(t *optimizev1beta2.Trial, env []corev1.EnvVar) []corev1.EnvVar {
 	for i := range t.Spec.SetupTasks {
 		if IsPrometheusSetupTask(&t.Spec.SetupTasks[i]) {


### PR DESCRIPTION
This primarily enables setting labels and environment variables in setup tasks.

The reason for this change is to enable things like proxy settings to be configured on setup tasks as well as application specific labels needed to work with policy engines to allow the pod to be scheduled.

There is also a minor change included with the prometheus chart to allow setting labels as well ( same reasoning as above ) as well as the ability to slightly customize the scrape configs by disabling specific scrapers ( in this case we only want to scrape the push gateway ). 