### PR TITLE
Make audience configurable

### DIFF
--- a/cli/internal/commands/commands.go
+++ b/cli/internal/commands/commands.go
@@ -61,10 +61,16 @@ func NewRootCommand() *cobra.Command {
 	cfg := &config.OptimizeConfig{}
 	commander.ConfigGlobals(cfg, rootCmd)
 
+	// TODO This is temporary while we migrate the audience value
+	aud := os.Getenv("STORMFORGE_AUDIENCE")
+	if aud == "" {
+		aud = "https://api.carbonrelay.io/v1/"
+	}
+
 	// Establish OAuth client identity
 	cfg.ClientIdentity = authorizationIdentity
 	cfg.AuthorizationParameters = map[string][]string{
-		"audience": {"https://api.carbonrelay.io/v1/"},
+		"audience": {aud},
 	}
 
 	// Kubernetes Commands

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -18,6 +18,7 @@ package server
 
 import (
 	"context"
+	"os"
 	"strings"
 
 	"github.com/thestormforge/optimize-controller/v2/internal/version"
@@ -26,8 +27,6 @@ import (
 	experimentsv1alpha1 "github.com/thestormforge/optimize-go/pkg/api/experiments/v1alpha1"
 	"github.com/thestormforge/optimize-go/pkg/config"
 )
-
-const audience = "https://api.carbonrelay.io/v1/"
 
 func NewExperimentAPI(ctx context.Context, uaComment string) (experimentsv1alpha1.API, error) {
 	client, err := newClientFromConfig(ctx, uaComment, func(srv config.Server) string {
@@ -65,10 +64,16 @@ func NewApplicationAPI(ctx context.Context, uaComment string) (applications.API,
 }
 
 func newClientFromConfig(ctx context.Context, uaComment string, address func(config.Server) string) (api.Client, error) {
+	// TODO This is temporary while we migrate the audience value
+	aud := os.Getenv("STORMFORGE_AUDIENCE")
+	if aud == "" {
+		aud = "https://api.carbonrelay.io/v1/"
+	}
+
 	// Load the configuration
 	cfg := &config.OptimizeConfig{}
 	cfg.AuthorizationParameters = map[string][]string{
-		"audience": {audience},
+		"audience": {aud},
 	}
 
 	if err := cfg.Load(); err != nil {


### PR DESCRIPTION
This is necessary to allow testing during the migration to new audience values. Instead of switching everything over all at once, this will let us change one environment and test the by setting the environment variable. A similar change will be necessary in the other controllers.

The next version of optimize-go will set the audience for us (since it will match the server identifier).