### PR TITLE
Add deprecation notices to some commands

### DIFF
--- a/cli/internal/commands/authorize_cluster/authorize_cluster.go
+++ b/cli/internal/commands/authorize_cluster/authorize_cluster.go
@@ -37,9 +37,10 @@ type Options struct {
 // NewCommand creates a new command for authorizing a cluster
 func NewCommand(o *Options) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "authorize-cluster",
-		Short: "Authorize a cluster",
-		Long:  "Authorize StormForge Optimize in a cluster",
+		Use:        "authorize-cluster",
+		Short:      "Authorize a cluster",
+		Long:       "Authorize StormForge Optimize in a cluster",
+		Deprecated: "it will be removed in v3.0.0",
 
 		PreRun: commander.StreamsPreRun(&o.IOStreams),
 		RunE:   commander.WithContextE(o.authorizeCluster),

--- a/cli/internal/commands/check/config.go
+++ b/cli/internal/commands/check/config.go
@@ -43,9 +43,10 @@ type ConfigOptions struct {
 // NewConfigCommand creates a new command for checking the Optimize Configuration
 func NewConfigCommand(o *ConfigOptions) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "config",
-		Short: "Check the configuration",
-		Long:  "Check the StormForge Optimize Configuration",
+		Use:        "config",
+		Short:      "Check the configuration",
+		Long:       "Check the StormForge Optimize Configuration",
+		Deprecated: "it will be removed in v3.0.0",
 
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			// TODO We should have an option to overwrite the configuration using stdin (e.g. to test connections using the controller config)

--- a/cli/internal/commands/check/version.go
+++ b/cli/internal/commands/check/version.go
@@ -44,9 +44,10 @@ type VersionOptions struct {
 // NewVersionCommand creates a new command for checking the current version of the product
 func NewVersionCommand(o *VersionOptions) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "version",
-		Short: "Check for the latest version number",
-		Long:  "Check the current version number against the latest",
+		Use:        "version",
+		Short:      "Check for the latest version number",
+		Long:       "Check the current version number against the latest",
+		Deprecated: "it will be removed in v3.0.0",
 
 		PreRun: commander.StreamsPreRun(&o.IOStreams),
 		RunE:   commander.WithContextE(o.checkVersion),

--- a/cli/internal/commands/configure/currentcontext.go
+++ b/cli/internal/commands/configure/currentcontext.go
@@ -35,9 +35,10 @@ type CurrentContextOptions struct {
 // NewCurrentContextCommand creates a new command for viewing the current context
 func NewCurrentContextCommand(o *CurrentContextOptions) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "current-context",
-		Short: "Displays the current context",
-		Long:  "Displays the current context",
+		Use:        "current-context",
+		Short:      "Displays the current context",
+		Long:       "Displays the current context",
+		Deprecated: "it will be removed in v3.0.0",
 
 		PreRun: commander.StreamsPreRun(&o.IOStreams),
 		RunE:   commander.WithoutArgsE(o.currentContext),

--- a/cli/internal/commands/configure/env.go
+++ b/cli/internal/commands/configure/env.go
@@ -41,9 +41,10 @@ type EnvOptions struct {
 // NewEnvCommand creates a new command for viewing a configuration as environment variables
 func NewEnvCommand(o *EnvOptions) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "env",
-		Short: "Generate environment variables from configuration",
-		Long:  "View the Optimize Configuration file as environment variables",
+		Use:        "env",
+		Short:      "Generate environment variables from configuration",
+		Long:       "View the Optimize Configuration file as environment variables",
+		Deprecated: "it will be removed in v3.0.0",
 
 		PreRun: commander.StreamsPreRun(&o.IOStreams),
 		RunE:   commander.WithoutArgsE(o.env),

--- a/cli/internal/commands/configure/set.go
+++ b/cli/internal/commands/configure/set.go
@@ -38,9 +38,10 @@ type SetOptions struct {
 // NewSetCommand creates a new command for setting a configuration property
 func NewSetCommand(o *SetOptions) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "set NAME [VALUE]",
-		Short: "Modify the configuration file",
-		Long:  "Modify the Optimize Configuration file",
+		Use:        "set NAME [VALUE]",
+		Short:      "Modify the configuration file",
+		Long:       "Modify the Optimize Configuration file",
+		Deprecated: "it will be removed in v3.0.0",
 
 		Example: `# Add an environment variable to the controller
 stormforge config set controller.default.env.FOOBAR example

--- a/cli/internal/commands/generate/trial.go
+++ b/cli/internal/commands/generate/trial.go
@@ -43,9 +43,10 @@ type TrialOptions struct {
 
 func NewTrialCommand(o *TrialOptions) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "trial",
-		Short: "Generate experiment trials",
-		Long:  "Generate a trial from an experiment manifest",
+		Use:        "trial",
+		Short:      "Generate experiment trials",
+		Long:       "Generate a trial from an experiment manifest",
+		Deprecated: "it will be removed in v3.0.0",
 
 		Annotations: map[string]string{
 			commander.PrinterAllowedFormats: "json,yaml",

--- a/cli/internal/commands/grant_permissions/generator.go
+++ b/cli/internal/commands/grant_permissions/generator.go
@@ -55,9 +55,10 @@ type GeneratorOptions struct {
 // NewGeneratorCommand creates a command for generating the controller role definitions
 func NewGeneratorCommand(o *GeneratorOptions) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "controller-rbac",
-		Short: "Generate Optimize permissions",
-		Long:  "Generate RBAC for StormForge Optimize",
+		Use:        "controller-rbac",
+		Short:      "Generate Optimize permissions",
+		Long:       "Generate RBAC for StormForge Optimize",
+		Deprecated: "it will be removed in v3.0.0",
 
 		Annotations: map[string]string{
 			commander.PrinterAllowedFormats: "json,yaml",

--- a/cli/internal/commands/grant_permissions/grant_permissions.go
+++ b/cli/internal/commands/grant_permissions/grant_permissions.go
@@ -32,9 +32,10 @@ type Options struct {
 // NewCommand creates a new command for granting controller permissions
 func NewCommand(o *Options) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "grant-permissions",
-		Short: "Grant permissions",
-		Long:  "Grant the StormForge Optimize Controller permissions",
+		Use:        "grant-permissions",
+		Short:      "Grant permissions",
+		Long:       "Grant the StormForge Optimize Controller permissions",
+		Deprecated: "it will be removed in v3.0.0",
 
 		PreRun: commander.StreamsPreRun(&o.IOStreams),
 		RunE:   commander.WithContextE(o.grantPermissions),


### PR DESCRIPTION
Commands which will be removed without replacement in v3 are all getting early deprecation notices now that the v3.0.0-beta.1 is out. There will be another round of deprecation notices once v3 GAs.