### PR TITLE
Prometheus support for explicit kubeconfig secret

### DIFF
--- a/config/prometheus/templates/configmap.yaml
+++ b/config/prometheus/templates/configmap.yaml
@@ -19,10 +19,14 @@ data:
     - job_name: kubernetes-cadvisor
       scheme: https
       metrics_path: /metrics/cadvisor
+      {{-  if .Values.promServer.kubeconfigSecret }}
+      kubeconfig_file: /.kube/config
+      {{- else }}
       tls_config:
         ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
         insecure_skip_verify: true
       bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      {{- end }}
       kubernetes_sd_configs:
       - role: node
       relabel_configs:

--- a/config/prometheus/templates/deployment.yaml
+++ b/config/prometheus/templates/deployment.yaml
@@ -38,6 +38,7 @@ spec:
     spec:
       serviceAccountName: {{ .Release.Name }}-server
       containers:
+      {{- if .Values.promServer.scrapes.kubeStateMetrics }}
       - name: kube-state-metrics
         args:
         - --collectors=pods
@@ -59,6 +60,8 @@ spec:
           timeoutSeconds: 5
         resources:
           {{- toYaml .Values.kubeStateMetrics.resources | nindent 10 }}
+      {{- end }}
+      {{- if .Values.promServer.scrapes.pushGateway }}
       - name: prometheus-pushgateway
         image: "{{ .Values.pushGateway.image.repository }}:{{ .Values.pushGateway.image.tag }}"
         imagePullPolicy: {{ .Values.pushGateway.image.pullPolicy }}
@@ -79,6 +82,7 @@ spec:
           timeoutSeconds: 10
         resources:
           {{- toYaml .Values.pushGateway.resources | nindent 10 }}
+      {{- end }}
       - name: prometheus-server
         image: "{{ .Values.promServer.image.repository }}:{{ .Values.promServer.image.tag }}"
         imagePullPolicy: {{ .Values.promServer.image.pullPolicy }}

--- a/config/prometheus/templates/deployment.yaml
+++ b/config/prometheus/templates/deployment.yaml
@@ -60,6 +60,12 @@ spec:
           timeoutSeconds: 5
         resources:
           {{- toYaml .Values.kubeStateMetrics.resources | nindent 10 }}
+        {{- if .Values.promServer.kubeconfigSecret }}
+        volumeMounts:
+        - name: kubeconfig-volume
+          mountPath: /.kube
+          readOnly: true
+        {{- end }}
       {{- end }}
       {{- if .Values.promServer.scrapes.pushGateway }}
       - name: prometheus-pushgateway
@@ -116,6 +122,11 @@ spec:
             mountPath: /etc/config
           - name: storage-volume
             mountPath: /data
+          {{- if .Values.promServer.kubeconfigSecret }}
+          - name: kubeconfig-volume
+            mountPath: /.kube
+            readOnly: true
+          {{- end }}
       - name: configmap-reloader
         image: "{{ .Values.configReload.image.repository }}:{{ .Values.configReload.image.tag }}"
         imagePullPolicy: {{ .Values.configReload.image.pullPolicy }}
@@ -141,6 +152,11 @@ spec:
         - name: storage-volume
           emptyDir:
             sizeLimit: "{{ .Values.storageVolumeSize }}"
+        {{- with .Values.promServer.kubeconfigSecret }}
+        - name: kubeconfig-volume
+          secret:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/config/prometheus/templates/deployment.yaml
+++ b/config/prometheus/templates/deployment.yaml
@@ -65,7 +65,6 @@ spec:
       - name: prometheus-pushgateway
         image: "{{ .Values.pushGateway.image.repository }}:{{ .Values.pushGateway.image.tag }}"
         imagePullPolicy: {{ .Values.pushGateway.image.pullPolicy }}
-        args:
         ports:
           - containerPort: 9091
         livenessProbe:

--- a/config/prometheus/values.yaml
+++ b/config/prometheus/values.yaml
@@ -53,6 +53,7 @@ promServer:
     limits:
       cpu: 200m
       memory: 1000M
+  kubeconfigSecret: {}
 
 configReload:
   image:


### PR DESCRIPTION
This PR has two changes:
1. If the scrapes are disabled for KSM or PG, then we won't run the containers that aren't being scraped
2. There is a new `promServer.kubeconfigSecret` value that can be used to override what KSM and Prometheus `kubernetes_sd_configs` use as a kubeconfig