### PR TITLE
Remove kubeconfigSecret from built-in Prometheus chart

### DIFF
--- a/config/prometheus/templates/configmap.yaml
+++ b/config/prometheus/templates/configmap.yaml
@@ -21,17 +21,12 @@ data:
     - job_name: kubernetes-cadvisor
       scheme: https
       metrics_path: /metrics/cadvisor
-      {{-  if not .Values.promServer.kubeconfigSecret }}
       tls_config:
         ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
         insecure_skip_verify: true
       bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-      {{- end }}
       kubernetes_sd_configs:
       - role: node
-        {{-  if .Values.promServer.kubeconfigSecret }}
-        kubeconfig_file: /.kube/config
-        {{- end }}
       relabel_configs:
       - action: labelmap
         regex: __meta_kubernetes_node_label_(.+)

--- a/config/prometheus/templates/deployment.yaml
+++ b/config/prometheus/templates/deployment.yaml
@@ -41,9 +41,6 @@ spec:
       {{- if .Values.promServer.scrapes.kubeStateMetrics }}
       - name: kube-state-metrics
         args:
-        {{- if .Values.promServer.kubeconfigSecret }}
-        - --kubeconfig=/.kube/config
-        {{- end }}
         - --collectors=pods
         imagePullPolicy: {{ .Values.kubeStateMetrics.image.pullPolicy }}
         image: "{{ .Values.kubeStateMetrics.image.repository }}:{{ .Values.kubeStateMetrics.image.tag }}"
@@ -63,12 +60,6 @@ spec:
           timeoutSeconds: 5
         resources:
           {{- toYaml .Values.kubeStateMetrics.resources | nindent 10 }}
-        {{- if .Values.promServer.kubeconfigSecret }}
-        volumeMounts:
-        - name: kubeconfig-volume
-          mountPath: /.kube
-          readOnly: true
-        {{- end }}
       {{- end }}
       {{- if .Values.promServer.scrapes.pushGateway }}
       - name: prometheus-pushgateway
@@ -125,11 +116,6 @@ spec:
             mountPath: /etc/config
           - name: storage-volume
             mountPath: /data
-          {{- if .Values.promServer.kubeconfigSecret }}
-          - name: kubeconfig-volume
-            mountPath: /.kube
-            readOnly: true
-          {{- end }}
       - name: configmap-reloader
         image: "{{ .Values.configReload.image.repository }}:{{ .Values.configReload.image.tag }}"
         imagePullPolicy: {{ .Values.configReload.image.pullPolicy }}
@@ -155,11 +141,6 @@ spec:
         - name: storage-volume
           emptyDir:
             sizeLimit: "{{ .Values.storageVolumeSize }}"
-        {{- with .Values.promServer.kubeconfigSecret }}
-        - name: kubeconfig-volume
-          secret:
-            {{- toYaml . | nindent 12 }}
-        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/config/prometheus/values.yaml
+++ b/config/prometheus/values.yaml
@@ -55,7 +55,6 @@ promServer:
     limits:
       cpu: 200m
       memory: 1000M
-  kubeconfigSecret: {}
 
 configReload:
   image:


### PR DESCRIPTION
I'm going to back this out since we know it isn't actually working (it does not produce a working cadvisor configuration). I think it is likely we will eventually need something to volume mount secrets on the primary Prometheus server container (perhaps more generically then just in a kubeconfig file), however I'd rather defer building that until we have a better idea of exactly what is needed.