### PR TITLE
Send an explicit image tag to the Helm chart generator

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,8 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.BMASTERS_TOKEN }}
         GH_REPO: thestormforge/helm-charts
-      run: gh workflow run build.yaml --ref main
+        IMAGE_TAG: ${{ github.event.release.tag_name }}
+      run: gh workflow run build.yaml --ref main -f image_tag=${IMAGE_TAG#v}
 
   redhat:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Apparently there is a time delay where `latest` isn't returning the correct image (the last Helm chart build needed to be run manually).