### PR TITLE
Fixes for promServer.kubeconfigSecret

### DIFF
--- a/config/prometheus/templates/configmap.yaml
+++ b/config/prometheus/templates/configmap.yaml
@@ -21,9 +21,7 @@ data:
     - job_name: kubernetes-cadvisor
       scheme: https
       metrics_path: /metrics/cadvisor
-      {{-  if .Values.promServer.kubeconfigSecret }}
-      kubeconfig_file: /.kube/config
-      {{- else }}
+      {{-  if not .Values.promServer.kubeconfigSecret }}
       tls_config:
         ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
         insecure_skip_verify: true
@@ -31,6 +29,9 @@ data:
       {{- end }}
       kubernetes_sd_configs:
       - role: node
+        {{-  if .Values.promServer.kubeconfigSecret }}
+        kubeconfig_file: /.kube/config
+        {{- end }}
       relabel_configs:
       - action: labelmap
         regex: __meta_kubernetes_node_label_(.+)

--- a/config/prometheus/templates/deployment.yaml
+++ b/config/prometheus/templates/deployment.yaml
@@ -41,6 +41,9 @@ spec:
       {{- if .Values.promServer.scrapes.kubeStateMetrics }}
       - name: kube-state-metrics
         args:
+        {{- if .Values.promServer.kubeconfigSecret }}
+        - --kubeconfig /.kube/config
+        {{- end }}
         - --collectors=pods
         imagePullPolicy: {{ .Values.kubeStateMetrics.image.pullPolicy }}
         image: "{{ .Values.kubeStateMetrics.image.repository }}:{{ .Values.kubeStateMetrics.image.tag }}"


### PR DESCRIPTION
I was putting the `kubeconfig_file` in the wrong spot of the Prometheus configuration and kube-state-metrics complains that it doesn't have an explicit --kubeconfig.