### PR TITLE
Updates to the latest release

### DIFF
--- a/cli/internal/commands/authorize_cluster/generator.go
+++ b/cli/internal/commands/authorize_cluster/generator.go
@@ -350,7 +350,9 @@ func printHelmValues(obj interface{}, w io.Writer) error {
 					values.Authorization["clientID"] = string(v)
 				case "STORMFORGE_AUTHORIZATION_CLIENT_SECRET":
 					values.Authorization["clientSecret"] = string(v)
-				case "STORMFORGE_SERVER_IDENTIFIER", "STORMFORGE_SERVER_ISSUER":
+				case "STORMFORGE_SERVER_ISSUER":
+					values.Authorization["issuer"] = string(v)
+				case "STORMFORGE_SERVER_IDENTIFIER":
 				// The Helm chart hard codes these to the production default values
 				// NOTE: the server identifier and the issuer should be the same
 				default:

--- a/cli/internal/commands/authorize_cluster/generator.go
+++ b/cli/internal/commands/authorize_cluster/generator.go
@@ -184,9 +184,8 @@ func (o *GeneratorOptions) generate(ctx context.Context) error {
 	// Register a robot account with the registry server
 	registry, err := o.Config.RegisterRobot(ctx, info.ClientID)
 	if err != nil {
-		// Ignore unlicensed errors
 		if errors.Is(err, config.ErrUnlicensed) {
-			return o.Printer.PrintObj(secret, o.Out)
+			return fmt.Errorf("image pull secrets require a valid Optimize Live license, please contact sales")
 		}
 		return err
 	}

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -83,7 +83,7 @@ func newClientFromConfig(ctx context.Context, uaComment string, address func(con
 		return nil, err
 	}
 
-	rt, err := cfg.Authorize(ctx, version.UserAgent("optimize-controller", uaComment, nil))
+	rt, err := cfg.Authorize(ctx, version.UserAgent("optimize-pro", uaComment, nil))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Minor updates to the 2.0.7 release:
1. Make failure to provision a robot account a hard failure
2. Update the `User-Agent` header to reflect new branding
3. Include the address of the API and authorization server in the `generate secret -o helm` output