### PR TITLE
Generate secret should emit extraEnvVars and image pull secrets

### DIFF
--- a/controllers/application_poller_api_test.go
+++ b/controllers/application_poller_api_test.go
@@ -151,6 +151,18 @@ func (f *fakeAPI) UpdateTemplate(ctx context.Context, u string, s applications.T
 func (f *fakeAPI) PatchTemplate(ctx context.Context, u string, s applications.Template) error {
 	return nil
 }
+func (f *fakeAPI) CreateRecommendation(ctx context.Context, u string) (api.Metadata, error) {
+	return nil, nil
+}
+func (f *fakeAPI) GetRecommendation(ctx context.Context, u string) (applications.Recommendation, error) {
+	return applications.Recommendation{}, nil
+}
+func (f *fakeAPI) ListRecommendations(ctx context.Context, u string) (applications.RecommendationList, error) {
+	return applications.RecommendationList{}, nil
+}
+func (f *fakeAPI) PatchRecommendations(ctx context.Context, u string, details applications.RecommendationList) error {
+	return nil
+}
 func (f *fakeAPI) ListActivity(ctx context.Context, u string, q applications.ActivityFeedQuery) (applications.ActivityFeed, error) {
 	return applications.ActivityFeed{}, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
 	github.com/thestormforge/konjure v0.3.2
-	github.com/thestormforge/optimize-go v0.0.22
+	github.com/thestormforge/optimize-go v0.0.23
 	github.com/yujunz/go-getter v1.5.1-lite.0.20201201013212-6d9c071adddf
 	github.com/zorkian/go-datadog-api v2.24.0+incompatible
 	go.uber.org/zap v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -563,8 +563,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/thestormforge/konjure v0.3.2 h1:9h1HsAB9k8ENMHOOlUl2RYPE2+pZ+OqLn/Z0q0/COjM=
 github.com/thestormforge/konjure v0.3.2/go.mod h1:5cZj+F9imDQJrk4TUmXyA+dtSm6L0YdjSWFYvIX/668=
-github.com/thestormforge/optimize-go v0.0.22 h1:KZQiXXk2mGOllaIwq+tKT3UHZTH7VJamG0+AaHTaOvA=
-github.com/thestormforge/optimize-go v0.0.22/go.mod h1:MpUI4Wjx5koU911F/VUezzMjhdmLJUClvm1aw9Ip7CQ=
+github.com/thestormforge/optimize-go v0.0.23 h1:8BWNTtDpf8zICHfNXImOJV5qJrr9qH2PJW73Iu6geJU=
+github.com/thestormforge/optimize-go v0.0.23/go.mod h1:MpUI4Wjx5koU911F/VUezzMjhdmLJUClvm1aw9Ip7CQ=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=


### PR DESCRIPTION
This adds any additional environment variables from the configuration to the Helm values.yaml formatted output.

We can consider making the URLs configurable, the original idea was that the Helm chart served a specific production-only audience and so making it configurable didn't make sense.