### PR TITLE
Change the app.kubernetes.io/name label

### DIFF
--- a/cli/internal/commands/initialize/initialize.go
+++ b/cli/internal/commands/initialize/initialize.go
@@ -57,7 +57,7 @@ func (o *Options) Initialize(ctx context.Context) error {
 	}
 
 	// Run `kubectl apply` to install the product
-	// TODO Handle upgrades with "--prune", "--selector", "app.kubernetes.io/name=optimize,app.kubernetes.io/managed-by=%s"
+	// TODO Handle upgrades with "--prune", "--selector", "app.kubernetes.io/name=optimize-controller,app.kubernetes.io/managed-by=%s"
 	kubectlApply, err := o.Config.Kubectl(ctx, "apply", "-f", "-")
 	if err != nil {
 		return err

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -10,7 +10,7 @@ namePrefix: optimize-
 
 # Labels to add to all resources and selectors.
 commonLabels:
-  app.kubernetes.io/name: optimize
+  app.kubernetes.io/name: optimize-controller
 
 resources:
 - ../crd


### PR DESCRIPTION
This is done to match the Git repository, Docker image, and Helm chart.