### PR TITLE
Applications run

### DIFF
--- a/api/apps/v1alpha1/application_types.go
+++ b/api/apps/v1alpha1/application_types.go
@@ -66,7 +66,7 @@ type Parameter struct {
 type ContainerResources struct {
 	filters.ResourceMetaFilter
 	// Label selector of Kubernetes objects to consider when generating container resources patches.
-	// Deprecated: use GenericSelector.LabelSelector instead.
+	// Deprecated: use ResourceMetaFilter.LabelSelector instead.
 	Selector string `json:"selector,omitempty"`
 	// Regular expression matching the container name.
 	ContainerName string `json:"containerName,omitempty"`
@@ -84,7 +84,7 @@ type ContainerResources struct {
 type Replicas struct {
 	filters.ResourceMetaFilter
 	// Label selector of Kubernetes objects to consider when generating replica patches.
-	// Deprecated: use GenericSelector.LabelSelector instead.
+	// Deprecated: use ResourceMetaFilter.LabelSelector instead.
 	Selector string `json:"selector,omitempty"`
 	// Path to the replica field.
 	Path string `json:"path,omitempty"`

--- a/cli/internal/commands/run/choiceinput/choiceinput.go
+++ b/cli/internal/commands/run/choiceinput/choiceinput.go
@@ -119,6 +119,12 @@ func (m *Model) SelectOnly() {
 	}
 }
 
+func (m *Model) SelectLast() {
+	if len(m.Choices) > 0 {
+		m.Select(len(m.Choices) - 1)
+	}
+}
+
 func (m Model) View() string {
 	var lines []string
 

--- a/cli/internal/commands/run/choiceinput/choiceinput.go
+++ b/cli/internal/commands/run/choiceinput/choiceinput.go
@@ -114,7 +114,11 @@ func (m *Model) Select(i int) {
 	}
 
 	if len(m.Choices) > 0 {
-		m.Model.SetValue(m.Choices[m.selected])
+		value := m.Choices[m.selected]
+		if pos := strings.IndexRune(value, '\t'); pos >= 0 {
+			value = value[0:pos]
+		}
+		m.Model.SetValue(value)
 	} else {
 		m.Model.SetValue("")
 	}
@@ -160,14 +164,6 @@ func (m Model) View() string {
 	}
 
 	return strings.Join(lines, "")
-}
-
-func (m Model) Value() string {
-	value := m.Model.Value()
-	if pos := strings.IndexRune(value, '\t'); pos >= 0 {
-		value = value[0:pos]
-	}
-	return value
 }
 
 func viewChoice(value string, selected, highlighted, focused bool) string {

--- a/cli/internal/commands/run/choiceinput/choiceinput.go
+++ b/cli/internal/commands/run/choiceinput/choiceinput.go
@@ -143,6 +143,14 @@ func (m Model) View() string {
 	return strings.Join(lines, "")
 }
 
+func (m Model) Value() string {
+	value := m.Model.Value()
+	if pos := strings.IndexRune(value, '\t'); pos >= 0 {
+		value = value[0:pos]
+	}
+	return value
+}
+
 func viewChoice(value string, selected, highlighted, focused bool) string {
 	var choice strings.Builder
 	var checkboxStyle, choiceStyle termenv.Style
@@ -154,6 +162,9 @@ func viewChoice(value string, selected, highlighted, focused bool) string {
 	if highlighted && focused {
 		checkboxStyle = checkboxStyle.Bold()
 		choiceStyle = choiceStyle.Bold()
+	}
+	if pos := strings.IndexRune(value, '\t'); pos >= 0 {
+		value = value[pos+1:]
 	}
 
 	choice.WriteString("\n")

--- a/cli/internal/commands/run/form/validation.go
+++ b/cli/internal/commands/run/form/validation.go
@@ -171,3 +171,7 @@ func (v *Name) ValidateTextField(value string) tea.Msg {
 
 	return ValidationMsg("")
 }
+
+func (v *Name) ValidateChoiceField(value string) tea.Msg {
+	return v.ValidateTextField(value)
+}

--- a/cli/internal/commands/run/form/validation.go
+++ b/cli/internal/commands/run/form/validation.go
@@ -152,3 +152,22 @@ func (v *ContainerImage) ValidateTextField(value string) tea.Msg {
 
 	return ValidationMsg("")
 }
+
+var nameRegexp = regexp.MustCompile(`^[a-z\d](?:[-a-z\d]{0,62}[a-z\d])?$`)
+
+type Name struct {
+	Required string
+	Valid    string
+}
+
+func (v *Name) ValidateTextField(value string) tea.Msg {
+	if value == "" {
+		return ValidationMsg(v.Required)
+	}
+
+	if !nameRegexp.MatchString(value) {
+		return ValidationMsg(v.Valid)
+	}
+
+	return ValidationMsg("")
+}

--- a/cli/internal/commands/run/form/validation.go
+++ b/cli/internal/commands/run/form/validation.go
@@ -153,7 +153,7 @@ func (v *ContainerImage) ValidateTextField(value string) tea.Msg {
 	return ValidationMsg("")
 }
 
-var nameRegexp = regexp.MustCompile(`^[a-z\d](?:[-a-z\d]{0,62}[a-z\d])?$`)
+var nameRegexp = regexp.MustCompile(`^[a-z\d](?:[-a-z\d]{0,61}[a-z\d])?$`)
 
 type Name struct {
 	Required string

--- a/cli/internal/commands/run/internal/messages.go
+++ b/cli/internal/commands/run/internal/messages.go
@@ -59,14 +59,8 @@ type KubernetesNamespacesMsg []string
 // test case names.
 type StormForgeTestCasesMsg []string
 
-// ApplicationMsg contains the application ULID if an existing application is used.
+// ApplicationMsg contains the names (and optional titles) of existing applications.
 type ApplicationMsg []string
-
-// DoScenarioLookup triggers the retrieval of scenario names for an application.
-type DoScenarioLookup struct{}
-
-// ScenarioMsg contains the scenario ULID if an existing scenario is used.
-type ScenarioMsg []string
 
 // ExperimentMsg represents the generated experiment.
 type ExperimentMsg []*yaml.RNode

--- a/cli/internal/commands/run/model.go
+++ b/cli/internal/commands/run/model.go
@@ -165,7 +165,7 @@ func (m generatorModel) Update(msg tea.Msg) (generatorModel, tea.Cmd) {
 			m.ExistingApplications.Disable()
 			m.ApplicationName.Enable()
 		} else {
-			m.ExistingApplications.Choices = append(msg, m.ExistingApplications.Choices[len(m.ExistingApplications.Choices)-1])
+			m.ExistingApplications.Choices = append(msg, "\tCreate a new application")
 			m.ExistingApplications.SelectLast()
 		}
 

--- a/cli/internal/commands/run/run.go
+++ b/cli/internal/commands/run/run.go
@@ -28,6 +28,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
 	konjurev1beta2 "github.com/thestormforge/konjure/pkg/api/core/v1beta2"
+	"github.com/thestormforge/konjure/pkg/filters"
 	"github.com/thestormforge/konjure/pkg/konjure"
 	optimizeappsv1alpha1 "github.com/thestormforge/optimize-controller/v2/api/apps/v1alpha1"
 	"github.com/thestormforge/optimize-controller/v2/cli/internal/commander"
@@ -365,7 +366,9 @@ func (m generatorModel) applyToApp(app *optimizeappsv1alpha1.Application) {
 		// the presence of any parameter bypasses the default inclusion of container resources.
 		app.Configuration = append(app.Configuration, optimizeappsv1alpha1.Parameter{
 			ContainerResources: &optimizeappsv1alpha1.ContainerResources{
-				Selector: m.ContainerResourcesSelectorInput.Value(),
+				ResourceMetaFilter: filters.ResourceMetaFilter{
+					LabelSelector: m.ContainerResourcesSelectorInput.Value(),
+				},
 			},
 		})
 	}
@@ -374,7 +377,9 @@ func (m generatorModel) applyToApp(app *optimizeappsv1alpha1.Application) {
 		if sel := m.ReplicasSelectorInput.Value(); sel != "" {
 			app.Configuration = append(app.Configuration, optimizeappsv1alpha1.Parameter{
 				Replicas: &optimizeappsv1alpha1.Replicas{
-					Selector: sel,
+					ResourceMetaFilter: filters.ResourceMetaFilter{
+						LabelSelector: sel,
+					},
 				},
 			})
 		}

--- a/cli/internal/commands/run/run.go
+++ b/cli/internal/commands/run/run.go
@@ -282,9 +282,7 @@ func (o *Options) ReadApplication(args []string) error {
 
 // applyToApp takes all of the what is on the model and applies it to an application.
 func (m generatorModel) applyToApp(app *optimizeappsv1alpha1.Application) {
-	if name := m.ExistingApplications.Value(); m.ExistingApplications.Enabled() && name != "" {
-		app.Name = name
-	} else if m.ApplicationName.Enabled() {
+	if m.ApplicationName.Enabled() {
 		app.Name = m.ApplicationName.Value()
 	}
 

--- a/cli/internal/commands/run/run.go
+++ b/cli/internal/commands/run/run.go
@@ -220,9 +220,6 @@ func (o *Options) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Refresh the trials list
 		cmds = append(cmds, o.refreshTrials)
 
-	case internal.DoScenarioLookup:
-		cmds = append(cmds, o.listScenarioNames)
-
 	case error:
 		// Handle errors so any command returning tea.Msg can just return an error
 		o.lastErr = msg
@@ -285,19 +282,18 @@ func (o *Options) ReadApplication(args []string) error {
 
 // applyToApp takes all of the what is on the model and applies it to an application.
 func (m generatorModel) applyToApp(app *optimizeappsv1alpha1.Application) {
-	if m.ApplicationInput.Enabled() {
-		parts := strings.Fields(m.ApplicationInput.Value())
-		app.Name = strings.Trim(parts[len(parts)-1], "()")
+	if name := m.ExistingApplications.Value(); m.ExistingApplications.Enabled() && name != "" {
+		app.Name = name
+	} else if m.ApplicationName.Enabled() {
+		app.Name = m.ApplicationName.Value()
 	}
 
 	var scenarioName string
-	if m.ScenarioInput.Enabled() {
-		parts := strings.Fields(m.ScenarioInput.Value())
-		scenarioName = strings.Trim(parts[len(parts)-1], "()")
+	if m.ScenarioName.Enabled() {
+		scenarioName = m.ScenarioName.Value()
 	}
 
 	if m.NamespaceInput.Enabled() {
-
 		// TODO We need a better way to set the name/namespace of the application
 		if namespaces := m.NamespaceInput.Values(); len(namespaces) == 1 {
 			app.Namespace = namespaces[0]

--- a/cli/internal/commands/run/view.go
+++ b/cli/internal/commands/run/view.go
@@ -54,6 +54,7 @@ func (o *Options) initializeModel() {
 		opts = append(opts, out.VerbosePrompts)
 	}
 	opts = append(opts, out.GlobalInstructions(
+		// TODO The first field includes the "back" instruction even though it's not possible
 		out.KeyBinding{
 			Key:  tea.Key{Type: tea.KeyPgUp},
 			Desc: "back",
@@ -64,27 +65,26 @@ func (o *Options) initializeModel() {
 		},
 	))
 
-	o.generatorModel.ExistingApplications = out.FormField{
-		Prompt:         "Please select an existing application (or create a new one):",
-		LoadingMessage: "Fetching applications",
-		Instructions: []interface{}{
-			"up/down: select",
-			out.KeyBinding{Key: tea.Key{Type: tea.KeyRunes, Runes: []rune{'x'}}, Desc: "choose"},
-		},
-	}.NewChoiceField(opts...)
-
 	o.generatorModel.ApplicationName = out.FormField{
 		Prompt:          "Enter an application name:",
+		LoadingMessage:  "Fetching applications",
 		InputOnSameLine: true,
-	}.NewTextField(opts...)
+		Instructions: []interface{}{
+			"up/down: select",
+		},
+	}.NewChoiceField(opts...)
+	o.generatorModel.ApplicationName.Editable = true
 	o.generatorModel.ApplicationName.Validator = &form.Name{
 		Required: "Required",
 		Valid:    "Must be valid name (lowercase alphanumerics and '-' only)",
 	}
 
 	o.generatorModel.ScenarioName = out.FormField{
-		Prompt:          "Enter a scenario name (optional):",
+		Prompt:          "Enter a scenario name:",
 		InputOnSameLine: true,
+		Instructions: []interface{}{
+			"Leave blank to generate a name",
+		},
 	}.NewTextField(opts...)
 	o.generatorModel.ScenarioName.Validator = &form.Name{
 		Valid: "Must be valid name (lowercase alphanumerics and '-' only)",
@@ -100,7 +100,7 @@ func (o *Options) initializeModel() {
 			ScenarioTypeLocust,
 			ScenarioTypeCustom,
 		},
-	}.NewChoiceField(opts...) // TODO This includes the "back" instruction even though it's not possible
+	}.NewChoiceField(opts...)
 	o.generatorModel.ScenarioType.Select(0)
 
 	o.generatorModel.StormForgeTestCaseInput = out.FormField{
@@ -376,7 +376,7 @@ func (o *Options) updateGeneratorForm() {
 	}
 
 	if o.Generator.Application.Name == "" {
-		o.generatorModel.ExistingApplications.Enable()
+		o.generatorModel.ApplicationName.Enable()
 	}
 
 	if len(o.Generator.Application.Scenarios) == 0 {

--- a/cli/internal/commands/run/view.go
+++ b/cli/internal/commands/run/view.go
@@ -72,8 +72,6 @@ func (o *Options) initializeModel() {
 			out.KeyBinding{Key: tea.Key{Type: tea.KeyRunes, Runes: []rune{'x'}}, Desc: "choose"},
 		},
 	}.NewChoiceField(opts...)
-	o.generatorModel.ExistingApplications.Choices = []string{"\tCreate a new application"}
-	o.generatorModel.ExistingApplications.Select(0)
 
 	o.generatorModel.ApplicationName = out.FormField{
 		Prompt:          "Enter an application name:",

--- a/cli/internal/commands/run/view.go
+++ b/cli/internal/commands/run/view.go
@@ -64,6 +64,34 @@ func (o *Options) initializeModel() {
 		},
 	))
 
+	o.generatorModel.ExistingApplications = out.FormField{
+		Prompt:         "Please select an existing application (or create a new one):",
+		LoadingMessage: "Fetching applications",
+		Instructions: []interface{}{
+			"up/down: select",
+			out.KeyBinding{Key: tea.Key{Type: tea.KeyRunes, Runes: []rune{'x'}}, Desc: "choose"},
+		},
+	}.NewChoiceField(opts...)
+	o.generatorModel.ExistingApplications.Choices = []string{"\tCreate a new application"}
+	o.generatorModel.ExistingApplications.Select(0)
+
+	o.generatorModel.ApplicationName = out.FormField{
+		Prompt:          "Enter an application name:",
+		InputOnSameLine: true,
+	}.NewTextField(opts...)
+	o.generatorModel.ApplicationName.Validator = &form.Name{
+		Required: "Required",
+		Valid:    "Must be valid name (lowercase alphanumerics and '-' only)",
+	}
+
+	o.generatorModel.ScenarioName = out.FormField{
+		Prompt:          "Enter a scenario name (optional):",
+		InputOnSameLine: true,
+	}.NewTextField(opts...)
+	o.generatorModel.ScenarioName.Validator = &form.Name{
+		Valid: "Must be valid name (lowercase alphanumerics and '-' only)",
+	}
+
 	o.generatorModel.ScenarioType = out.FormField{
 		Prompt: "Where do you want to get your load test from?",
 		Instructions: []interface{}{
@@ -203,24 +231,6 @@ https://docs.stormforger.com/guides/getting-started/`,
 	}.NewMultiChoiceField(opts...)
 	o.generatorModel.ObjectiveInput.Select(0)
 	o.generatorModel.ObjectiveInput.Select(2)
-
-	o.generatorModel.ApplicationInput = out.FormField{
-		Prompt:         "Please select an application name:",
-		LoadingMessage: "Fetching applications",
-		Instructions: []interface{}{
-			"up/down: select",
-			out.KeyBinding{Key: tea.Key{Type: tea.KeyRunes, Runes: []rune{'x'}}, Desc: "choose"},
-		},
-	}.NewChoiceField(opts...)
-
-	o.generatorModel.ScenarioInput = out.FormField{
-		Prompt:         "Please select a scenario name:",
-		LoadingMessage: "Fetching scenarios",
-		Instructions: []interface{}{
-			"up/down: select",
-			out.KeyBinding{Key: tea.Key{Type: tea.KeyRunes, Runes: []rune{'x'}}, Desc: "choose"},
-		},
-	}.NewChoiceField(opts...)
 
 	o.previewModel.Destination = out.FormField{
 		Prompt: "What would you like to do?",
@@ -368,11 +378,11 @@ func (o *Options) updateGeneratorForm() {
 	}
 
 	if o.Generator.Application.Name == "" {
-		o.generatorModel.ApplicationInput.Enable()
+		o.generatorModel.ExistingApplications.Enable()
 	}
 
 	if len(o.Generator.Application.Scenarios) == 0 {
-		o.generatorModel.ScenarioInput.Enable()
+		o.generatorModel.ScenarioName.Enable()
 
 		o.generatorModel.ScenarioType.Enable()
 		useStormForge := o.generatorModel.ScenarioType.Value() == ScenarioTypeStormForge
@@ -403,12 +413,6 @@ func (o *Options) updateGeneratorForm() {
 
 	if len(o.Generator.Application.Objectives) == 0 {
 		o.generatorModel.ObjectiveInput.Enable()
-	}
-
-	// TODO Temporarily disable application and scenario name inputs if they are non-nil and still empty
-	if o.generatorModel.ApplicationInput.Choices != nil && len(o.generatorModel.ApplicationInput.Choices) == 0 {
-		o.generatorModel.ApplicationInput.Disable()
-		o.generatorModel.ScenarioInput.Disable()
 	}
 }
 


### PR DESCRIPTION
This PR makes some updates the `run` command:
1. Improved support for `ChoiceInput` when `Editable == true`
2. Allow `ChoiceInput` choices to be `"value\tName"` where the console shows "Name" but the code sees "value"
3. Moved the application name to top of the field list and made it an editable `ChoiceInput`
4. Moved the scenario name above the scenario type input and changed it from `ChoiceInput` to a `TextInput`
