### PR TITLE
Include UA header on authorization requests

### DIFF
--- a/internal/version/useragent.go
+++ b/internal/version/useragent.go
@@ -40,6 +40,7 @@ type Transport struct {
 
 // RoundTrip sets the incoming request header and delegates to the base transport
 func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = req.Clone(req.Context())
 	req.Header.Set("User-Agent", t.userAgent())
 	return t.base().RoundTrip(req)
 }


### PR DESCRIPTION
This PR updates the context used to make authorization requests so that it will include the UA string (minus the Kube version) when fetching tokens. It also fixes the UA round tripper (round trippers are not supposed to mutate the incoming request, they must clone it and mutate that).