### PR TITLE
Fix field ordering when printing YAML from the CLI

### DIFF
--- a/cli/internal/commander/printer.go
+++ b/cli/internal/commander/printer.go
@@ -280,8 +280,8 @@ type marshalPrinter struct {
 // PrintObj will marshal the supplied object
 func (p *marshalPrinter) PrintObj(obj interface{}, w io.Writer) error {
 	if strings.ToLower(p.outputFormat) == "yaml" {
-		// Hack to perform field ordering on maps
-		if m, ok := obj.(map[string]interface{}); ok {
+		// Hack to perform field ordering on maps that look like resources
+		if m, ok := obj.(map[string]interface{}); ok && m["kind"] != nil && m["apiVersion"] != nil {
 			node, err := kyaml.FromMap(m)
 			if err != nil {
 				return err

--- a/cli/internal/commander/printer.go
+++ b/cli/internal/commander/printer.go
@@ -33,6 +33,9 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/duration"
+	"sigs.k8s.io/kustomize/kyaml/kio"
+	"sigs.k8s.io/kustomize/kyaml/kio/filters"
+	kyaml "sigs.k8s.io/kustomize/kyaml/yaml"
 	"sigs.k8s.io/yaml"
 )
 
@@ -276,8 +279,20 @@ type marshalPrinter struct {
 
 // PrintObj will marshal the supplied object
 func (p *marshalPrinter) PrintObj(obj interface{}, w io.Writer) error {
-	// TODO It would be really nice if we could fix the field ordering for Unstructured objects
 	if strings.ToLower(p.outputFormat) == "yaml" {
+		// Hack to perform field ordering on maps
+		if m, ok := obj.(map[string]interface{}); ok {
+			node, err := kyaml.FromMap(m)
+			if err != nil {
+				return err
+			}
+			return kio.Pipeline{
+				Inputs:  []kio.Reader{kio.ResourceNodeSlice{node}},
+				Filters: []kio.Filter{filters.FormatFilter{}},
+				Outputs: []kio.Writer{&kio.ByteWriter{Writer: &prefixWriter{w: w}}},
+			}.Execute()
+		}
+
 		output, err := yaml.Marshal(obj)
 		if err != nil {
 			return err


### PR DESCRIPTION
This is just a hack to impose consistent field ordering when rendering YAML from the CLI, in particular when generating secrets. Today, when the code sees a `map[string]interface{}` being printed as YAML, the encoder just going to use a lexicographical sort over the keys. This PR ensures that maps are formatted using KYAML so we can leverage the format filter (which will impose a sane field ordering for Kubernetes objects).

The primary motivation for this is to fix the [generated secrets file](https://github.com/thestormforge/helm-charts/blob/main/charts/optimize-controller/templates/secret.yaml) in the Helm chart; since the `data` field will always sort last for a secret, this will allow us to just append to the file (instead of trying to split the file up to make changes for the chart).