### PR TITLE
Change the default audience used for authorization

### DIFF
--- a/cli/internal/commands/commands.go
+++ b/cli/internal/commands/commands.go
@@ -61,16 +61,14 @@ func NewRootCommand() *cobra.Command {
 	cfg := &config.OptimizeConfig{}
 	commander.ConfigGlobals(cfg, rootCmd)
 
-	// TODO This is temporary while we migrate the audience value
-	aud := os.Getenv("STORMFORGE_AUTHORIZATION_AUDIENCE")
-	if aud == "" {
-		aud = "https://api.carbonrelay.io/v1/"
-	}
-
 	// Establish OAuth client identity
 	cfg.ClientIdentity = authorizationIdentity
-	cfg.AuthorizationParameters = map[string][]string{
-		"audience": {aud},
+
+	// TODO This is temporary while we migrate the audience value
+	if aud := os.Getenv("STORMFORGE_AUTHORIZATION_AUDIENCE"); aud != "" {
+		cfg.AuthorizationParameters = map[string][]string{
+			"audience": {aud},
+		}
 	}
 
 	// Kubernetes Commands

--- a/internal/experiment/generation/stormforgeperfaz.go
+++ b/internal/experiment/generation/stormforgeperfaz.go
@@ -119,13 +119,13 @@ func (az *StormForgePerformanceAuthorization) setDefaults() error {
 
 	// If we still need a configuration, load a fresh instance
 	if az.Config == nil {
-		aud := os.Getenv("STORMFORGE_AUTHORIZATION_AUDIENCE")
-		if aud == "" {
-			aud = "https://api.carbonrelay.io/v1/"
+		az.Config = &config.OptimizeConfig{}
+
+		// TODO This is temporary while we migrate the audience value
+		if aud := os.Getenv("STORMFORGE_AUTHORIZATION_AUDIENCE"); aud != "" {
+			az.Config.AuthorizationParameters = map[string][]string{"audience": {aud}}
 		}
-		az.Config = &config.OptimizeConfig{
-			AuthorizationParameters: map[string][]string{"audience": {aud}},
-		}
+
 		if err := az.Config.Load(); err != nil {
 			return err
 		}

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -64,16 +64,14 @@ func NewApplicationAPI(ctx context.Context, uaComment string) (applications.API,
 }
 
 func newClientFromConfig(ctx context.Context, uaComment string, address func(config.Server) string) (api.Client, error) {
-	// TODO This is temporary while we migrate the audience value
-	aud := os.Getenv("STORMFORGE_AUTHORIZATION_AUDIENCE")
-	if aud == "" {
-		aud = "https://api.carbonrelay.io/v1/"
-	}
-
 	// Load the configuration
 	cfg := &config.OptimizeConfig{}
-	cfg.AuthorizationParameters = map[string][]string{
-		"audience": {aud},
+
+	// TODO This is temporary while we migrate the audience value
+	if aud := os.Getenv("STORMFORGE_AUTHORIZATION_AUDIENCE"); aud != "" {
+		cfg.AuthorizationParameters = map[string][]string{
+			"audience": {aud},
+		}
 	}
 
 	if err := cfg.Load(); err != nil {


### PR DESCRIPTION
This PR changes the default audience from `https://api.carbonrelay.io/v1/` to `https://api.stormforge.io/`; support for the `STORMFORGE_AUTHORIZATION_AUDIENCE` environment variable temporarily remains during the migration period.