### PR TITLE
Expose constant parameters as assignments

### DIFF
--- a/internal/experiment/trial_template.go
+++ b/internal/experiment/trial_template.go
@@ -78,13 +78,13 @@ func PopulateTrialFromTemplate(exp *optimizev1beta2.Experiment, t *optimizev1bet
 // on the server.
 func ParameterConstant(p optimizev1beta2.Parameter) *intstr.IntOrString {
 	switch {
-	case p.Min != p.Max || len(p.Values) > 1:
-		return nil
+	case p.Min == p.Max && len(p.Values) == 0:
+		v := intstr.FromInt(int(p.Max))
+		return &v
 	case len(p.Values) == 1:
 		v := intstr.FromString(p.Values[0])
 		return &v
 	default:
-		v := intstr.FromInt(int(p.Max))
-		return &v
+		return nil
 	}
 }

--- a/internal/server/common.go
+++ b/internal/server/common.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	optimizev1beta2 "github.com/thestormforge/optimize-controller/v2/api/v1beta2"
+	"github.com/thestormforge/optimize-controller/v2/internal/experiment"
 	"github.com/thestormforge/optimize-go/pkg/api"
 	experimentsv1alpha1 "github.com/thestormforge/optimize-go/pkg/api/experiments/v1alpha1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -52,7 +53,7 @@ func parameters(exp *optimizev1beta2.Experiment) []experimentsv1alpha1.Parameter
 
 	for _, p := range exp.Spec.Parameters {
 		// This is a special case to omit parameters client side
-		if p.Min == p.Max && len(p.Values) == 0 {
+		if experiment.ParameterConstant(p) != nil {
 			continue
 		}
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -222,7 +222,7 @@ func TestFromCluster(t *testing.T) {
 					Parameters: []optimizev1beta2.Parameter{
 						{Name: "one", Min: 0, Max: 1, Baseline: &one},
 						{Name: "two", Min: 0, Max: 2, Baseline: &two},
-						{Name: "three", Values: []string{"three"}, Baseline: &three},
+						{Name: "three", Values: []string{"three", "four"}, Baseline: &three},
 					},
 				},
 			},
@@ -241,7 +241,7 @@ func TestFromCluster(t *testing.T) {
 					{
 						Type:   experimentsv1alpha1.ParameterTypeCategorical,
 						Name:   "three",
-						Values: []string{"three"},
+						Values: []string{"three", "four"},
 					},
 				},
 			},


### PR DESCRIPTION
For a long time, we have had the ability to set a parameter min==max to have it omitted from the experiment definition we send to the server. However, this did not work for categorical parameters (i.e. a parameter with a single value). Also, because the parameter was withheld from the server definition, it was not included in the assignments that come back and therefore could not be used in patches.

This PR fixes the issue with omitting single value categorical parameters and adds the constant value into the trial assignments so it can be used in patches.