### PR TITLE
Use tpl instead of toYaml for extra scrape configs/rules

### DIFF
--- a/config/prometheus/templates/configmap.yaml
+++ b/config/prometheus/templates/configmap.yaml
@@ -72,9 +72,9 @@ data:
         - localhost:9091
     {{- end }}
     {{- with .Values.promServer.extraScrapeConfigs }}
-    {{- toYaml . | nindent 4 }}
+    {{- tpl . $ | nindent 4 }}
     {{- end }}
   rules.yml: |
     groups: {{ with .Values.promServer.extraRuleGroups }}
-    {{- toYaml . | nindent 4 }}
+    {{- tpl . $ | nindent 4 }}
     {{- else }}[]{{ end }}


### PR DESCRIPTION
Using `tpl` instead of `toYaml` for the extra scrape configs allows us to configure them using the following syntax in the experiment YAML:
```
      setupTasks:
      - name: prometheus
        helmChart: ../prometheus
        helmValues:
        - name: 'promServer.extraScrapeConfigs'
          value: |
            - job_name: foobar
              tls_config:
                insecure_skip_verify: true
              # ...
```
Without this change, you need to do something like this (which gets tedious quick):
```
      setupTasks:
      - name: prometheus
        helmChart: ../prometheus
        helmValues:
        - name: 'promServer.extraScrapeConfigs[0].job_name'
          value: 'foobar'
        - name: 'promServer.extraScrapeConfigs[0].tls_config.insecure_skip_verify
          value: 'true'
        # ...
```