### PR TITLE
v1beta1 is deprecated in k8s 1.22+

### DIFF
--- a/config/crd/bases/optimize.stormforge.io_experiments.yaml
+++ b/config/crd/bases/optimize.stormforge.io_experiments.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:


### PR DESCRIPTION
`Warning: apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
`