### PR TITLE
Stop saving the client ID in the configuration

### DIFF
--- a/cli/internal/commands/authorize_cluster/generator.go
+++ b/cli/internal/commands/authorize_cluster/generator.go
@@ -228,13 +228,9 @@ func mergeString(m map[string][]byte, key, value string) {
 }
 
 func (o *GeneratorOptions) readConfig() (*config.Controller, map[string][]byte, error) {
-	// Read the initial information from the configuration
 	r := o.Config.Reader()
-	controllerName, err := r.ControllerName(r.ContextName())
-	if err != nil {
-		return nil, nil, err
-	}
-	ctrl, err := r.Controller(controllerName)
+
+	ctrl, err := config.CurrentController(r)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -243,6 +239,7 @@ func (o *GeneratorOptions) readConfig() (*config.Controller, map[string][]byte, 
 	if err != nil {
 		return nil, nil, err
 	}
+
 	return &ctrl, data, nil
 }
 
@@ -276,7 +273,7 @@ func (o *GeneratorOptions) clientInfo(ctx context.Context, ctrl *config.Controll
 func (o *GeneratorOptions) clusterClientInformation(ctx context.Context, ctrl *config.Controller) *registration.ClientInformationResponse {
 	cmd, err := o.Config.Kubectl(ctx, "get", "secret", "--namespace", ctrl.Namespace, o.Name,
 		"--output", "go-template", "--template",
-		"{{ .data.STORMFORGE_AUTHORIZATION_CLIENT_ID }}/{{.data.STORMFORGE_AUTHORIZATION_CLIENT_SECRET }}")
+		"{{ .data.STORMFORGE_AUTHORIZATION_CLIENT_ID }}/{{ .data.STORMFORGE_AUTHORIZATION_CLIENT_SECRET }}")
 	if err != nil {
 		return nil
 	}

--- a/hack/integration.sh
+++ b/hack/integration.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-CLI_BIN="${CLI_BIN:-dist/stormforge_linux_amd64/stormforge}"
+CLI_BIN="${CLI_BIN:-dist/stormforge_linux_amd64_v1/stormforge}"
 #${CLI_CONFIG-...} allows us to test just for parameter existance which means we can rely on
 # the default and overwrite as needed ( for those pesky cases where you want to do
 # CLI_CONFIG="--stormforgeconfig /dev/null" hack/integration.sh


### PR DESCRIPTION
This PR stops writing the client registration URI in the configuration file. The net effect of this is that every call to `gen secret` will produce a unique client ID/secret.

A consequence of this is that the number of clients will grow more quickly so customers may need to revoke unused clients from the "Clusters" tab in the UI.