### PR TITLE
Fix `set config` for controllers with dot names

### DIFF
--- a/cli/internal/commands/configure/set.go
+++ b/cli/internal/commands/configure/set.go
@@ -86,7 +86,7 @@ func (o *SetOptions) set() error {
 		r := o.Config.Reader()
 		if _, err := r.Controller(parts[1]); err != nil {
 			if name, err := r.ControllerName(parts[1]); err == nil {
-				parts[1] = name
+				parts[1] = strings.ReplaceAll(name, ".", "\\.")
 				o.Key = strings.Join(parts, ".")
 			}
 		}

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.1
 	github.com/thestormforge/konjure v0.3.2
-	github.com/thestormforge/optimize-go v0.0.27
+	github.com/thestormforge/optimize-go v0.0.28
 	github.com/yujunz/go-getter v1.5.1-lite.0.20201201013212-6d9c071adddf
 	github.com/zorkian/go-datadog-api v2.24.0+incompatible
 	go.uber.org/zap v1.10.0


### PR DESCRIPTION
Previously if a controller had a dot character "." in the name, it wasn't possible to set configs on that controller.

This commit fixes the issue by using optimize-go 0.0.28, which is assumed to support escaping dot characters in path element names with a backslash. E.g. "one\.two" is a single path element.

NOTE: This PR depends on thestormforge/optimize-go#85, and a new release of optimize-go. It is in draft form until that condition is met.