### PR TITLE
feat: Add support for windows cli

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,11 +6,17 @@ builds:
   - dir: cli
     env:
       - CGO_ENABLED=0
+    goos:
+      - windows
+      - darwin
+      - linux
     goarch:
       - amd64
       - arm64
     ignore:
     - goos: linux
+      goarch: arm64
+    - goos: windows
       goarch: arm64
     ldflags:
       - '-s -w'

--- a/cli/internal/kustomize/options.go
+++ b/cli/internal/kustomize/options.go
@@ -48,7 +48,7 @@ func defaultOptions() *Kustomize {
 	fs := filesys.MakeFsInMemory()
 
 	return &Kustomize{
-		Base:       "/",
+		Base:       string(filepath.Separator),
 		fs:         fs,
 		Kustomizer: krusty.MakeKustomizer(krusty.MakeDefaultOptions()),
 		kustomize:  &types.Kustomization{},


### PR DESCRIPTION
I think there is still some work to do in optimize go ( specifically around XDG_HOME and Kubectl binary name) , but `login` and `generate install` work.

Didn't have a Kubernetes cluster on windows to test with :D

Signed-off-by: Brad Beam <brad.beam@stormforge.io>