### PR TITLE
Fixes for Performance authorization

### DIFF
--- a/cli/internal/commands/run/command.go
+++ b/cli/internal/commands/run/command.go
@@ -236,8 +236,7 @@ func (o *Options) listStormForgeTestCaseNames() tea.Msg {
 		}
 		for j := range testCases.Data {
 			testCase := testCases.Data[j].Attributes.Name
-			if len(orgs.Data) == 1 {
-				// If there is only one organization we can just use the test case name
+			if strings.HasPrefix(org, "optimize.") {
 				msg = append(msg, testCase)
 			} else {
 				msg = append(msg, fmt.Sprintf("%s/%s", org, testCase))

--- a/internal/experiment/generation/stormforgeperfaz.go
+++ b/internal/experiment/generation/stormforgeperfaz.go
@@ -139,7 +139,9 @@ func (az *StormForgePerformanceAuthorization) setDefaults() error {
 func (az *StormForgePerformanceAuthorization) lookupEnv(key string) (string, bool) {
 	// Check the actual current environment, if configured
 	if az.LookupEnvFunc != nil {
-		return az.LookupEnvFunc(key)
+		if value, ok := az.LookupEnvFunc(key); ok {
+			return value, true
+		}
 	}
 
 	// Check to see if the environment variable is persisted in the configuration file


### PR DESCRIPTION
This PR has two fixes for Performance authorization:

First, we no longer skip falling back to values stored in the config file.

Second, we no longer omit the organization name from the test case name unless it starts with the special prefix `"optimize."`