### PR TITLE
Ignore application service failures in run

### DIFF
--- a/cli/internal/commands/run/command.go
+++ b/cli/internal/commands/run/command.go
@@ -260,7 +260,8 @@ func (o *Options) listApplicationNames() tea.Msg {
 		return nil
 	})
 	if err != nil {
-		return err
+		// TODO Temporarily return an empty list
+		return msg
 	}
 
 	sort.Strings(msg)

--- a/cli/internal/commands/run/view.go
+++ b/cli/internal/commands/run/view.go
@@ -404,6 +404,12 @@ func (o *Options) updateGeneratorForm() {
 	if len(o.Generator.Application.Objectives) == 0 {
 		o.generatorModel.ObjectiveInput.Enable()
 	}
+
+	// TODO Temporarily disable application and scenario name inputs if they are non-nil and still empty
+	if o.generatorModel.ApplicationInput.Choices != nil && len(o.generatorModel.ApplicationInput.Choices) == 0 {
+		o.generatorModel.ApplicationInput.Disable()
+		o.generatorModel.ScenarioInput.Disable()
+	}
 }
 
 // View returns the rendering of the preview model.


### PR DESCRIPTION
This is a temporary change until the application service rolls out in production. Basically it just ignores errors and hides the application and scenario name inputs when they are explicitly an empty list.