### PR TITLE
Login force environment

### DIFF
--- a/cli/internal/commands/login/login.go
+++ b/cli/internal/commands/login/login.go
@@ -149,6 +149,20 @@ func (o *Options) complete() error {
 		}
 	}
 
+	// Allow `--force --env x` to overwrite existing configuration
+	if o.Force && o.Environment != "" {
+		// Avert your gaze.
+		cfg := config.Config{}
+		_ = config.SetExecutionEnvironment(o.Environment)(&cfg)
+		_ = config.SaveServer("", &config.Server{}, cfg.Environment)(&cfg)
+		if o.Server == "" {
+			o.Server = cfg.Servers[0].Server.Identifier
+		}
+		if o.Issuer == "" {
+			o.Issuer = cfg.Servers[0].Server.Authorization.Issuer
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This makes `stormforge login --env x --force` behave more predictably by explicitly overwriting the server and issuer values. This requires a horrible hack to get at the default values, but this is just us getting the far edge of the usefulness for this config code.