### PR TITLE
Add the trial status via environment variables

### DIFF
--- a/internal/setup/job.go
+++ b/internal/setup/job.go
@@ -116,6 +116,9 @@ func NewJob(t *optimizev1beta2.Trial, mode string) (*batchv1.Job, error) {
 		// Add the trial assignments to the environment
 		c.Env = AppendAssignmentEnv(t, c.Env)
 
+		// Include the trial status as environment variables
+		c.Env = AppendStatusEnv(t, c.Env)
+
 		// Add the configured volume mounts
 		c.VolumeMounts = append(c.VolumeMounts, task.VolumeMounts...)
 

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -166,6 +166,23 @@ func AppendPrometheusEnv(t *optimizev1beta2.Trial, env []corev1.EnvVar) []corev1
 	return env
 }
 
+// AppendStatusEnv appends the trial status as environment variables.
+func AppendStatusEnv(t *optimizev1beta2.Trial, env []corev1.EnvVar) []corev1.EnvVar {
+	for i := range t.Status.Conditions {
+		c := t.Status.Conditions[i]
+		if c.Type == optimizev1beta2.TrialFailed && c.Status == corev1.ConditionTrue {
+			failureReason := c.Reason
+			if failureReason == "" {
+				failureReason = "Failed"
+			}
+
+			env = append(env, corev1.EnvVar{Name: "FAILURE_REASON", Value: failureReason})
+		}
+	}
+
+	return env
+}
+
 // IsPrometheusSetupTask checks to see if the supplied setup task is for the built-in Prometheus.
 func IsPrometheusSetupTask(st *optimizev1beta2.SetupTask) bool {
 	// Needs to have these arguments


### PR DESCRIPTION
This PR adds a `FAILURE_REASON` environment variable to the setup job for failed trials, this will only appear on setup delete jobs.