### PR TITLE
Add missing requests error rate to default

### DIFF
--- a/api/apps/v1alpha1/application_defaults.go
+++ b/api/apps/v1alpha1/application_defaults.go
@@ -189,10 +189,12 @@ func (in *Objective) enforceErrorRate() {
 	nonOptimized := false
 	maxErrorRate := resource.MustParse("0.05")
 	in.Goals = appendDefaultedGoal(in.Goals, Goal{
-		Name:      "error-ratio",
-		Max:       &maxErrorRate,
-		Optimize:  &nonOptimized,
-		ErrorRate: &ErrorRateGoal{},
+		Name:     "error-ratio",
+		Max:      &maxErrorRate,
+		Optimize: &nonOptimized,
+		ErrorRate: &ErrorRateGoal{
+			ErrorRateType: ErrorRateRequests,
+		},
 		Ignorable: true,
 	})
 }

--- a/api/apps/v1alpha1/application_defaults_test.go
+++ b/api/apps/v1alpha1/application_defaults_test.go
@@ -108,10 +108,12 @@ func TestObjective_Default(t *testing.T) {
 						},
 					},
 					{
-						Name:      "error-ratio",
-						Max:       resource.NewScaledQuantity(5, -2),
-						Optimize:  new(bool),
-						ErrorRate: &ErrorRateGoal{},
+						Name:     "error-ratio",
+						Max:      resource.NewScaledQuantity(5, -2),
+						Optimize: new(bool),
+						ErrorRate: &ErrorRateGoal{
+							ErrorRateType: ErrorRateRequests,
+						},
 						Ignorable: true,
 					},
 				},

--- a/controllers/application_poller_test.go
+++ b/controllers/application_poller_test.go
@@ -89,6 +89,14 @@ func TestPoller(t *testing.T) {
 						Minimize: true,
 					},
 					{
+						Name:     "error-ratio",
+						Minimize: true,
+						Optimize: &pfalse,
+						Bounds: &applications.TemplateMetricBounds{
+							Max: 0.05,
+						},
+					},
+					{
 						Name:     "cost",
 						Minimize: true,
 					},


### PR DESCRIPTION
The `enforceErrorRate` function that adds the default error rate objective was omitting the type of error rate that should be optimized for (i.e. "requests"). Since Perftest only supports error rate objectives for requests, the Perftest objective code didn't think it could generate the required metric.